### PR TITLE
Fixed bug in ignoring unwatched implementation.

### DIFF
--- a/src/Libs/Mappers/Import/MemoryMapper.php
+++ b/src/Libs/Mappers/Import/MemoryMapper.php
@@ -127,6 +127,12 @@ final class MemoryMapper implements ImportInterface
         }
 
         if (false === ($pointer = $this->getPointer($entity))) {
+            if (0 === $entity->watched && true !== ($opts[ServerInterface::OPT_IMPORT_UNWATCHED] ?? false)) {
+                $this->logger->debug(sprintf('Ignoring %s. Not watched.', $name));
+                Data::increment($bucket, $entity->type . '_ignored_not_watched');
+                return $this;
+            }
+
             $this->objects[] = $entity;
 
             $pointer = array_key_last($this->objects);


### PR DESCRIPTION
As we delegated the checks to the mapper, we missed a spot where an unwatched item could make it into the database even if the --import-unwatched flag is missing. 