### PR TITLE
Made No Valid GUIDs error level controllable

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -203,16 +203,23 @@ for changes to take effect.
 
 ### Q: Can this tool work with alternative Plex agents?
 
-Those are all supported plex agents currently:
+#### Supported Agents GUIDs:
 
+* plex://(type)/(id)
+* tvdb://(id)
+* imdb://(id)
+* tmdb://(id)
 * com.plexapp.agents.imdb://(id)?lang=en
 * com.plexapp.agents.tmdb://(id)?lang=en
 * com.plexapp.agents.themoviedb://(id)?lang=en
-* com.plexapp.agents.tvdb://(id)/(season)/(episode)?lang=en
-* com.plexapp.agents.thetvdb://(id)/(season)/(episode)?lang=en
-* com.plexapp.agents.tvmaze://(id)/(season)/(episode))?lang=en
 * com.plexapp.agents.hama://(db)-(id)
-* com.plexapp.agents.xbmcnfo://(id)?lang=xn > imdb
+* com.plexapp.agents.xbmcnfo://(id)?lang=en
 
-`com.plexapp.agents.xbmcnfotv://(show-id)/(season)/(episode)?lang=xn` This agent is not supported as it does not provide
-unique episode id.
+#### Unsupported Agents:
+
+* com.plexapp.agents.tvdb://(show-id)/(season)/(episode)?lang=en
+* com.plexapp.agents.thetvdb://(show-id)/(season)/(episode)?lang=en
+* com.plexapp.agents.tvmaze://(show-id)/(season)/(episode)?lang=en
+* com.plexapp.agents.xbmcnfotv://(show-id)/(season)/(episode)?lang=en
+
+Those agents do not provide episode unique ID thus will not work with the way we do syncing.

--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ None that we are aware of.
 - (string) `WS_LOGS_PRUNE_AFTER` Delete logs older than specified time, set to `disable` to disable logs pruning. it
   follows php [strtotime](https://www.php.net/strtotime) function rules.
 - (bool) `WS_DEBUG_IMPORT` Whether to log invalid GUID items from server in `${WS_TMP_DIR}/debug`.
+- (bool) `WS_IMPORT_PROMOTE_GUID_ERROR` By default we log this error to `INFO` if this variable set to true it will
+  promote it to `NOTICE` level.
 
 # Container specific environment variables
 

--- a/src/Libs/Mappers/Import/DirectMapper.php
+++ b/src/Libs/Mappers/Import/DirectMapper.php
@@ -21,9 +21,11 @@ final class DirectMapper implements ImportInterface
     ];
 
     private int $changed = 0;
+    private string $guidErrorLevel = 'info';
 
     public function __construct(private LoggerInterface $logger, private StorageInterface $storage)
     {
+        $this->guidErrorLevel = true === (bool)env('WS_IMPORT_PROMOTE_GUID_ERROR', false) ? 'notice' : 'info';
     }
 
     public function setUp(array $opts): ImportInterface
@@ -39,7 +41,7 @@ final class DirectMapper implements ImportInterface
     public function add(string $bucket, string $name, StateInterface $entity, array $opts = []): self
     {
         if (!$entity->hasGuids()) {
-            $this->logger->notice(sprintf('Ignoring %s. No valid GUIDs.', $name));
+            $this->logger->{$this->guidErrorLevel}(sprintf('Ignoring %s. No valid GUIDs.', $name));
             Data::increment($bucket, $entity->type . '_failed_no_guid');
             return $this;
         }

--- a/src/Libs/Mappers/Import/MemoryMapper.php
+++ b/src/Libs/Mappers/Import/MemoryMapper.php
@@ -33,8 +33,11 @@ final class MemoryMapper implements ImportInterface
 
     private bool $fullyLoaded = false;
 
+    private string $guidErrorLevel = 'info';
+
     public function __construct(private LoggerInterface $logger, private StorageInterface $storage)
     {
+        $this->guidErrorLevel = true === (bool)env('WS_IMPORT_PROMOTE_GUID_ERROR', false) ? 'notice' : 'info';
     }
 
     public function setUp(array $opts): ImportInterface
@@ -62,7 +65,7 @@ final class MemoryMapper implements ImportInterface
     public function add(string $bucket, string $name, StateInterface $entity, array $opts = []): self
     {
         if (!$entity->hasGuids()) {
-            $this->logger->notice(sprintf('Ignoring %s. No valid GUIDs.', $name));
+            $this->logger->{$this->guidErrorLevel}(sprintf('Ignoring %s. No valid GUIDs.', $name));
             Data::increment($bucket, $entity->type . '_failed_no_guid');
             return $this;
         }

--- a/src/Libs/Servers/JellyfinServer.php
+++ b/src/Libs/Servers/JellyfinServer.php
@@ -28,7 +28,6 @@ use Psr\SimpleCache\CacheInterface;
 use Psr\SimpleCache\InvalidArgumentException;
 use RuntimeException;
 use StdClass;
-use Symfony\Component\Yaml\Yaml;
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -75,11 +74,14 @@ class JellyfinServer implements ServerInterface
     protected array $cacheData = [];
     protected string|int|null $uuid = null;
 
+    protected string $guidErrorLevel = 'info';
+
     public function __construct(
         protected HttpClientInterface $http,
         protected LoggerInterface $logger,
         protected CacheInterface $cache
     ) {
+        $this->guidErrorLevel = true === (bool)env('WS_IMPORT_PROMOTE_GUID_ERROR', false) ? 'notice' : 'info';
     }
 
     /**
@@ -1294,7 +1296,7 @@ class JellyfinServer implements ServerInterface
 
                 $guids = (array)($item->ProviderIds ?? []);
 
-                $this->logger->notice(
+                $this->logger->{$this->guidErrorLevel}(
                     sprintf(
                         'Ignoring %s. No valid GUIDs. Possibly unmatched item?',
                         $iName


### PR DESCRIPTION
You can control No valid GUIDs error level by setting `WS_IMPORT_PROMOTE_GUID_ERROR`, we reverted the log level to `INFO` instead of `NOTICE` unless this variable is set.