### PR TITLE
Massively increased Direct Mapper performance during import operation.

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -278,4 +278,3 @@ importing your database it's fine to use this mapper.
 | Memory Usage   | (✗) Higher    | (✓) Lower       |
 | Matching Speed | (✓) Faster    | (✗) Slower      |
 | DB Operations  | (✓) Faster    | (✗) Slower      |
-| Initial Import | (✓) Faster    | (✗) MUCH Slower |

--- a/src/Libs/Mappers/Import/MemoryMapper.php
+++ b/src/Libs/Mappers/Import/MemoryMapper.php
@@ -359,16 +359,6 @@ final class MemoryMapper implements ImportInterface
         foreach ([...$entity->getPointers(), ...$entity->getRelativePointers()] as $key) {
             $this->guids[$key . '/' . $entity->type] = $pointer;
         }
-
-        foreach ($entity->metadata ?? [] as $backend => $meta) {
-            if (null === ($meta[iFace::COLUMN_ID] ?? null)) {
-                continue;
-            }
-
-            $key = self::GUID . $backend . '-' . $entity->metadata[$backend][iFace::COLUMN_ID];
-
-            $this->guids[$key] = $pointer;
-        }
     }
 
     /**
@@ -382,14 +372,6 @@ final class MemoryMapper implements ImportInterface
     {
         if (null !== $entity->id && null !== ($this->objects[self::GUID . $entity->id] ?? null)) {
             return self::GUID . $entity->id;
-        }
-
-        if (!empty($entity->via) && null !== ($entity->metadata[$entity->via][iFace::COLUMN_ID] ?? null)) {
-            $key = self::GUID . $entity->via . '-' . $entity->metadata[$entity->via][iFace::COLUMN_ID];
-
-            if (null !== ($this->guids[$key] ?? null)) {
-                return $this->guids[$key];
-            }
         }
 
         foreach ([...$entity->getRelativePointers(), ...$entity->getPointers()] as $key) {
@@ -417,14 +399,6 @@ final class MemoryMapper implements ImportInterface
             if (null !== ($this->guids[$lookup] ?? null)) {
                 unset($this->guids[$lookup]);
             }
-        }
-
-        foreach ($entity->metadata ?? [] as $backend => $meta) {
-            if (null === ($meta[iFace::COLUMN_ID] ?? null)) {
-                continue;
-            }
-
-            unset($this->guids[self::GUID . $backend . '-' . $meta[iFace::COLUMN_ID]]);
         }
     }
 

--- a/tests/Fixtures/EpisodeEntity.php
+++ b/tests/Fixtures/EpisodeEntity.php
@@ -27,6 +27,7 @@ return [
         Guid::GUID_TVMAZE => '6400',
         Guid::GUID_TVRAGE => '6500',
         Guid::GUID_ANIDB => '6600',
+        ...Guid::makeVirtualGuid('home_plex', '122'),
     ],
     iFace::COLUMN_META_DATA => [
         'home_plex' => [

--- a/tests/Fixtures/MovieEntity.php
+++ b/tests/Fixtures/MovieEntity.php
@@ -24,6 +24,7 @@ return [
         Guid::GUID_TVMAZE => '1400',
         Guid::GUID_TVRAGE => '1500',
         Guid::GUID_ANIDB => '1600',
+        ...Guid::makeVirtualGuid('home_plex', '121'),
     ],
     iFace::COLUMN_META_DATA => [
         'home_plex' => [


### PR DESCRIPTION
We were able to gain massive performance by not calling the backend storage unnecessarily, by setting the flag fullyloaded it means that we loaded all external ids pointers into memory and thus we do not need to inquiry the storage for such information that reduced storage calls by 4 x (backends x number_of_items_from_backend), in our test environment that change alone reduce storage calls by `320,055`. and the Direct mapper speed still slower than memory mapper, however it's not by that much anymore. before during import in our test environment full import using memory mapper is around 1m 20s, while direct mapper was north of 10m+, however with this changes. the time is around 1m 40s now.