### PR TITLE
Rebased the container image on our base php image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ on:
 env:
   DOCKERHUB_SLUG: arabcoders/watchstate
   GHCR_SLUG: ghcr.io/arabcoders/watchstate
+  PLATFORMS: linux/amd64${{ endsWith(github.ref, github.event.repository.default_branch) && ', linux/arm64, linux/arm' || '' }}
 
 jobs:
   unit-tests:
@@ -61,9 +62,6 @@ jobs:
     needs: unit-tests
     if: github.event_name != 'pull_request'
     runs-on: "ubuntu-latest"
-
-    env:
-      PLATFORMS: linux/amd64${{ endsWith(github.ref, github.event.repository.default_branch) && ', linux/arm64, linux/arm' || '' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
 env:
   DOCKERHUB_SLUG: arabcoders/watchstate
   GHCR_SLUG: ghcr.io/arabcoders/watchstate
-  PLATFORMS: linux/amd64${{ endsWith(github.ref, github.event.repository.default_branch) && ', linux/arm64, linux/arm' || '' }}
+  PLATFORMS: linux/amd64,linux/arm64,linux/arm
 
 jobs:
   unit-tests:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,10 @@
-FROM php:8.1-fpm-alpine
+FROM ghcr.io/arabcoders/php_container:latest
 
-ENV IN_DOCKER=1
 LABEL maintainer="admin@arabcoders.org"
 
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/bin/
+ENV IN_DOCKER=1
 
-RUN mv "${PHP_INI_DIR}/php.ini-production" "${PHP_INI_DIR}/php.ini" && chmod +x /usr/bin/install-php-extensions && \
-    sync && install-php-extensions opcache xhprof redis && \
-    apk add --no-cache nginx nano curl procps net-tools iproute2 shadow runuser sqlite redis && \
-    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
-    mkdir -p /app /config
+RUN mkdir -p /app /config
 
 COPY . /app
 


### PR DESCRIPTION
This drastically reduces the time needed to publish images, before this change container build could take 20min to build due to the need to compile php extensions. moving that step outside the container reduced the build time to 2-3mins