### PR TITLE
Added notice about jellyfin/emby Use Date scanned into library.

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -479,6 +479,8 @@ Those are some Webhook limitations we discovered for the following media backend
   items. [See feature request](https://emby.media/community/index.php?/topic/97889-new-content-notification-webhook/).
 * Emby webhook test event does not contain data. To test if your setup works, play something or do mark an item as
   played or unplayed you should see changes reflected in `docker exec -ti watchstate console db:list`.
+* Items might be marked as unplayed if Libraries > Advanced - `Date added behavior for new content:` is set
+  to `Use date scanned into library`. This happens if the media file has been replaced.
 
 #### Jellyfin
 
@@ -486,6 +488,8 @@ Those are some Webhook limitations we discovered for the following media backend
   you happen to enable `webhook.match.user` for jellyfin.
 * Sometimes jellyfin will fire webhook `itemAdd` event without the item being matched.
 * Even if you select user id, sometimes `itemAdd` event will fire without user data.
+* Items might be marked as unplayed if Libraries > Display - `Date added behavior for new content:` is set
+  to `Use date scanned into library`. This happens if the media file has been replaced.
 
 ---
 

--- a/src/Libs/Initializer.php
+++ b/src/Libs/Initializer.php
@@ -672,7 +672,7 @@ final class Initializer
             $query = [];
             parse_str($uri->getQuery(), $query);
             if (true === ag_exists($query, 'apikey')) {
-                $query['apikey'] = '(removed_api_key)';
+                $query['apikey'] = 'api_key_removed';
                 $uri = $uri->withQuery(http_build_query($query));
             }
         }

--- a/src/Libs/Initializer.php
+++ b/src/Libs/Initializer.php
@@ -664,13 +664,26 @@ final class Initializer
             return;
         }
 
+        $params = $request->getServerParams();
+
+        $uri = new Uri((string)ag($params, 'REQUEST_URI', '/'));
+
+        if (false === empty($uri->getQuery())) {
+            $query = [];
+            parse_str($uri->getQuery(), $query);
+            if (true === ag_exists($query, 'apikey')) {
+                $query['apikey'] = '(removed_api_key)';
+                $uri = $uri->withQuery(http_build_query($query));
+            }
+        }
+
         $context = array_replace_recursive(
             [
                 'request' => [
-                    'id' => ag($request->getServerParams(), 'X_REQUEST_ID'),
-                    'ip' => ag($request->getServerParams(), 'REMOTE_ADDR'),
-                    'agent' => ag($request->getServerParams(), 'HTTP_USER_AGENT'),
-                    'uri' => ag($request->getServerParams(), 'REQUEST_URI'),
+                    'id' => ag($params, 'X_REQUEST_ID'),
+                    'ip' => ag($params, 'REMOTE_ADDR'),
+                    'agent' => ag($params, 'HTTP_USER_AGENT'),
+                    'uri' => (string)$uri,
                 ],
             ],
             $context


### PR DESCRIPTION
In under specific conditions in jellyfin/emby

1. Enable real time monitoring is turned off.
2. external source asks jellyfin/emby to scan the library.

this will trigger scan that will replace the item and remove the play state and thus with new date the time will be marked as unplayed. as the new date is newer than last played date.
