### PR TITLE
redirect tasks output.

### DIFF
--- a/container/files/cron.sh
+++ b/container/files/cron.sh
@@ -18,7 +18,7 @@ echo $$ >"${PID}"
 #
 while true; do
   sleep 60
-  /usr/bin/console system:tasks --run --save-log
+  /usr/bin/console system:tasks --run --save-log >/dev/null 2>&1
 done
 
 if [ -f "${PID}" ]; then


### PR DESCRIPTION
Since we no longer use CRON the output of tasks are flooding the stderr of the container, therefore, we null the output in job-runner, while still retaining the logs with --save-log flag. 