### PR TITLE
Change how we process webhook http requests.

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -164,7 +164,7 @@ These environment variables relates to the tool itself, you can load them via th
 | WS_LIBRARY_SEGMENT       | integer | Paginate backend library items request. Per request get total X number.       | `8000`             |
 
 **Note**: for environment variables that has `{TASK}` tag, you **MUST** replace it with one
-of `IMPORT`, `EXPORT`, `PUSH`, `BACKUP`, `PRUNE`, `INDEXES`. To see tasks active settings run
+of `IMPORT`, `EXPORT`, `PUSH`, `BACKUP`, `PRUNE`, `INDEXES`, `REQUESTS`. To see tasks active settings run
 
 ```bash
 $ docker exec -ti watchstate console system:tasks

--- a/bin/console
+++ b/bin/console
@@ -32,16 +32,16 @@ set_error_handler(function (int $number, mixed $error, mixed $file, int $line) {
         return;
     }
 
-    $message = sprintf('%s: %s (%s:%d).' . PHP_EOL, $errorLevels[$number] ?? (string)$number, $error, $file, $line);
+    $message = sprintf('%s: %s (%s:%d).', $errorLevels[$number] ?? (string)$number, $error, $file, $line);
     fwrite(STDERR, trim($message) . PHP_EOL);
 
-    exit(Command::FAILURE);
+    exit(501);
 });
 
 set_exception_handler(function (Throwable $e) {
-    $message = sprintf("%s: %s (%s:%d)." . PHP_EOL, get_class($e), $e->getMessage(), $e->getFile(), $e->getLine());
+    $message = sprintf('%s: %s (%s:%d).', get_class($e), $e->getMessage(), $e->getFile(), $e->getLine());
     fwrite(STDERR, trim($message) . PHP_EOL);
-    exit(Command::FAILURE);
+    exit(502);
 });
 
 if (!file_exists(__DIR__ . '/../vendor/autoload.php')) {
@@ -54,12 +54,10 @@ require __DIR__ . '/../vendor/autoload.php';
 try {
     $app = (new App\Libs\Initializer())->boot();
 } catch (Throwable $e) {
-    fwrite(
-            STDERR,
-            trim(sprintf("PANIC: %s: %s (%s:%d).", get_class($e), $e->getMessage(), $e->getFile(), $e->getLine()))
-    );
+    $message = sprintf('%s: %s (%s:%d).', get_class($e), $e->getMessage(), $e->getFile(), $e->getLine());
+    fwrite(STDERR, trim($message) . PHP_EOL);
 
-    exit(Command::FAILURE);
+    exit(503);
 }
 
-$app->runConsole();
+$app->console();

--- a/config/config.php
+++ b/config/config.php
@@ -9,6 +9,7 @@ use App\Commands\State\BackupCommand;
 use App\Commands\State\ExportCommand;
 use App\Commands\State\ImportCommand;
 use App\Commands\State\PushCommand;
+use App\Commands\State\RequestsCommand;
 use App\Commands\System\IndexCommand;
 use App\Commands\System\PruneCommand;
 use App\Libs\Mappers\Import\MemoryMapper;
@@ -247,6 +248,14 @@ return (function () {
                 'enabled' => (bool)env('WS_CRON_INDEXES', true),
                 'timer' => (string)env('WS_CRON_INDEXES_AT', '0 3 * * 3'),
                 'args' => env('WS_CRON_INDEXES_ARGS', '-v'),
+            ],
+            RequestsCommand::TASK_NAME => [
+                'command' => RequestsCommand::ROUTE,
+                'name' => RequestsCommand::TASK_NAME,
+                'info' => 'Process queued http requests.',
+                'enabled' => (bool)env('WS_CRON_REQUESTS', true),
+                'timer' => (string)env('WS_CRON_REQUESTS_AT', '*/2 * * * *'),
+                'args' => env('WS_CRON_REQUESTS_ARGS', '-v'),
             ],
         ],
     ];

--- a/public/index.php
+++ b/public/index.php
@@ -57,4 +57,4 @@ try {
     exit(Command::FAILURE);
 }
 
-$app->runHttp();
+$app->http();

--- a/src/Commands/State/RequestsCommand.php
+++ b/src/Commands/State/RequestsCommand.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands\State;
+
+use App\Command;
+use App\Libs\Entity\StateInterface as iState;
+use App\Libs\Mappers\Import\DirectMapper;
+use App\Libs\Options;
+use App\Libs\Routable;
+use Psr\Log\LoggerInterface as iLogger;
+use Psr\SimpleCache\CacheInterface as iCache;
+use Psr\SimpleCache\InvalidArgumentException;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[Routable(command: self::ROUTE)]
+class RequestsCommand extends Command
+{
+    public const ROUTE = 'state:requests';
+
+    public const TASK_NAME = 'requests';
+
+    public function __construct(private iLogger $logger, private iCache $cache, private DirectMapper $mapper)
+    {
+        set_time_limit(0);
+        ini_set('memory_limit', '-1');
+
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setName(self::ROUTE)
+            ->setDescription('Process queued requests.')
+            ->addOption('keep', 'k', InputOption::VALUE_NONE, 'Do not expunge queue after run is complete.')
+            ->addOption('list', 'l', InputOption::VALUE_NONE, 'List queued requests.')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do not commit changes to backends.')
+            ->addOption('no-stats', null, InputOption::VALUE_NONE, 'Do not display end of run stats.')
+            ->setHelp('This command process <notice>queued</notice> http requests.');
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     * @throws InvalidArgumentException
+     */
+    protected function runCommand(InputInterface $input, OutputInterface $output): int
+    {
+        return $this->single(fn(): int => $this->process($input, $output), $output);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    protected function process(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$this->cache->has('requests')) {
+            $this->logger->info('No requests in the queue.');
+            return self::SUCCESS;
+        }
+
+        $requests = $this->cache->get('requests', []);
+
+        if (count($requests) < 1) {
+            $this->logger->info('No requests in the queue.');
+            return self::SUCCESS;
+        }
+
+        if ($input->getOption('list')) {
+            return $this->listItems($input, $output, $requests);
+        }
+
+        if ($input->getOption('dry-run')) {
+            $this->logger->info('Dry run mode. No changes will be committed.');
+        }
+
+        $this->mapper->setOptions([
+            Options::DRY_RUN => $input->getOption('dry-run'),
+            Options::DEBUG_TRACE => $input->getOption('trace')
+        ]);
+
+        foreach ($requests as $request) {
+            $entity = ag($request, 'entity');
+            assert($entity instanceof iState);
+
+            $options = ag($request, 'options', []);
+
+            $this->logger->notice('SYSTEM: Processing [%(backend)] [%(title)] %(tainted) request.', [
+                'backend' => $entity->via,
+                'title' => $entity->getName(),
+                'event' => ag($entity->getExtra($entity->via), iState::COLUMN_EXTRA_EVENT, '??'),
+                'tainted' => $entity->isTainted() ? 'tainted' : 'untainted',
+            ]);
+
+            $this->mapper->add($entity, [
+                Options::IMPORT_METADATA_ONLY => (bool)ag($options, Options::IMPORT_METADATA_ONLY),
+            ]);
+        }
+
+        $operations = $this->mapper->commit();
+
+        $a = [
+            [
+                'Type' => ucfirst(iState::TYPE_MOVIE),
+                'Added' => $operations[iState::TYPE_MOVIE]['added'] ?? '-',
+                'Updated' => $operations[iState::TYPE_MOVIE]['updated'] ?? '-',
+                'Failed' => $operations[iState::TYPE_MOVIE]['failed'] ?? '-',
+            ],
+            new TableSeparator(),
+            [
+                'Type' => ucfirst(iState::TYPE_EPISODE),
+                'Added' => $operations[iState::TYPE_EPISODE]['added'] ?? '-',
+                'Updated' => $operations[iState::TYPE_EPISODE]['updated'] ?? '-',
+                'Failed' => $operations[iState::TYPE_EPISODE]['failed'] ?? '-',
+            ],
+        ];
+
+        if (false === $input->getOption('no-stats')) {
+            (new Table($output))
+                ->setHeaders(array_keys($a[0]))
+                ->setStyle('box')
+                ->setRows(array_values($a))
+                ->render();
+        }
+
+        if (false === $input->getOption('keep') && false === $input->getOption('dry-run')) {
+            $this->cache->delete('requests');
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * List Items.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @param array $requests
+     * @return int
+     */
+    private function listItems(InputInterface $input, OutputInterface $output, array $requests): int
+    {
+        $list = [];
+
+        $mode = $input->getOption('output');
+
+        foreach ($requests as $request) {
+            $opts = ag($request, 'options', []);
+            $item = ag($request, 'entity');
+
+            assert($item instanceof iState);
+
+            if ('table' === $mode) {
+                $builder = [
+                    'queued' => makeDate(ag($item->getExtra($item->via), iState::COLUMN_EXTRA_DATE))->format(
+                        'Y-m-d H:i:s T'
+                    ),
+                    'via' => $item->via,
+                    'title' => $item->getName(),
+                    'played' => $item->isWatched() ? 'Yes' : 'No',
+                    'tainted' => $item->isTainted() ? 'Yes' : 'No',
+                    'event' => ag($item->getExtra($item->via), iState::COLUMN_EXTRA_EVENT, '??'),
+                ];
+            } else {
+                $builder = [
+                    ...$item->getAll(),
+                    'tainted' => $item->isTainted(),
+                    'options' => $opts
+                ];
+            }
+
+            $list[] = $builder;
+        }
+
+        $this->displayContent($list, $output, $mode);
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Libs/Mappers/Import/DirectMapper.php
+++ b/src/Libs/Mappers/Import/DirectMapper.php
@@ -404,17 +404,20 @@ final class DirectMapper implements iImport
             return $this;
         }
 
+        $context = [
+            'id' => $cloned->id,
+            'backend' => $entity->via,
+            'title' => $cloned->getName(),
+        ];
+
         if (true === $this->inTraceMode()) {
-            $this->logger->debug('MAPPER: [%(backend)] [%(title)] metadata and play state is identical.', [
-                'id' => $cloned->id,
-                'backend' => $entity->via,
-                'title' => $cloned->getName(),
-                'state' => [
-                    'database' => $cloned->getAll(),
-                    'backend' => $entity->getAll(),
-                ],
-            ]);
+            $context['state'] = [
+                'database' => $cloned->getAll(),
+                'backend' => $entity->getAll(),
+            ];
         }
+
+        $this->logger->debug('MAPPER: [%(backend)] [%(title)] metadata and play state is identical.', $context);
 
         Message::increment("{$entity->via}.{$entity->type}.ignored_no_change");
 

--- a/src/Libs/Mappers/Import/MemoryMapper.php
+++ b/src/Libs/Mappers/Import/MemoryMapper.php
@@ -289,17 +289,20 @@ final class MemoryMapper implements iImport
             return $this;
         }
 
+        $context = [
+            'id' => $cloned->id,
+            'backend' => $entity->via,
+            'title' => $cloned->getName(),
+        ];
+
         if (true === $this->inTraceMode()) {
-            $this->logger->debug('MAPPER: [%(backend)] [%(title)] metadata and play state is identical.', [
-                'id' => $cloned->id,
-                'backend' => $entity->via,
-                'title' => $cloned->getName(),
-                'state' => [
-                    'database' => $cloned->getAll(),
-                    'backend' => $entity->getAll(),
-                ],
-            ]);
+            $context['state'] = [
+                'database' => $cloned->getAll(),
+                'backend' => $entity->getAll(),
+            ];
         }
+
+        $this->logger->debug('MAPPER: [%(backend)] [%(title)] metadata and play state is identical.', $context);
 
         Message::increment("{$entity->via}.{$entity->type}.ignored_no_change");
 


### PR DESCRIPTION
The way we process webhook requests right now have some draw backs, if the tasks are in progress and webhook request comes in, this would lead to deadlock and potentially losing the event if we cant retrieve it via `state:import` later.  As we are forced to accept some spammy events like jellyfin `UserDataSaved` because they dont provide events like mark `played/unplayed/scrobble`  this lead to many requests hitting the database for no reason.

Therefore, the new approach is instead of processing all those events in real time as they come we queue them keyed by some unique identifier like `{type}://{id}:{tainted}@{backend}`. Using the identifier like this we disregard all older "same events" from being processed. 

The new command to process the requests is named `state:requests` the task named `requests` controlled by the same variables as other tasks `WS_CRON_REQUESTS_*`. This task is enabled by default to retain the same behavior as the old approach.

The future plan is to merge both `state:requests` and `state:push` as it make sense to process those two things at the same time. 
