### PR TITLE
Miscellaneous changes

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -255,7 +255,7 @@ return (function () {
                 'info' => 'Process queued http requests.',
                 'enabled' => (bool)env('WS_CRON_REQUESTS', true),
                 'timer' => (string)env('WS_CRON_REQUESTS_AT', '*/2 * * * *'),
-                'args' => env('WS_CRON_REQUESTS_ARGS', '-v'),
+                'args' => env('WS_CRON_REQUESTS_ARGS', '-v --no-stats'),
             ],
         ],
     ];

--- a/src/Backends/Jellyfin/Action/ParseWebhook.php
+++ b/src/Backends/Jellyfin/Action/ParseWebhook.php
@@ -38,6 +38,7 @@ final class ParseWebhook
     protected const WEBHOOK_TAINTED_EVENTS = [
         'PlaybackStart',
         'PlaybackStop',
+        'ItemAdded',
     ];
 
     /**


### PR DESCRIPTION
* Mark jellyfin `ItemAdd` event as tainted.
* Change default `state:requests` task flags to be less verbose.
* Support tainted events handling at mappers level.