### PR TITLE
Fixes #265 and re-enable emby library.new webhook event.

### DIFF
--- a/src/Backends/Emby/Action/ParseWebhook.php
+++ b/src/Backends/Emby/Action/ParseWebhook.php
@@ -39,9 +39,7 @@ final class ParseWebhook
         'playback.unpause',
         'playback.start',
         'playback.stop',
-        // @TODO turn it on when Emby 4.8 releases
-        // right now it's reporting bogus data for episodes.
-        // 'library.new',
+        'library.new',
     ];
 
     protected const WEBHOOK_TAINTED_EVENTS = [

--- a/src/Libs/Initializer.php
+++ b/src/Libs/Initializer.php
@@ -336,6 +336,24 @@ final class Initializer
                     'item' => [
                         'title' => $entity->getName(),
                         'type' => $entity->type,
+                    ],
+                ]
+            );
+
+            return new Response(304);
+        }
+
+        if ((null === $entity->episode || null === $entity->season) && $entity->isEpisode()) {
+            $this->write(
+                $request, Logger::NOTICE,
+                'Ignoring [%(backend)] %(item.type) [%(item.title)]. No episode/season number present.',
+                [
+                    'backend' => $entity->via,
+                    'item' => [
+                        'title' => $entity->getName(),
+                        'type' => $entity->type,
+                        'season' => (string)($entity->season ?? 'None'),
+                        'episode' => (string)($entity->episode ?? 'None'),
                     ]
                 ]
             );
@@ -363,7 +381,7 @@ final class Initializer
 
         $cache->set('requests', $items, new DateInterval('P3D'));
 
-        $this->write($request, Logger::INFO, 'Queued [%(backend)] %(item.type) [%(item.title)] for processing.', [
+        $this->write($request, Logger::INFO, 'Queued [%(backend)] %(item.type) [%(item.title)].', [
             'backend' => $entity->via,
             'item' => [
                 'title' => $entity->getName(),


### PR DESCRIPTION
Emby pushed new update to their webhook events system, with that a new event "library.new" has been added, eventually in 4.8 they will implement a delay system so that the metadata is available before sending the event. the event right now is barebone useful only for getting the item id in which we can query API for more info if it's available.

When we enabled the event for 4.7 there was problem with events that does not contain any metadata yet being added to the database, that exposes a problem with our handling of episodes events. as such, we prevent adding any episodes that does not contain season & episode number.
