### PR TITLE
Plex Fixed bug in parsing youtube agent GUID. Added an option to remove records that fails parity checks.

### DIFF
--- a/src/Backends/Plex/PlexGuid.php
+++ b/src/Backends/Plex/PlexGuid.php
@@ -260,7 +260,7 @@ final class PlexGuid implements iGuid
                 }
 
                 // -- fallback to channel if episode match fails.
-                $pRegex = '/^youtube\|(?<channel>PL[^\[\]]{16}|PL[^\[\]]{32}|(UC|HC|UU|FL|LP|RD)[^\[\]]{22})(?<folder>\|?.+)?/is';
+                $pRegex = '/^youtube\|(?<channel>PL[^\[\]]{32}|PL[^\[\]]{16}|(UC|HC|UU|FL|LP|RD)[^\[\]]{22})(?<folder>\|?.+)?/is';
                 if (1 === preg_match($pRegex, $af, $matches)) {
                     return r('{agent}://{channel}', [
                         'agent' => 'youtube',


### PR DESCRIPTION
* Fixed bug in PlexGuid related to `com.plexapp.agents.youtube` Playlist ID parsing.
* Added new flag flag `-p, --prune` to `db:parity` command that allows the user to remove records that fails parity check.