### PR TITLE
Track items play progress

### DIFF
--- a/src/Backends/Jellyfin/JellyfinActionTrait.php
+++ b/src/Backends/Jellyfin/JellyfinActionTrait.php
@@ -149,6 +149,13 @@ trait JellyfinActionTrait
 
         if (true === $isPlayed) {
             $metadata[iState::COLUMN_META_DATA_PLAYED_AT] = (string)makeDate($date)->getTimestamp();
+            $metadata[iState::COLUMN_META_DATA_PROGRESS] = "0";
+        }
+
+        if (false === $isPlayed && null !== ($progress = ag($item, 'UserData.PlaybackPositionTicks', null))) {
+            $metadata[iState::COLUMN_META_DATA_PROGRESS] = (string)floor(
+                $progress / 1_00_00
+            ); // -- Convert to milliseconds.
         }
 
         unset($metadata, $metadataExtra);

--- a/src/Backends/Plex/PlexActionTrait.php
+++ b/src/Backends/Plex/PlexActionTrait.php
@@ -165,6 +165,12 @@ trait PlexActionTrait
 
         if (true === $isPlayed) {
             $metadata[iState::COLUMN_META_DATA_PLAYED_AT] = (string)$date;
+            $metadata[iState::COLUMN_META_DATA_PROGRESS] = "0";
+        }
+
+        if (false === $isPlayed && null !== ($progress = ag($item, 'viewOffset', null))) {
+            // -- Plex reports play progress in milliseconds already no need to convert.
+            $metadata[iState::COLUMN_META_DATA_PROGRESS] = (string)$progress;
         }
 
         unset($metadata, $metadataExtra);

--- a/src/Libs/Entity/StateInterface.php
+++ b/src/Libs/Entity/StateInterface.php
@@ -38,6 +38,7 @@ interface StateInterface extends LoggerAwareInterface
     public const COLUMN_META_PATH = 'path';
     public const COLUMN_META_DATA_ADDED_AT = 'added_at';
     public const COLUMN_META_DATA_PLAYED_AT = 'played_at';
+    public const COLUMN_META_DATA_PROGRESS = 'progress';
     public const COLUMN_META_DATA_EXTRA = 'extra';
     public const COLUMN_META_DATA_EXTRA_TITLE = 'title';
     public const COLUMN_META_DATA_EXTRA_DATE = 'date';


### PR DESCRIPTION
Right now, it's pretty useless as we don't really do anything with the data. Having said that, i need to find a way to use it probably create new task that runs and sync those items play state back to backends.