### PR TITLE
Support ytinforeader.bundle

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -236,10 +236,11 @@ $ mv /config/db/watchstate_v01-repaired.db /config/db/watchstate_v01.db
 * com.plexapp.agents.xbmcnfo://(id)?lang=en `(XBMC NFO Movies agent)`
 * com.plexapp.agents.xbmcnfotv://(id)?lang=en `(XBMC NFO TV agent)`
 * com.plexapp.agents.hama://(db)\d?-(id)?lang=en `(HAMA multi source db agent mainly for anime)`
-* com.plexapp.agents.youtube://youtube|(seriesId)|(?<folder>\w)?/(?<season>
-  \d)?(.+) [YouTube-Agent.bundle](https://github.com/ZeroQI/YouTube-Agent.bundle)
+* com.plexapp.agents.ytinforeader://(id)
+  ?lang=en [ytinforeader.bundle](https://github.com/arabcoders/plex-ytdlp-info-reader-agent)
   With [jp_scanner.py](https://gist.github.com/arabcoders/ecb2755aa1d76dc89301ec44b8d367d5) as scanner.
-* com.plexapp.agents.cmdb://(id)?(.+) `(Custom metadata db agent)` Will release more information about it at later time.
+* com.plexapp.agents.cmdb://(id)?lang=en [Custom metadata db agent](https://github.com/arabcoders/cmdb.bundle) User
+  created metadata database.
 
 ---
 
@@ -544,11 +545,9 @@ make `.info.json` optional However at the moment the file is required for emby/j
 
 #### Plex Setup
 
-* Download this agent [YouTube-Agent.bundle](https://github.com/ZeroQI/YouTube-Agent.bundle) please follow the
-  instructions on how to install it from the link itself.
-* Download my custom scanner [jp_scanner.py](https://gist.github.com/arabcoders/ecb2755aa1d76dc89301ec44b8d367d5) and
-  save it into `[...]/Plex Media Server/Scanners/Series/jp_scanner.py` if you don't know there are more detailed guide
-  at this link [How to install a Scanner](https://github.com/ZeroQI/Absolute-Series-Scanner#install--update).
+* Download this agent [ytinforeader.bundle](https://github.com/arabcoders/plex-ytdlp-info-reader-agent) please follow
+  the instructions on how to install it from the link itself. It's important to use the specified scanner otherwise the
+  syncing will not work.
 
 #### Jellyfin Setup
 

--- a/src/Backends/Plex/PlexClient.php
+++ b/src/Backends/Plex/PlexClient.php
@@ -82,7 +82,7 @@ class PlexClient implements iClient
         'com.plexapp.agents.xbmcnfotv',
         'com.plexapp.agents.thetvdb',
         'com.plexapp.agents.hama',
-        'com.plexapp.agents.youtube',
+        'com.plexapp.agents.ytinforeader',
         'com.plexapp.agents.cmdb',
         'tv.plex.agents.movie',
         'tv.plex.agents.series',

--- a/src/Backends/Plex/PlexGuid.php
+++ b/src/Backends/Plex/PlexGuid.php
@@ -22,7 +22,7 @@ final class PlexGuid implements iGuid
         'tvmaze' => Guid::GUID_TVMAZE,
         'tvrage' => Guid::GUID_TVRAGE,
         'anidb' => Guid::GUID_ANIDB,
-        'youtube' => Guid::GUID_YOUTUBE,
+        'ytinforeader' => Guid::GUID_YOUTUBE,
         'cmdb' => Guid::GUID_CMDB,
     ];
 
@@ -37,7 +37,7 @@ final class PlexGuid implements iGuid
         'com.plexapp.agents.xbmcnfotv',
         'com.plexapp.agents.thetvdb',
         'com.plexapp.agents.hama',
-        'com.plexapp.agents.youtube',
+        'com.plexapp.agents.ytinforeader',
         'com.plexapp.agents.cmdb',
     ];
 
@@ -149,8 +149,7 @@ final class PlexGuid implements iGuid
 
                 if (true === str_starts_with($val, 'com.plexapp.agents.')) {
                     // -- DO NOT accept plex relative unique ids, we generate our own.
-                    // -- exception for youtube agent, as it is a mess.
-                    if (false === str_contains($val, '.youtube') && substr_count($val, '/') >= 3) {
+                    if (substr_count($val, '/') >= 3) {
                         continue;
                     }
 
@@ -271,43 +270,6 @@ final class PlexGuid implements iGuid
         }
 
         try {
-            /**
-             * YouTube agent IDs are a mess, and hard to parse, so we have to use fallback system,
-             * series id usually looks like
-             * com.plexapp.agents.youtube://youtube|UCIfuY0NRq1szr_6tzFy23NF|Season 2022?lang=xn
-             * and season looks like
-             * com.plexapp.agents.youtube://youtube|UCIfuY0NRq1szr_6tzFy23NF|Season 2023/2015?lang=xn
-             * and episodes looks like
-             * com.plexapp.agents.youtube://youtube|UCIfuY0NRq1szr_6tzFy23NF|Season 2022/2018/1102421482?lang=xn
-             *
-             * So the order of parsing is from episode to channel.
-             */
-            if (true === str_starts_with($guid, 'com.plexapp.agents.youtube')) {
-                $af = after($guid, '://');
-
-                // -- Check for episode id.
-                $iRegex = '/^youtube\|(?<channel>PL[^\[\]]{16}|PL[^\[\]]{32}|(UC|HC|UU|FL|LP|RD)[^\[\]]{22})(?<folder>\|?.+)\/(?<season>\d+)\/(?<episode>\d+)\?.+$/is';
-                if (1 === preg_match($iRegex, $af, $matches)) {
-                    return r('{agent}://{channel}/{season}/{episode}', [
-                        'agent' => 'youtube',
-                        'channel' => ag($matches, 'channel'),
-                        'season' => ag($matches, 'season'),
-                        'episode' => ag($matches, 'episode'),
-                    ]);
-                }
-
-                // -- fallback to channel if episode match fails.
-                $pRegex = '/^youtube\|(?<channel>PL[^\[\]]{32}|PL[^\[\]]{16}|(UC|HC|UU|FL|LP|RD)[^\[\]]{22})(?<folder>\|?.+)?/is';
-                if (1 === preg_match($pRegex, $af, $matches)) {
-                    return r('{agent}://{channel}', [
-                        'agent' => 'youtube',
-                        'channel' => ag($matches, 'channel'),
-                    ]);
-                }
-
-                return $guid;
-            }
-
             // -- Handle hama plex agent. This is multi source agent.
             if (true === str_starts_with($guid, 'com.plexapp.agents.hama')) {
                 $hamaRegex = '/(?P<source>(anidb|tvdb|tmdb|tsdb|imdb))\d?-(?P<id>[^\[\]]*)/';

--- a/src/Libs/Database/PDO/PDOAdapter.php
+++ b/src/Libs/Database/PDO/PDOAdapter.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Libs\Database\PDO;
 
 use App\Libs\Container;
-use App\Libs\Database\DatabaseException as DBException;
 use App\Libs\Database\DatabaseInterface as iDB;
 use App\Libs\Entity\StateInterface as iState;
+use App\Libs\Exceptions\DatabaseException as DBException;
 use App\Libs\Options;
 use Closure;
 use DateTimeInterface;

--- a/src/Libs/Exceptions/DatabaseException.php
+++ b/src/Libs/Exceptions/DatabaseException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Libs\Database;
+namespace App\Libs\Exceptions;
 
 use RuntimeException;
 

--- a/tests/Backends/Common/ErrorTest.php
+++ b/tests/Backends/Common/ErrorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Backends\Common;
+namespace Tests\Backends\Common;
 
 use App\Backends\Common\Error;
 use App\Backends\Common\Levels;

--- a/tests/Backends/Plex/GetLibrariesListTest.php
+++ b/tests/Backends/Plex/GetLibrariesListTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Backends\Plex;
+namespace Tests\Backends\Plex;
 
 use App\Backends\Common\Cache;
 use App\Backends\Common\Context;
@@ -52,8 +52,7 @@ class GetLibrariesListTest extends TestCase
         ]);
 
         $client = new MockHttpClient($resp);
-        $list = new GetLibrariesList($client, $this->logger);
-        $response = $list($this->context);
+        $response = (new GetLibrariesList($client, $this->logger))($this->context);
 
         $this->assertTrue($response->status);
         $this->assertNull($response->error);

--- a/tests/Database/PDOAdapterTest.php
+++ b/tests/Database/PDOAdapterTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Database;
 
-use App\Libs\Database\DatabaseException as DBException;
 use App\Libs\Database\DatabaseInterface as iDB;
 use App\Libs\Database\PDO\PDOAdapter;
 use App\Libs\Entity\StateEntity;
 use App\Libs\Entity\StateInterface;
+use App\Libs\Exceptions\DatabaseException as DBException;
 use App\Libs\Guid;
 use App\Libs\TestCase;
 use DateTimeImmutable;

--- a/tests/Mappers/Import/AbstractTestsMapper.php
+++ b/tests/Mappers/Import/AbstractTestsMapper.php
@@ -16,6 +16,7 @@ use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use PDO;
 use Psr\Log\LoggerInterface;
+use Random\RandomException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 
@@ -52,6 +53,9 @@ abstract class AbstractTestsMapper extends TestCase
         Message::reset();
     }
 
+    /**
+     * @throws RandomException
+     */
     public function test_loadData_null_date_conditions(): void
     {
         $testEpisode = new StateEntity($this->testEpisode);
@@ -75,6 +79,9 @@ abstract class AbstractTestsMapper extends TestCase
         );
     }
 
+    /**
+     * @throws RandomException
+     */
     public function test_loadData_date_conditions(): void
     {
         $time = time();
@@ -299,6 +306,9 @@ abstract class AbstractTestsMapper extends TestCase
         );
     }
 
+    /**
+     * @throws RandomException
+     */
     public function test_get_conditions(): void
     {
         $movie = $this->testMovie;
@@ -341,6 +351,9 @@ abstract class AbstractTestsMapper extends TestCase
         );
     }
 
+    /**
+     * @throws RandomException
+     */
     public function test_get_fully_loaded_conditions(): void
     {
         $time = time();
@@ -424,6 +437,9 @@ abstract class AbstractTestsMapper extends TestCase
         );
     }
 
+    /**
+     * @throws RandomException
+     */
     public function test_has_conditions(): void
     {
         $testEpisode = new StateEntity($this->testEpisode);
@@ -438,6 +454,9 @@ abstract class AbstractTestsMapper extends TestCase
         );
     }
 
+    /**
+     * @throws RandomException
+     */
     public function test_has_fully_loaded_conditions(): void
     {
         $time = time();
@@ -471,6 +490,9 @@ abstract class AbstractTestsMapper extends TestCase
         $this->assertCount(0, $this->mapper, 'Mapper should be empty as we have called reset on the mapper.');
     }
 
+    /**
+     * @throws RandomException
+     */
     public function test_getObjects_conditions(): void
     {
         $testMovie = new StateEntity($this->testMovie);


### PR DESCRIPTION
We dopped support for https://github.com/ZeroQI/YouTube-Agent.bundle in favor of our own https://github.com/arabcoders/ytinforeader.bundle The reason behind this, is so we can control how the IDs are generated and enforce correct behavior, due to the way youtube-agent generate ids we have to make so many workarounds to get it to work, and we already have working plugins for emby/jellyfin, so might as well make one for plex.