### PR TITLE
Added version constraint check for sync play progress

### DIFF
--- a/src/Backends/Jellyfin/JellyfinClient.php
+++ b/src/Backends/Jellyfin/JellyfinClient.php
@@ -337,7 +337,7 @@ class JellyfinClient implements iClient
     {
         $version = $this->getVersion();
 
-        if (false === version_compare($version, '10.8.14', '>=')) {
+        if (false === version_compare($version, '10.9', '>=')) {
             $this->throwError(
                 response: new Response(
                     status: false,
@@ -346,7 +346,7 @@ class JellyfinClient implements iClient
                         context: [
                             'version' => [
                                 'current' => $version,
-                                'required' => '10.8.14',
+                                'required' => '10.9.x',
                             ],
                         ],
                         level: Levels::ERROR,

--- a/src/Commands/Database/ListCommand.php
+++ b/src/Commands/Database/ListCommand.php
@@ -476,6 +476,7 @@ final class ListCommand extends Command
                     'via' => $entity->via ?? '??',
                     'date' => makeDate($entity->updated)->format('Y-m-d H:i:s T'),
                     'played' => $entity->isWatched() ? 'Yes' : 'No',
+                    'progress' => $entity->hasPlayProgress() ? $entity->getPlayProgress() : 'None',
                     'event' => ag($entity->extra[$entity->via] ?? [], iState::COLUMN_EXTRA_EVENT, '-'),
                 ];
             }

--- a/src/Libs/Exceptions/Backends/UnexpectedVersionException.php
+++ b/src/Libs/Exceptions/Backends/UnexpectedVersionException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Libs\Exceptions\Backends;
+
+/**
+ * Class UnexpectedVersionException
+ *
+ * This exception is thrown when backend version is unexpected.
+ */
+class UnexpectedVersionException extends BackendException
+{
+}

--- a/src/Libs/helpers.php
+++ b/src/Libs/helpers.php
@@ -41,7 +41,7 @@ if (!function_exists('env')) {
             return getValue($default);
         }
 
-        return match (strtolower($value)) {
+        return match (is_string($value) ? strtolower($value) : $value) {
             'true', '(true)' => true,
             'false', '(false)' => false,
             'empty', '(empty)' => '',
@@ -962,7 +962,7 @@ if (!function_exists('getClientIp')) {
             return $realIp;
         }
 
-        if (null === ($firstIp = explode(',', $forwardIp)[0] ?? null)) {
+        if (null === ($firstIp = explode(',', $forwardIp)[0] ?? null) || empty($firstIp)) {
             return $realIp;
         }
 

--- a/tests/Fixtures/EpisodeEntity.php
+++ b/tests/Fixtures/EpisodeEntity.php
@@ -2,24 +2,24 @@
 
 declare(strict_types=1);
 
-use App\Libs\Entity\StateInterface as iFace;
+use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Guid;
 
 return [
-    iFace::COLUMN_ID => null,
-    iFace::COLUMN_TYPE => iFace::TYPE_EPISODE,
-    iFace::COLUMN_UPDATED => 1,
-    iFace::COLUMN_WATCHED => 1,
-    iFace::COLUMN_VIA => 'home_plex',
-    iFace::COLUMN_TITLE => 'Series Title',
-    iFace::COLUMN_YEAR => 2020,
-    iFace::COLUMN_SEASON => 1,
-    iFace::COLUMN_EPISODE => 2,
-    iFace::COLUMN_PARENT => [
+    iState::COLUMN_ID => null,
+    iState::COLUMN_TYPE => iState::TYPE_EPISODE,
+    iState::COLUMN_UPDATED => 1,
+    iState::COLUMN_WATCHED => 1,
+    iState::COLUMN_VIA => 'home_plex',
+    iState::COLUMN_TITLE => 'Series Title',
+    iState::COLUMN_YEAR => 2020,
+    iState::COLUMN_SEASON => 1,
+    iState::COLUMN_EPISODE => 2,
+    iState::COLUMN_PARENT => [
         Guid::GUID_IMDB => 'tt510',
         Guid::GUID_TVDB => '520',
     ],
-    iFace::COLUMN_GUIDS => [
+    iState::COLUMN_GUIDS => [
         Guid::GUID_IMDB => 'tt6100',
         Guid::GUID_TVDB => '6200',
         Guid::GUID_TMDB => '6300',
@@ -27,27 +27,27 @@ return [
         Guid::GUID_TVRAGE => '6500',
         Guid::GUID_ANIDB => '6600',
     ],
-    iFace::COLUMN_META_DATA => [
+    iState::COLUMN_META_DATA => [
         'home_plex' => [
-            iFace::COLUMN_ID => 122,
-            iFace::COLUMN_TYPE => iFace::TYPE_EPISODE,
-            iFace::COLUMN_WATCHED => 1,
-            iFace::COLUMN_TITLE => 'Series Title',
-            iFace::COLUMN_YEAR => '2020',
-            iFace::COLUMN_SEASON => '1',
-            iFace::COLUMN_EPISODE => '2',
-            iFace::COLUMN_META_DATA_EXTRA => [
-                iFace::COLUMN_META_DATA_EXTRA_DATE => '2020-01-03',
-                iFace::COLUMN_META_DATA_EXTRA_TITLE => 'Episode Title',
+            iState::COLUMN_ID => 122,
+            iState::COLUMN_TYPE => iState::TYPE_EPISODE,
+            iState::COLUMN_WATCHED => 1,
+            iState::COLUMN_TITLE => 'Series Title',
+            iState::COLUMN_YEAR => '2020',
+            iState::COLUMN_SEASON => '1',
+            iState::COLUMN_EPISODE => '2',
+            iState::COLUMN_META_DATA_EXTRA => [
+                iState::COLUMN_META_DATA_EXTRA_DATE => '2020-01-03',
+                iState::COLUMN_META_DATA_EXTRA_TITLE => 'Episode Title',
             ],
-            iFace::COLUMN_META_DATA_ADDED_AT => 1,
-            iFace::COLUMN_META_DATA_PLAYED_AT => 2,
+            iState::COLUMN_META_DATA_ADDED_AT => 1,
+            iState::COLUMN_META_DATA_PLAYED_AT => 2,
         ],
     ],
-    iFace::COLUMN_EXTRA => [
+    iState::COLUMN_EXTRA => [
         'home_plex' => [
-            iFace::COLUMN_EXTRA_DATE => 1,
-            iFace::COLUMN_EXTRA_EVENT => 'media.scrobble'
+            iState::COLUMN_EXTRA_DATE => 1,
+            iState::COLUMN_EXTRA_EVENT => 'media.scrobble'
         ],
     ],
 ];

--- a/tests/Fixtures/MovieEntity.php
+++ b/tests/Fixtures/MovieEntity.php
@@ -2,21 +2,21 @@
 
 declare(strict_types=1);
 
-use App\Libs\Entity\StateInterface as iFace;
+use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Guid;
 
 return [
-    iFace::COLUMN_ID => null,
-    iFace::COLUMN_TYPE => iFace::TYPE_MOVIE,
-    iFace::COLUMN_UPDATED => 1,
-    iFace::COLUMN_WATCHED => 1,
-    iFace::COLUMN_VIA => 'home_plex',
-    iFace::COLUMN_TITLE => 'Movie Title',
-    iFace::COLUMN_YEAR => 2020,
-    iFace::COLUMN_SEASON => null,
-    iFace::COLUMN_EPISODE => null,
-    iFace::COLUMN_PARENT => [],
-    iFace::COLUMN_GUIDS => [
+    iState::COLUMN_ID => null,
+    iState::COLUMN_TYPE => iState::TYPE_MOVIE,
+    iState::COLUMN_UPDATED => 1,
+    iState::COLUMN_WATCHED => 1,
+    iState::COLUMN_VIA => 'home_plex',
+    iState::COLUMN_TITLE => 'Movie Title',
+    iState::COLUMN_YEAR => 2020,
+    iState::COLUMN_SEASON => null,
+    iState::COLUMN_EPISODE => null,
+    iState::COLUMN_PARENT => [],
+    iState::COLUMN_GUIDS => [
         Guid::GUID_IMDB => 'tt1100',
         Guid::GUID_TVDB => '1200',
         Guid::GUID_TMDB => '1300',
@@ -24,23 +24,24 @@ return [
         Guid::GUID_TVRAGE => '1500',
         Guid::GUID_ANIDB => '1600',
     ],
-    iFace::COLUMN_META_DATA => [
+    iState::COLUMN_META_DATA => [
         'home_plex' => [
-            iFace::COLUMN_ID => 121,
-            iFace::COLUMN_TYPE => iFace::TYPE_MOVIE,
-            iFace::COLUMN_WATCHED => 1,
-            iFace::COLUMN_YEAR => '2020',
-            iFace::COLUMN_META_DATA_EXTRA => [
-                iFace::COLUMN_META_DATA_EXTRA_DATE => '2020-01-03',
+            iState::COLUMN_ID => 121,
+            iState::COLUMN_TYPE => iState::TYPE_MOVIE,
+            iState::COLUMN_WATCHED => 1,
+            iState::COLUMN_YEAR => '2020',
+            iState::COLUMN_META_DATA_EXTRA => [
+                iState::COLUMN_META_DATA_EXTRA_DATE => '2020-01-03',
             ],
-            iFace::COLUMN_META_DATA_ADDED_AT => 1,
-            iFace::COLUMN_META_DATA_PLAYED_AT => 2,
+            iState::COLUMN_META_DATA_PROGRESS => 5000,
+            iState::COLUMN_META_DATA_ADDED_AT => 1,
+            iState::COLUMN_META_DATA_PLAYED_AT => 2,
         ],
     ],
-    iFace::COLUMN_EXTRA => [
+    iState::COLUMN_EXTRA => [
         'home_plex' => [
-            iFace::COLUMN_EXTRA_EVENT => 'media.scrobble',
-            iFace::COLUMN_EXTRA_DATE => 1,
+            iState::COLUMN_EXTRA_EVENT => 'media.scrobble',
+            iState::COLUMN_EXTRA_DATE => 2,
         ],
     ],
 ];


### PR DESCRIPTION
- [x] Added version constraint check for jellyfin for sync play progress. Support for it was added in later versions than `10.8.13`. The version isn't sure yet.
- [x] Added progress column to `db:list`
- [x] Improved testing code to include play progress tests for state entity, still missing testing code for mappers.