### PR TITLE
Code changes to support time drift for state:progress

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -544,6 +544,8 @@ something like `redis://redis:6379?password=my_secert_password&db=8`. We only su
 
 Once that done, restart the container.
 
+---
+
 ### There are weirdly named directories in my data path?
 
 Unfortunately, That was due to a bug introduced in (2023-09-12 877a41a) and was fixed in (2023-09-19 a2f8c8a), if you
@@ -551,6 +553,8 @@ have happened to installation or update during this period, you will have those 
 can simply delete those folders `%(tmpDir)` `%(path)` `{path}` `{tmpDir}`. I decided to not do it automatically to avoid
 any data loss. you should check the directories to make sure they are empty. if not copy the directories to the correct
 location and delete the empty directories.
+
+---
 
 ### How to get WatchState working with YouTube content/library?
 
@@ -597,7 +601,7 @@ If the command fails for any reason, then you most likely have network related p
 
 ```bash
 $ docker exec -ti watchstate bash
-$ curl -v -H "Accept: application/json" -H "X-Plex-Token: [PLEX_TOKEN]" http://[PLEX_URL]/library/sections
+$ curl -H "Accept: application/json" -H "X-Plex-Token: [PLEX_TOKEN]" http://[PLEX_URL]/
 ```
 
 * Replace `[PLEX_TOKEN]` with your plex token.
@@ -613,7 +617,7 @@ If everything is working correctly you should see something like this previous j
 
 ```bash
 $ docker exec -ti watchstate bash
-$ curl -v -H "Accept: application/json" -H "X-MediaBrowser-Token: [BACKEND_API_KEY]" http://[BACKEND_HOST]/library/sections
+$ curl -v -H "Accept: application/json" -H "X-MediaBrowser-Token: [BACKEND_API_KEY]" http://[BACKEND_HOST]/System/Info
 ```
 
 * Replace `[BACKEND_API_KEY]` with your jellyfin/emby api key.

--- a/src/Backends/Jellyfin/JellyfinActionTrait.php
+++ b/src/Backends/Jellyfin/JellyfinActionTrait.php
@@ -45,6 +45,13 @@ trait JellyfinActionTrait
             $date = ag($item, true === $isPlayed ? ['UserData.LastPlayedDate', 'DateCreated'] : 'DateCreated');
         }
 
+        // -- For Progress action we need to use the latest date.
+        if (true === (bool)($opts['latest_date'] ?? false)) {
+            if (null !== ($_lastPlayed = ag($item, 'UserData.LastPlayedDate'))) {
+                $date = $_lastPlayed;
+            }
+        }
+
         if (null === $date) {
             throw new InvalidArgumentException('No date was set on object.');
         }

--- a/src/Backends/Plex/PlexActionTrait.php
+++ b/src/Backends/Plex/PlexActionTrait.php
@@ -48,6 +48,11 @@ trait PlexActionTrait
             $date = ag($item, true === $isPlayed ? 'lastViewedAt' : 'addedAt');
         }
 
+        // -- For Progress action we need to use the latest date.
+        if (true === (bool)($opts['latest_date'] ?? false)) {
+            $date = max(ag($item, 'lastViewedAt', 0), ag($item, 'addedAt', 0), ag($item, 'updatedAt', 0));
+        }
+
         if (null === $date) {
             throw new InvalidArgumentException('No date was set on object.');
         }
@@ -113,10 +118,8 @@ trait PlexActionTrait
                     iState::COLUMN_WATCHED => true === $isPlayed ? '1' : '0',
                     iState::COLUMN_VIA => $context->backendName,
                     iState::COLUMN_TITLE => ag($item, ['title', 'originalTitle'], '??'),
-                    iState::COLUMN_GUIDS => $guid->parse(
-                        guids: ag($item, 'Guid', []),
-                        context: $logContext
-                    ),
+                    iState::COLUMN_GUIDS => $guid->parse(guids: ag($item, 'Guid', []), context: $logContext),
+                    iState::COLUMN_META_DATA_RATING => (string)ag($item, 'userRating', '0'),
                     iState::COLUMN_META_DATA_ADDED_AT => (string)ag($item, 'addedAt'),
                 ],
             ],

--- a/src/Commands/Backend/Ignore/ManageCommand.php
+++ b/src/Commands/Backend/Ignore/ManageCommand.php
@@ -11,6 +11,7 @@ use App\Libs\Exceptions\InvalidArgumentException;
 use App\Libs\Exceptions\RuntimeException;
 use App\Libs\Guid;
 use App\Libs\Routable;
+use App\Libs\Stream;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -177,7 +178,10 @@ final class ManageCommand extends Command
         }
 
         @copy($path, $path . '.bak');
-        @file_put_contents($path, Yaml::dump($list, 8, 2));
+
+        $stream = new Stream($path, 'w');
+        $stream->write(Yaml::dump($list, 8, 2));
+        $stream->close();
 
         return self::SUCCESS;
     }

--- a/src/Commands/Config/DeleteCommand.php
+++ b/src/Commands/Config/DeleteCommand.php
@@ -8,6 +8,7 @@ use App\Command;
 use App\Libs\Config;
 use App\Libs\Database\DatabaseInterface as iDB;
 use App\Libs\Routable;
+use App\Libs\Stream;
 use PDO;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -245,7 +246,9 @@ final class DeleteCommand extends Command
 
         $backends = ag_delete($backends, $name);
 
-        file_put_contents($config, Yaml::dump($backends, 8, 2));
+        $stream = new Stream($config, 'w');
+        $stream->write(Yaml::dump($backends, 8, 2));
+        $stream->close();
 
         $output->writeln('<info>Config updated.</info>');
 

--- a/src/Commands/Config/ManageCommand.php
+++ b/src/Commands/Config/ManageCommand.php
@@ -10,6 +10,7 @@ use App\Commands\System\IndexCommand;
 use App\Libs\Config;
 use App\Libs\Options;
 use App\Libs\Routable;
+use App\Libs\Stream;
 use Symfony\Component\Console\Exception\ExceptionInterface;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
@@ -397,7 +398,9 @@ final class ManageCommand extends Command
 
         $backends = ag_set($backends, $name, $u);
 
-        file_put_contents($config, Yaml::dump($backends, 8, 2));
+        $stream = new Stream($config, 'w');
+        $stream->write(Yaml::dump($backends, 8, 2));
+        $stream->close();
 
         $output->writeln('<info>Config updated.</info>');
 

--- a/src/Commands/Config/UnifyCommand.php
+++ b/src/Commands/Config/UnifyCommand.php
@@ -7,6 +7,7 @@ namespace App\Commands\Config;
 use App\Command;
 use App\Libs\Config;
 use App\Libs\Routable;
+use App\Libs\Stream;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Input\InputArgument;
@@ -225,7 +226,9 @@ final class UnifyCommand extends Command
             copy($config, $config . '.bak');
         }
 
-        file_put_contents($config, Yaml::dump(Config::get('servers', []), 8, 2));
+        $stream = new Stream($config, 'w');
+        $stream->write(Yaml::dump(Config::get('servers', []), 8, 2));
+        $stream->close();
 
         $output->writeln(
             sprintf('<comment>Unified the webhook token of %d %s backends.</comment>', count($list), $type)

--- a/src/Libs/Database/PDO/PDOMigrations.php
+++ b/src/Libs/Database/PDO/PDOMigrations.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Libs\Database\PDO;
 
 use App\Libs\Database\DatabaseInterface as iDB;
+use App\Libs\Stream;
 use PDO;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -169,8 +170,8 @@ final class PDOMigrations
             ]));
         }
 
-        file_put_contents(
-            $file,
+        $stream = new Stream($file, 'w');
+        $stream->write(
             <<<SQL
         -- # migrate_up
 
@@ -182,6 +183,7 @@ final class PDOMigrations
 
         SQL
         );
+        $stream->close();
 
         $this->logger->info(r("PDOMigrations: Created new Migration file at '{file}'.", [
             'file' => $file

--- a/src/Libs/Entity/StateInterface.php
+++ b/src/Libs/Entity/StateInterface.php
@@ -42,6 +42,7 @@ interface StateInterface extends LoggerAwareInterface
     public const COLUMN_META_DATA_ADDED_AT = 'added_at';
     public const COLUMN_META_DATA_PLAYED_AT = 'played_at';
     public const COLUMN_META_DATA_PROGRESS = 'progress';
+    public const COLUMN_META_DATA_RATING = 'rating';
     public const COLUMN_META_DATA_EXTRA = 'extra';
     public const COLUMN_META_DATA_EXTRA_TITLE = 'title';
     public const COLUMN_META_DATA_EXTRA_DATE = 'date';

--- a/tests/Backends/Plex/GetLibrariesListTest.php
+++ b/tests/Backends/Plex/GetLibrariesListTest.php
@@ -9,6 +9,7 @@ use App\Backends\Common\Context;
 use App\Backends\Plex\Action\GetLibrariesList;
 use App\Backends\Plex\PlexClient;
 use App\Libs\Extends\LogMessageProcessor;
+use App\Libs\Stream;
 use App\Libs\TestCase;
 use App\Libs\Uri;
 use Monolog\Handler\TestHandler;
@@ -24,11 +25,16 @@ class GetLibrariesListTest extends TestCase
     protected TestHandler|null $handler = null;
     protected LoggerInterface|null $logger = null;
     protected Context|null $context = null;
-    
+    protected array $data = [];
+
     public function setUp(): void
     {
         $this->handler = new TestHandler();
         $this->logger = new Logger('test', [$this->handler], [new LogMessageProcessor()]);
+        $this->data = json_decode(
+            json: (string)Stream::make(__DIR__ . '/../../Fixtures/plex_data.json', 'r'),
+            associative: true
+        );
 
         $this->context = new Context(
             clientName: PlexClient::CLIENT_NAME,
@@ -43,9 +49,7 @@ class GetLibrariesListTest extends TestCase
 
     public function test_correct_response(): void
     {
-        $data = json_decode(file_get_contents(__DIR__ . '/../../Fixtures/plex_data.json'), true);
-
-        $json = ag($data, 'sections_get_200');
+        $json = ag($this->data, 'sections_get_200');
 
         $resp = new MockResponse(json_encode(ag($json, 'response.body')), [
             'http_code' => (int)ag($json, 'response.http_code'),
@@ -90,11 +94,9 @@ class GetLibrariesListTest extends TestCase
         }
     }
 
-    public function test_401_response(): void
+    public function test_401_response_with_invalid_token(): void
     {
-        $data = json_decode(file_get_contents(__DIR__ . '/../../Fixtures/plex_data.json'), true);
-
-        $json = ag($data, 'sections_get_401');
+        $json = ag($this->data, 'sections_get_401');
 
         $resp = new MockResponse(json_encode(ag($json, 'response.body')), [
             'http_code' => (int)ag($json, 'response.http_code'),


### PR DESCRIPTION
- [x] `FAQ.md` fix jellyfin/emby url for testing connection.
- [x] Updated Commands to use Stream instead of direct file writes.
- [x] Added time drift support for state:progress to prevent unending cycle of updates.
- [x] Plex Backend, change the progress report endpoint to `:/timeline` instead of `:/progress`.
- [x] Plex Backend, retrieve the user rating if exists. we do nothing with it right now. we just store it for possible future use, Sadly both emby/jellyfin does not support user rating and instead support simple like/dislike system.