### PR TITLE
Added guard clause to prevent backend reporting incorrect episode range

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -630,3 +630,21 @@ $ curl -v -H "Accept: application/json" -H "X-MediaBrowser-Token: [BACKEND_API_K
 
 If everything is working correctly you should see something like this previous json output.
 
+----
+
+### I keep receiving this warning in log `INFO: Ignoring [xxx] Episode range, and treating it as single episode. Backend says it covers [00-00]`?
+
+We recently added guard clause to prevent backends from sending possibly invalid episode ranges, as such if you see this,
+this likely means your backend mis-identified episodes range. By default, we allow an episode to cover up to 4 episodes.
+
+If this is not enough for your library content. fear not we have you covered you can increase the limit by running the following command:
+
+```bash 
+$ docker exec -ti watchstate console config:edit --key options.MAX_EPISODE_RANGE --set 10 -- [BACKEND_NAME] 
+```
+
+where `10` is the new limit. You can set it to any number you want. However, Please do inspect the reported records as
+it most likely you have incorrect metadata in your library.
+
+In the future, we plan to reduce the log level to `DEBUG` instead of `INFO`. However, for now, we will keep it as is.
+to inform you about the issue. 

--- a/src/Libs/Options.php
+++ b/src/Libs/Options.php
@@ -28,6 +28,7 @@ final class Options
     public const ADMIN_TOKEN = 'ADMIN_TOKEN';
     public const NO_THROW = 'NO_THROW';
     public const NO_LOGGING = 'NO_LOGGING';
+    public const MAX_EPISODE_RANGE = 'MAX_EPISODE_RANGE';
 
     private function __construct()
     {


### PR DESCRIPTION
I noticed lately, that jellyfin/emby sometimes parse the episode ranges from titles incorrectly, leading to huge episode range. As such we added new guard to prevent this from happening. By default, we allow an episode to cover 4 episodes at most, however this is configurable via options key. read the FAQ about it. 