### PR TITLE
Prevent progress update for the items which are being played right now

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -128,16 +128,16 @@
     },
     {
       "name": "laminas/laminas-httphandlerrunner",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "source": {
         "type": "git",
         "url": "https://github.com/laminas/laminas-httphandlerrunner.git",
-        "reference": "d3e84755a17e563b1c5f8290cbfb150210501a77"
+        "reference": "35a0ba92e940a2f9533754f5a56187fa321f7693"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/laminas/laminas-httphandlerrunner/zipball/d3e84755a17e563b1c5f8290cbfb150210501a77",
-        "reference": "d3e84755a17e563b1c5f8290cbfb150210501a77",
+        "url": "https://api.github.com/repos/laminas/laminas-httphandlerrunner/zipball/35a0ba92e940a2f9533754f5a56187fa321f7693",
+        "reference": "35a0ba92e940a2f9533754f5a56187fa321f7693",
         "shasum": ""
       },
       "require": {
@@ -148,10 +148,10 @@
       },
       "require-dev": {
         "laminas/laminas-coding-standard": "~2.5.0",
-        "laminas/laminas-diactoros": "^3.0.0",
-        "phpunit/phpunit": "^10.1.2",
+        "laminas/laminas-diactoros": "^3.3.0",
+        "phpunit/phpunit": "^10.5.5",
         "psalm/plugin-phpunit": "^0.18.4",
-        "vimeo/psalm": "^5.11"
+        "vimeo/psalm": "^5.18"
       },
       "type": "library",
       "extra": {
@@ -191,7 +191,7 @@
           "type": "community_bridge"
         }
       ],
-      "time": "2023-09-04T10:43:03+00:00"
+      "time": "2024-01-04T10:50:34+00:00"
     },
     {
       "name": "league/container",
@@ -1077,16 +1077,16 @@
     },
     {
       "name": "symfony/cache",
-      "version": "v6.4.0",
+      "version": "v6.4.2",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/cache.git",
-        "reference": "ac2d25f97b17eec6e19760b6b9962a4f7c44356a"
+        "reference": "14a75869bbb41cb35bc5d9d322473928c6f3f978"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/cache/zipball/ac2d25f97b17eec6e19760b6b9962a4f7c44356a",
-        "reference": "ac2d25f97b17eec6e19760b6b9962a4f7c44356a",
+        "url": "https://api.github.com/repos/symfony/cache/zipball/14a75869bbb41cb35bc5d9d322473928c6f3f978",
+        "reference": "14a75869bbb41cb35bc5d9d322473928c6f3f978",
         "shasum": ""
       },
       "require": {
@@ -1153,7 +1153,7 @@
         "psr6"
       ],
       "support": {
-        "source": "https://github.com/symfony/cache/tree/v6.4.0"
+        "source": "https://github.com/symfony/cache/tree/v6.4.2"
       },
       "funding": [
         {
@@ -1169,7 +1169,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2023-11-24T19:28:07+00:00"
+      "time": "2023-12-29T15:34:34+00:00"
     },
     {
       "name": "symfony/cache-contracts",
@@ -1249,16 +1249,16 @@
     },
     {
       "name": "symfony/console",
-      "version": "v6.4.1",
+      "version": "v6.4.2",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/console.git",
-        "reference": "a550a7c99daeedef3f9d23fb82e3531525ff11fd"
+        "reference": "0254811a143e6bc6c8deea08b589a7e68a37f625"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/console/zipball/a550a7c99daeedef3f9d23fb82e3531525ff11fd",
-        "reference": "a550a7c99daeedef3f9d23fb82e3531525ff11fd",
+        "url": "https://api.github.com/repos/symfony/console/zipball/0254811a143e6bc6c8deea08b589a7e68a37f625",
+        "reference": "0254811a143e6bc6c8deea08b589a7e68a37f625",
         "shasum": ""
       },
       "require": {
@@ -1323,7 +1323,7 @@
         "terminal"
       ],
       "support": {
-        "source": "https://github.com/symfony/console/tree/v6.4.1"
+        "source": "https://github.com/symfony/console/tree/v6.4.2"
       },
       "funding": [
         {
@@ -1339,7 +1339,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2023-11-30T10:54:28+00:00"
+      "time": "2023-12-10T16:15:48+00:00"
     },
     {
       "name": "symfony/deprecation-contracts",
@@ -1410,16 +1410,16 @@
     },
     {
       "name": "symfony/dotenv",
-      "version": "v6.4.0",
+      "version": "v6.4.2",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/dotenv.git",
-        "reference": "d0d584a91422ddaa2c94317200d4c4e5b935555f"
+        "reference": "835f8d2d1022934ac038519de40b88158798c96f"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/dotenv/zipball/d0d584a91422ddaa2c94317200d4c4e5b935555f",
-        "reference": "d0d584a91422ddaa2c94317200d4c4e5b935555f",
+        "url": "https://api.github.com/repos/symfony/dotenv/zipball/835f8d2d1022934ac038519de40b88158798c96f",
+        "reference": "835f8d2d1022934ac038519de40b88158798c96f",
         "shasum": ""
       },
       "require": {
@@ -1464,7 +1464,7 @@
         "environment"
       ],
       "support": {
-        "source": "https://github.com/symfony/dotenv/tree/v6.4.0"
+        "source": "https://github.com/symfony/dotenv/tree/v6.4.2"
       },
       "funding": [
         {
@@ -1480,20 +1480,20 @@
           "type": "tidelift"
         }
       ],
-      "time": "2023-10-26T18:19:48+00:00"
+      "time": "2023-12-28T19:16:56+00:00"
     },
     {
       "name": "symfony/http-client",
-      "version": "v6.4.0",
+      "version": "v6.4.2",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/http-client.git",
-        "reference": "5c584530b77aa10ae216989ffc48b4bedc9c0b29"
+        "reference": "fc0944665bd932cf32a7b8a1d009466afc16528f"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/http-client/zipball/5c584530b77aa10ae216989ffc48b4bedc9c0b29",
-        "reference": "5c584530b77aa10ae216989ffc48b4bedc9c0b29",
+        "url": "https://api.github.com/repos/symfony/http-client/zipball/fc0944665bd932cf32a7b8a1d009466afc16528f",
+        "reference": "fc0944665bd932cf32a7b8a1d009466afc16528f",
         "shasum": ""
       },
       "require": {
@@ -1557,7 +1557,7 @@
         "http"
       ],
       "support": {
-        "source": "https://github.com/symfony/http-client/tree/v6.4.0"
+        "source": "https://github.com/symfony/http-client/tree/v6.4.2"
       },
       "funding": [
         {
@@ -1573,7 +1573,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2023-11-28T20:55:58+00:00"
+      "time": "2023-12-02T12:49:56+00:00"
     },
     {
       "name": "symfony/http-client-contracts",
@@ -1655,16 +1655,16 @@
     },
     {
       "name": "symfony/lock",
-      "version": "v6.4.0",
+      "version": "v6.4.2",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/lock.git",
-        "reference": "49c2d0ae4777d118edb13f23d0b4f125d7302cb3"
+        "reference": "e7be7af2ad07f645bb0c9f4533b5b6c46eba1f79"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/lock/zipball/49c2d0ae4777d118edb13f23d0b4f125d7302cb3",
-        "reference": "49c2d0ae4777d118edb13f23d0b4f125d7302cb3",
+        "url": "https://api.github.com/repos/symfony/lock/zipball/e7be7af2ad07f645bb0c9f4533b5b6c46eba1f79",
+        "reference": "e7be7af2ad07f645bb0c9f4533b5b6c46eba1f79",
         "shasum": ""
       },
       "require": {
@@ -1714,7 +1714,7 @@
         "semaphore"
       ],
       "support": {
-        "source": "https://github.com/symfony/lock/tree/v6.4.0"
+        "source": "https://github.com/symfony/lock/tree/v6.4.2"
       },
       "funding": [
         {
@@ -1730,20 +1730,20 @@
           "type": "tidelift"
         }
       ],
-      "time": "2023-11-21T09:41:01+00:00"
+      "time": "2023-12-19T09:12:31+00:00"
     },
     {
       "name": "symfony/process",
-      "version": "v6.4.0",
+      "version": "v6.4.2",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/process.git",
-        "reference": "191703b1566d97a5425dc969e4350d32b8ef17aa"
+        "reference": "c4b1ef0bc80533d87a2e969806172f1c2a980241"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/process/zipball/191703b1566d97a5425dc969e4350d32b8ef17aa",
-        "reference": "191703b1566d97a5425dc969e4350d32b8ef17aa",
+        "url": "https://api.github.com/repos/symfony/process/zipball/c4b1ef0bc80533d87a2e969806172f1c2a980241",
+        "reference": "c4b1ef0bc80533d87a2e969806172f1c2a980241",
         "shasum": ""
       },
       "require": {
@@ -1775,7 +1775,7 @@
       "description": "Executes commands in sub-processes",
       "homepage": "https://symfony.com",
       "support": {
-        "source": "https://github.com/symfony/process/tree/v6.4.0"
+        "source": "https://github.com/symfony/process/tree/v6.4.2"
       },
       "funding": [
         {
@@ -1791,25 +1791,25 @@
           "type": "tidelift"
         }
       ],
-      "time": "2023-11-17T21:06:49+00:00"
+      "time": "2023-12-22T16:42:54+00:00"
     },
     {
       "name": "symfony/service-contracts",
-      "version": "v3.4.0",
+      "version": "v3.4.1",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/service-contracts.git",
-        "reference": "b3313c2dbffaf71c8de2934e2ea56ed2291a3838"
+        "reference": "fe07cbc8d837f60caf7018068e350cc5163681a0"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/service-contracts/zipball/b3313c2dbffaf71c8de2934e2ea56ed2291a3838",
-        "reference": "b3313c2dbffaf71c8de2934e2ea56ed2291a3838",
+        "url": "https://api.github.com/repos/symfony/service-contracts/zipball/fe07cbc8d837f60caf7018068e350cc5163681a0",
+        "reference": "fe07cbc8d837f60caf7018068e350cc5163681a0",
         "shasum": ""
       },
       "require": {
         "php": ">=8.1",
-        "psr/container": "^2.0"
+        "psr/container": "^1.1|^2.0"
       },
       "conflict": {
         "ext-psr": "<1.1|>=2"
@@ -1857,7 +1857,7 @@
         "standards"
       ],
       "support": {
-        "source": "https://github.com/symfony/service-contracts/tree/v3.4.0"
+        "source": "https://github.com/symfony/service-contracts/tree/v3.4.1"
       },
       "funding": [
         {
@@ -1873,20 +1873,20 @@
           "type": "tidelift"
         }
       ],
-      "time": "2023-07-30T20:28:31+00:00"
+      "time": "2023-12-26T14:02:43+00:00"
     },
     {
       "name": "symfony/string",
-      "version": "v7.0.0",
+      "version": "v7.0.2",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/string.git",
-        "reference": "92bd2bfbba476d4a1838e5e12168bef2fd1e6620"
+        "reference": "cc78f14f91f5e53b42044d0620961c48028ff9f5"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/string/zipball/92bd2bfbba476d4a1838e5e12168bef2fd1e6620",
-        "reference": "92bd2bfbba476d4a1838e5e12168bef2fd1e6620",
+        "url": "https://api.github.com/repos/symfony/string/zipball/cc78f14f91f5e53b42044d0620961c48028ff9f5",
+        "reference": "cc78f14f91f5e53b42044d0620961c48028ff9f5",
         "shasum": ""
       },
       "require": {
@@ -1943,7 +1943,7 @@
         "utf8"
       ],
       "support": {
-        "source": "https://github.com/symfony/string/tree/v7.0.0"
+        "source": "https://github.com/symfony/string/tree/v7.0.2"
       },
       "funding": [
         {
@@ -1959,20 +1959,20 @@
           "type": "tidelift"
         }
       ],
-      "time": "2023-11-29T08:40:23+00:00"
+      "time": "2023-12-10T16:54:46+00:00"
     },
     {
       "name": "symfony/var-dumper",
-      "version": "v6.4.0",
+      "version": "v6.4.2",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/var-dumper.git",
-        "reference": "c40f7d17e91d8b407582ed51a2bbf83c52c367f6"
+        "reference": "68d6573ec98715ddcae5a0a85bee3c1c27a4c33f"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/var-dumper/zipball/c40f7d17e91d8b407582ed51a2bbf83c52c367f6",
-        "reference": "c40f7d17e91d8b407582ed51a2bbf83c52c367f6",
+        "url": "https://api.github.com/repos/symfony/var-dumper/zipball/68d6573ec98715ddcae5a0a85bee3c1c27a4c33f",
+        "reference": "68d6573ec98715ddcae5a0a85bee3c1c27a4c33f",
         "shasum": ""
       },
       "require": {
@@ -2028,7 +2028,7 @@
         "dump"
       ],
       "support": {
-        "source": "https://github.com/symfony/var-dumper/tree/v6.4.0"
+        "source": "https://github.com/symfony/var-dumper/tree/v6.4.2"
       },
       "funding": [
         {
@@ -2044,20 +2044,20 @@
           "type": "tidelift"
         }
       ],
-      "time": "2023-11-09T08:28:32+00:00"
+      "time": "2023-12-28T19:16:56+00:00"
     },
     {
       "name": "symfony/var-exporter",
-      "version": "v7.0.1",
+      "version": "v7.0.2",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/var-exporter.git",
-        "reference": "a3d7c877414fcd59ab7075ecdc3b8f9c00f7bcc3"
+        "reference": "345c62fefe92243c3a06fc0cc65f2ec1a47e0764"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/var-exporter/zipball/a3d7c877414fcd59ab7075ecdc3b8f9c00f7bcc3",
-        "reference": "a3d7c877414fcd59ab7075ecdc3b8f9c00f7bcc3",
+        "url": "https://api.github.com/repos/symfony/var-exporter/zipball/345c62fefe92243c3a06fc0cc65f2ec1a47e0764",
+        "reference": "345c62fefe92243c3a06fc0cc65f2ec1a47e0764",
         "shasum": ""
       },
       "require": {
@@ -2102,7 +2102,7 @@
         "serialize"
       ],
       "support": {
-        "source": "https://github.com/symfony/var-exporter/tree/v7.0.1"
+        "source": "https://github.com/symfony/var-exporter/tree/v7.0.2"
       },
       "funding": [
         {
@@ -2118,7 +2118,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2023-11-30T11:38:21+00:00"
+      "time": "2023-12-27T08:42:13+00:00"
     },
     {
       "name": "symfony/yaml",
@@ -2982,12 +2982,12 @@
       "source": {
         "type": "git",
         "url": "https://github.com/Roave/SecurityAdvisories.git",
-        "reference": "be9456d1430df8be755ff7da33b22b80f0ed2f5f"
+        "reference": "d38bb902559d517bf82d5388f9b36e0200d2671d"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/be9456d1430df8be755ff7da33b22b80f0ed2f5f",
-        "reference": "be9456d1430df8be755ff7da33b22b80f0ed2f5f",
+        "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/d38bb902559d517bf82d5388f9b36e0200d2671d",
+        "reference": "d38bb902559d517bf82d5388f9b36e0200d2671d",
         "shasum": ""
       },
       "conflict": {
@@ -3019,7 +3019,7 @@
         "athlon1600/php-proxy": "<=5.1",
         "athlon1600/php-proxy-app": "<=3",
         "austintoddj/canvas": "<=3.4.2",
-        "automad/automad": "<1.8",
+        "automad/automad": "<=1.10.9",
         "awesome-support/awesome-support": "<=6.0.7",
         "aws/aws-sdk-php": "<3.288.1",
         "azuracast/azuracast": "<0.18.3",
@@ -3061,6 +3061,7 @@
         "cesnet/simplesamlphp-module-proxystatistics": "<3.1",
         "chriskacerguis/codeigniter-restserver": "<=2.7.1",
         "civicrm/civicrm-core": ">=4.2,<4.2.9|>=4.3,<4.3.3",
+        "ckeditor/ckeditor": "<4.17",
         "cockpit-hq/cockpit": "<=2.6.3",
         "codeception/codeception": "<3.1.3|>=4,<4.1.22",
         "codeigniter/framework": "<3.1.9",
@@ -3068,7 +3069,7 @@
         "codeigniter4/shield": "<1.0.0.0-beta8",
         "codiad/codiad": "<=2.8.4",
         "composer/composer": "<1.10.27|>=2,<2.2.22|>=2.3,<2.6.4",
-        "concrete5/concrete5": "<9.2.2",
+        "concrete5/concrete5": "<9.2.3",
         "concrete5/core": "<8.5.8|>=9,<9.1",
         "contao-components/mediaelement": ">=2.14.2,<2.21.1",
         "contao/contao": ">=4,<4.4.56|>=4.5,<4.9.40|>=4.10,<4.11.7|>=4.13,<4.13.21|>=5.1,<5.1.4",
@@ -3076,8 +3077,9 @@
         "contao/core-bundle": "<4.9.42|>=4.10,<4.13.28|>=5,<5.1.10",
         "contao/listing-bundle": ">=4,<4.4.8",
         "contao/managed-edition": "<=1.5",
+        "corveda/phpsandbox": "<1.3.5",
         "cosenary/instagram": "<=2.3",
-        "craftcms/cms": "<=4.4.14",
+        "craftcms/cms": "<=4.5.10",
         "croogo/croogo": "<4",
         "cuyz/valinor": "<0.12",
         "czproject/git-php": "<4.0.3",
@@ -3107,6 +3109,7 @@
         "drupal/drupal": ">=6,<6.38|>=7,<7.80|>=8,<8.9.16|>=9,<9.1.12|>=9.2,<9.2.4",
         "duncanmcclean/guest-entries": "<3.1.2",
         "dweeves/magmi": "<=0.7.24",
+        "ec-cube/ec-cube": "<2.4.4",
         "ecodev/newsletter": "<=4",
         "ectouch/ectouch": "<=2.7.2",
         "elefant/cms": "<2.0.7",
@@ -3147,8 +3150,8 @@
         "firebase/php-jwt": "<6",
         "fixpunkt/fp-masterquiz": "<2.2.1|>=3,<3.5.2",
         "fixpunkt/fp-newsletter": "<1.1.1|>=2,<2.1.2|>=2.2,<3.2.6",
-        "flarum/core": "<1.8",
-        "flarum/framework": "<1.8",
+        "flarum/core": "<1.8.5",
+        "flarum/framework": "<1.8.5",
         "flarum/mentions": "<1.6.3",
         "flarum/sticky": ">=0.1.0.0-beta14,<=0.1.0.0-beta15",
         "flarum/tags": "<=0.1.0.0-beta13",
@@ -3168,7 +3171,7 @@
         "friendsoftypo3/mediace": ">=7.6.2,<7.6.5",
         "friendsoftypo3/openid": ">=4.5,<4.5.31|>=4.7,<4.7.16|>=6,<6.0.11|>=6.1,<6.1.6",
         "froala/wysiwyg-editor": "<3.2.7|>=4.0.1,<=4.1.1",
-        "froxlor/froxlor": "<2.1.0.0-beta1",
+        "froxlor/froxlor": "<=2.1.1",
         "fuel/core": "<1.8.1",
         "funadmin/funadmin": "<=3.2|>=3.3.2,<=3.3.3",
         "gaoming13/wechat-php-sdk": "<=1.10.2",
@@ -3178,7 +3181,7 @@
         "getkirby/kirby": "<=2.5.12",
         "getkirby/panel": "<2.5.14",
         "getkirby/starterkit": "<=3.7.0.2",
-        "gilacms/gila": "<=1.11.4",
+        "gilacms/gila": "<=1.15.4",
         "gleez/cms": "<=1.2|==2",
         "globalpayments/php-sdk": "<2",
         "gogentooss/samlbase": "<1.2.7",
@@ -3186,7 +3189,7 @@
         "gos/web-socket-bundle": "<1.10.4|>=2,<2.6.1|>=3,<3.3",
         "gree/jose": "<2.2.1",
         "gregwar/rst": "<1.0.3",
-        "grumpydictator/firefly-iii": "<6",
+        "grumpydictator/firefly-iii": "<6.1.1",
         "gugoan/economizzer": "<=0.9.0.0-beta1",
         "guzzlehttp/guzzle": "<6.5.8|>=7,<7.4.5",
         "guzzlehttp/psr7": "<1.9.1|>=2,<2.4.5",
@@ -3214,6 +3217,7 @@
         "illuminate/encryption": ">=4,<=4.0.11|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.40|>=5.6,<5.6.15",
         "illuminate/view": "<6.20.42|>=7,<7.30.6|>=8,<8.75",
         "impresscms/impresscms": "<=1.4.5",
+        "impresspages/impresspages": "<=1.0.12",
         "in2code/femanager": "<5.5.3|>=6,<6.3.4|>=7,<7.2.3",
         "in2code/ipandlanguageredirect": "<5.1.2",
         "in2code/lux": "<17.6.1|>=18,<24.0.2",
@@ -3237,11 +3241,12 @@
         "joyqi/hyper-down": "<=2.4.27",
         "jsdecena/laracom": "<2.0.9",
         "jsmitty12/phpwhois": "<5.1",
+        "juzaweb/cms": "<=3.4",
         "kazist/phpwhois": "<=4.2.6",
         "kelvinmo/simplexrd": "<3.1.1",
         "kevinpapst/kimai2": "<1.16.7",
         "khodakhah/nodcms": "<=3",
-        "kimai/kimai": "<=2.1",
+        "kimai/kimai": "<2.1",
         "kitodo/presentation": "<3.2.3|>=3.3,<3.3.4",
         "klaviyo/magento2-extension": ">=1,<3",
         "knplabs/knp-snappy": "<=1.4.2",
@@ -3270,11 +3275,14 @@
         "lms/routes": "<2.1.1",
         "localizationteam/l10nmgr": "<7.4|>=8,<8.7|>=9,<9.2",
         "luyadev/yii-helpers": "<1.2.1",
-        "magento/community-edition": "<=2.4",
+        "magento/community-edition": "<2.4.3.0-patch3|>=2.4.4,<2.4.5",
+        "magento/core": "<=1.9.4.5",
         "magento/magento1ce": "<1.9.4.3-dev",
         "magento/magento1ee": ">=1,<1.14.4.3-dev",
         "magento/product-community-edition": ">=2,<2.2.10|>=2.3,<2.3.2.0-patch2",
+        "magneto/core": "<1.9.4.4-dev",
         "maikuolan/phpmussel": ">=1,<1.6",
+        "mainwp/mainwp": "<=4.4.3.3",
         "mantisbt/mantisbt": "<=2.25.7",
         "marcwillmann/turn": "<0.3.3",
         "matyhtf/framework": "<3.0.6",
@@ -3362,6 +3370,7 @@
         "phenx/php-svg-lib": "<0.5.1",
         "php-mod/curl": "<2.3.2",
         "phpbb/phpbb": "<3.2.10|>=3.3,<3.3.1",
+        "phpems/phpems": ">=6,<=6.1.3",
         "phpfastcache/phpfastcache": "<6.1.5|>=7,<7.1.2|>=8,<8.0.7",
         "phpmailer/phpmailer": "<6.5",
         "phpmussel/phpmussel": ">=1,<1.6",
@@ -3378,12 +3387,14 @@
         "phpxmlrpc/phpxmlrpc": "<4.9.2",
         "pi/pi": "<=2.5",
         "pimcore/admin-ui-classic-bundle": "<1.2.2",
-        "pimcore/customer-management-framework-bundle": "<3.4.2",
+        "pimcore/customer-management-framework-bundle": "<4.0.6",
         "pimcore/data-hub": "<1.2.4",
         "pimcore/demo": "<10.3",
+        "pimcore/ecommerce-framework-bundle": "<1.0.10",
         "pimcore/perspective-editor": "<1.5.1",
         "pimcore/pimcore": "<11.1.1",
         "pixelfed/pixelfed": "<=0.11.4",
+        "plotly/plotly.js": "<2.25.2",
         "pocketmine/bedrock-protocol": "<8.0.2",
         "pocketmine/pocketmine-mp": "<=4.23|>=5,<5.3.1",
         "pocketmine/raklib": ">=0.14,<0.14.6|>=0.15,<0.15.1",
@@ -3393,7 +3404,7 @@
         "prestashop/blockwishlist": ">=2,<2.1.1",
         "prestashop/contactform": ">=1.0.1,<4.3",
         "prestashop/gamification": "<2.3.2",
-        "prestashop/prestashop": "<8.1.2",
+        "prestashop/prestashop": "<8.1.3",
         "prestashop/productcomments": "<5.0.2",
         "prestashop/ps_emailsubscription": "<2.6.1",
         "prestashop/ps_facetedsearch": "<3.4.1",
@@ -3577,7 +3588,7 @@
         "usmanhalalit/pixie": "<1.0.3|>=2,<2.0.2",
         "uvdesk/community-skeleton": "<=1.1.1",
         "vanilla/safecurl": "<0.9.2",
-        "verot/class.upload.php": "<=1.0.3|>=2,<=2.0.4",
+        "verot/class.upload.php": "<=2.1.6",
         "vova07/yii2-fileapi-widget": "<0.1.9",
         "vrana/adminer": "<4.8.1",
         "waldhacker/hcaptcha": "<2.1.2",
@@ -3593,6 +3604,8 @@
         "wikibase/wikibase": "<=1.39.3",
         "wikimedia/parsoid": "<0.12.2",
         "willdurand/js-translation-bundle": "<2.1.1",
+        "winter/wn-backend-module": "<1.2.4",
+        "winter/wn-system-module": "<1.2.4",
         "wintercms/winter": "<1.2.3",
         "woocommerce/woocommerce": "<6.6",
         "wp-cli/wp-cli": "<2.5",
@@ -3692,7 +3705,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2023-12-22T00:14:36+00:00"
+      "time": "2024-01-15T21:04:10+00:00"
     },
     {
       "name": "sebastian/cli-parser",

--- a/src/Backends/Common/ClientInterface.php
+++ b/src/Backends/Common/ClientInterface.php
@@ -211,6 +211,14 @@ interface ClientInterface
     public static function manage(array $backend, array $opts = []): array;
 
     /**
+     * Return list of active sessions.
+     *
+     * @param array $opts (Optional) options.
+     * @return array{sessions: array<array>}
+     */
+    public function getSessions(array $opts = []): array;
+
+    /**
      * Return user access token.
      *
      * @param int|string $userId user id.

--- a/src/Backends/Emby/Action/GetSessions.php
+++ b/src/Backends/Emby/Action/GetSessions.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backends\Emby\Action;
+
+class GetSessions extends \App\Backends\Jellyfin\Action\GetSessions
+{
+    protected string $action = 'emby.getSessions';
+}

--- a/src/Backends/Emby/EmbyClient.php
+++ b/src/Backends/Emby/EmbyClient.php
@@ -16,6 +16,7 @@ use App\Backends\Emby\Action\GetInfo;
 use App\Backends\Emby\Action\GetLibrariesList;
 use App\Backends\Emby\Action\GetLibrary;
 use App\Backends\Emby\Action\GetMetaData;
+use App\Backends\Emby\Action\GetSessions;
 use App\Backends\Emby\Action\GetUsersList;
 use App\Backends\Emby\Action\Import;
 use App\Backends\Emby\Action\InspectRequest;
@@ -435,6 +436,24 @@ class EmbyClient implements iClient
     public function getUsersList(array $opts = []): array
     {
         $response = Container::get(GetUsersList::class)($this->context, $opts);
+
+        if (false === $response->isSuccessful()) {
+            if ($response->hasError()) {
+                $this->logger->log($response->error->level(), $response->error->message, $response->error->context);
+            }
+
+            $this->throwError($response);
+        }
+
+        return $response->response;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSessions(array $opts = []): array
+    {
+        $response = Container::get(GetSessions::class)($this->context, $opts);
 
         if (false === $response->isSuccessful()) {
             if ($response->hasError()) {

--- a/src/Backends/Jellyfin/Action/GetSessions.php
+++ b/src/Backends/Jellyfin/Action/GetSessions.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Backends\Plex\Action;
+namespace App\Backends\Jellyfin\Action;
 
 use App\Backends\Common\CommonTrait;
 use App\Backends\Common\Context;
@@ -11,24 +11,31 @@ use App\Backends\Common\Levels;
 use App\Backends\Common\Response;
 use App\Libs\Options;
 use Psr\Log\LoggerInterface;
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-final class GetSessions
+/**
+ * Class GetInfo
+ *
+ * This class retrieves information from a jellyfin backend.
+ */
+class GetSessions
 {
     use CommonTrait;
 
-    private string $action = 'plex.getSessions';
+    protected string $action = 'jellyfin.getSessions';
 
     public function __construct(
         protected HttpClientInterface $http,
         protected LoggerInterface $logger,
+        protected CacheInterface $cache
     ) {
     }
 
     /**
-     * Get Backend unique identifier.
+     * Get backend information.
      *
-     * @param Context $context
+     * @param Context $context Backend context.
      * @param array $opts optional options.
      *
      * @return Response
@@ -38,7 +45,7 @@ final class GetSessions
         return $this->tryResponse(
             context: $context,
             fn: function () use ($context, $opts) {
-                $url = $context->backendUrl->withPath('/status/sessions');
+                $url = $context->backendUrl->withPath('/Sessions');
 
                 $this->logger->debug('Requesting [{client}: {backend}] play sessions.', [
                     'client' => $context->clientName,
@@ -76,7 +83,7 @@ final class GetSessions
                     return new Response(
                         status: false,
                         error: new Error(
-                            message: 'Request for [{backend}] {action} returned with empty response.',
+                            message: 'Request for [{backend}] {action} returned with empty response. Please make sure the container can communicate with the backend.',
                             context: [
                                 'action' => $this->action,
                                 'client' => $context->clientName,
@@ -89,7 +96,7 @@ final class GetSessions
                     );
                 }
 
-                $item = json_decode(
+                $items = json_decode(
                     json: $content,
                     associative: true,
                     flags: JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_IGNORE
@@ -100,49 +107,45 @@ final class GetSessions
                         'action' => $this->action,
                         'client' => $context->clientName,
                         'backend' => $context->backendName,
-                        'trace' => $item,
+                        'trace' => $items,
                     ]);
                 }
 
-                $data = ag($item, 'MediaContainer.Metadata', []);
+                $filtered = [];
+
+                foreach ($items as $item) {
+                    if (null === ag($item, 'NowPlayingItem')) {
+                        continue;
+                    }
+
+                    $filtered[] = $item;
+                }
 
                 $ret = [
                     'sessions' => [],
                 ];
 
-                if (true === ag_exists($opts, Options::RAW_RESPONSE)) {
-                    $ret[Options::RAW_RESPONSE] = $item;
+                foreach ($filtered as $item) {
+                    $ret['sessions'][] = [
+                        'user_uid' => ag($item, 'UserId'),
+                        'user_name' => ag($item, 'UserName'),
+                        'item_id' => ag($item, 'NowPlayingItem.Id'),
+                        'item_title' => ag($item, 'NowPlayingItem.Name'),
+                        'item_type' => ag($item, 'NowPlayingItem.Type'),
+                        'item_offset_at' => ag($item, 'PlayState.PositionTicks') / 1_00_00,
+                        'session_state' => (bool)ag($item, 'PlayState.IsPaused', false) === true ? 'paused' : 'playing',
+                        'session_updated_at' => makeDate(ag($item, 'LastActivityDate')),
+                        'session_id' => ag($item, 'Id'),
+                    ];
                 }
 
-                foreach ($data as $session) {
-                    $uuid = preg_match(
-                        '#/users/(.+?)/avatar#i',
-                        ag($session, 'User.thumb'),
-                        $matches
-                    ) ? $matches[1] : null;
-
-                    $item = [
-                        'user_uid' => (int)ag($session, 'User.id'),
-                        'user_name' => ag($session, 'User.title'),
-                        'user_uuid' => $uuid,
-                        'item_id' => (int)ag($session, 'ratingKey'),
-                        'item_title' => ag($session, 'title'),
-                        'item_type' => ag($session, 'type'),
-                        'item_offset_at' => ag($session, 'viewOffset'),
-                        'session_state' => ag($session, 'Player.state'),
-                        'session_id' => ag($session, 'Session.id', ag($session, 'sessionKey')),
-                    ];
-
-                    if ('playing' === $item['session_state']) {
-                        $item['session_updated_at'] = makeDate(date: time());
-                    }
-
-                    $ret['sessions'][] = $item;
+                if (true === ag_exists($opts, Options::RAW_RESPONSE)) {
+                    $ret[Options::RAW_RESPONSE] = $items;
                 }
 
                 return new Response(status: true, response: $ret);
             },
-            action: $this->action
+            action: $this->action,
         );
     }
 }

--- a/src/Backends/Jellyfin/Action/GetSessions.php
+++ b/src/Backends/Jellyfin/Action/GetSessions.php
@@ -127,7 +127,7 @@ class GetSessions
 
                 foreach ($filtered as $item) {
                     $ret['sessions'][] = [
-                        'user_uid' => ag($item, 'UserId'),
+                        'user_id' => ag($item, 'UserId'),
                         'user_name' => ag($item, 'UserName'),
                         'item_id' => ag($item, 'NowPlayingItem.Id'),
                         'item_title' => ag($item, 'NowPlayingItem.Name'),

--- a/src/Backends/Jellyfin/Action/Progress.php
+++ b/src/Backends/Jellyfin/Action/Progress.php
@@ -9,6 +9,7 @@ use App\Backends\Common\Context;
 use App\Backends\Common\GuidInterface as iGuid;
 use App\Backends\Common\Response;
 use App\Backends\Jellyfin\JellyfinActionTrait;
+use App\Libs\Container;
 use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Exceptions\Backends\InvalidArgumentException;
 use App\Libs\Exceptions\Backends\RuntimeException;
@@ -93,8 +94,27 @@ class Progress
         QueueRequests $queue,
         DateTimeInterface|null $after = null
     ): Response {
+        $sessions = [];
         $ignoreDate = (bool)ag($context->options, Options::IGNORE_DATE, false);
 
+        try {
+            $remoteSessions = Container::get(GetSessions::class)($context);
+            if (true === $remoteSessions->status) {
+                foreach (ag($remoteSessions->response, 'sessions', []) as $session) {
+                    $user_id = ag($session, 'user_id', null);
+
+                    $uid = $user_id && $context->backendUser === $user_id;
+
+                    if (true !== $uid) {
+                        continue;
+                    }
+
+                    $sessions[ag($session, 'item_id')] = ag($session, 'item_offset_at', 0);
+                }
+            }
+        } catch (Throwable) {
+            // simply ignore this error as it's not important enough to interrupt the whole process.
+        }
         foreach ($entities as $key => $entity) {
             if (true !== ($entity instanceof iState)) {
                 continue;
@@ -165,6 +185,17 @@ class Progress
             }
 
             $logContext['remote']['id'] = ag($metadata, iState::COLUMN_ID);
+
+            if (array_key_exists($logContext['remote']['id'], $sessions)) {
+                $this->logger->notice(
+                    'Ignoring [{item.title}] watch progress update for [{backend}]. The item is being played right now.',
+                    [
+                        'backend' => $context->backendName,
+                        ...$logContext,
+                    ]
+                );
+                continue;
+            }
 
             try {
                 $remoteItem = $this->createEntity(

--- a/src/Backends/Jellyfin/JellyfinClient.php
+++ b/src/Backends/Jellyfin/JellyfinClient.php
@@ -18,6 +18,7 @@ use App\Backends\Jellyfin\Action\GetInfo;
 use App\Backends\Jellyfin\Action\GetLibrariesList;
 use App\Backends\Jellyfin\Action\GetLibrary;
 use App\Backends\Jellyfin\Action\GetMetaData;
+use App\Backends\Jellyfin\Action\GetSessions;
 use App\Backends\Jellyfin\Action\GetUsersList;
 use App\Backends\Jellyfin\Action\GetVersion;
 use App\Backends\Jellyfin\Action\Import;
@@ -476,6 +477,24 @@ class JellyfinClient implements iClient
     public function getUsersList(array $opts = []): array
     {
         $response = Container::get(GetUsersList::class)($this->context, $opts);
+
+        if (false === $response->isSuccessful()) {
+            if ($response->hasError()) {
+                $this->logger->log($response->error->level(), $response->error->message, $response->error->context);
+            }
+
+            $this->throwError($response);
+        }
+
+        return $response->response;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSessions(array $opts = []): array
+    {
+        $response = Container::get(GetSessions::class)($this->context, $opts);
 
         if (false === $response->isSuccessful()) {
             if ($response->hasError()) {

--- a/src/Backends/Plex/Action/GetSessions.php
+++ b/src/Backends/Plex/Action/GetSessions.php
@@ -122,7 +122,7 @@ final class GetSessions
                     ) ? $matches[1] : null;
 
                     $item = [
-                        'user_uid' => (int)ag($session, 'User.id'),
+                        'user_id' => (int)ag($session, 'User.id'),
                         'user_name' => ag($session, 'User.title'),
                         'user_uuid' => $uuid,
                         'item_id' => (int)ag($session, 'ratingKey'),

--- a/src/Backends/Plex/Action/GetSessions.php
+++ b/src/Backends/Plex/Action/GetSessions.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backends\Plex\Action;
+
+use App\Backends\Common\CommonTrait;
+use App\Backends\Common\Context;
+use App\Backends\Common\Error;
+use App\Backends\Common\Levels;
+use App\Backends\Common\Response;
+use App\Libs\Options;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class GetSessions
+{
+    use CommonTrait;
+
+    private string $action = 'plex.getSessions';
+
+    public function __construct(
+        protected HttpClientInterface $http,
+        protected LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Get Backend unique identifier.
+     *
+     * @param Context $context
+     * @param array $opts optional options.
+     *
+     * @return Response
+     */
+    public function __invoke(Context $context, array $opts = []): Response
+    {
+        return $this->tryResponse(
+            context: $context,
+            fn: function () use ($context, $opts) {
+                $url = $context->backendUrl->withPath('/status/sessions');
+
+                $this->logger->debug('Requesting [{client}: {backend}] play sessions.', [
+                    'client' => $context->clientName,
+                    'backend' => $context->backendName,
+                    'url' => $url
+                ]);
+
+                $response = $this->http->request(
+                    'GET',
+                    (string)$url,
+                    array_replace_recursive($context->backendHeaders, $opts['headers'] ?? [])
+                );
+
+                $content = $response->getContent(false);
+
+                if (200 !== $response->getStatusCode()) {
+                    return new Response(
+                        status: false,
+                        error: new Error(
+                            message: 'Request for [{backend}] {action} returned with unexpected [{status_code}] status code.',
+                            context: [
+                                'action' => $this->action,
+                                'client' => $context->clientName,
+                                'backend' => $context->backendName,
+                                'status_code' => $response->getStatusCode(),
+                                'url' => (string)$url,
+                                'response' => $content,
+                            ],
+                            level: Levels::WARNING
+                        )
+                    );
+                }
+
+                if (empty($content)) {
+                    return new Response(
+                        status: false,
+                        error: new Error(
+                            message: 'Request for [{backend}] {action} returned with empty response.',
+                            context: [
+                                'action' => $this->action,
+                                'client' => $context->clientName,
+                                'backend' => $context->backendName,
+                                'url' => (string)$url,
+                                'response' => $content,
+                            ],
+                            level: Levels::ERROR
+                        )
+                    );
+                }
+
+                $item = json_decode(
+                    json: $content,
+                    associative: true,
+                    flags: JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_IGNORE
+                );
+
+                if (true === $context->trace) {
+                    $this->logger->debug('Processing [{client}: {backend}] {action} payload.', [
+                        'action' => $this->action,
+                        'client' => $context->clientName,
+                        'backend' => $context->backendName,
+                        'trace' => $item,
+                    ]);
+                }
+
+                $data = ag($item, 'MediaContainer.Metadata', []);
+
+                $ret = [
+                    'sessions' => [],
+                ];
+
+                if (true === ag_exists($opts, Options::RAW_RESPONSE)) {
+                    $ret[Options::RAW_RESPONSE] = $item;
+                }
+
+                foreach ($data as $session) {
+                    $uuid = preg_match(
+                        '#/users/(.+?)/avatar#i',
+                        ag($session, 'User.thumb'),
+                        $matches
+                    ) ? $matches[1] : null;
+
+                    $ret['sessions'][] = [
+                        'user_uid' => (int)ag($session, 'User.id'),
+                        'user_uuid' => $uuid,
+                        'item_id' => (int)ag($session, 'ratingKey'),
+                        'item_title' => ag($session, 'title'),
+                        'item_type' => ag($session, 'type'),
+                        'item_offset_at' => ag($session, 'viewOffset'),
+                        'session_state' => ag($session, 'Player.state'),
+                        'session_id' => ag($session, 'Session.id', ag($session, 'sessionKey')),
+                    ];
+                }
+
+                return new Response(status: true, response: $ret);
+            },
+            action: $this->action
+        );
+    }
+}

--- a/src/Backends/Plex/Action/Progress.php
+++ b/src/Backends/Plex/Action/Progress.php
@@ -193,21 +193,29 @@ class Progress
             }
 
             try {
-                $url = $context->backendUrl
-                    ->withPath('/:/timeline/')
-                    ->withQuery(
-                        http_build_query([
-                            'ratingKey' => $logContext['remote']['id'],
-                            'key' => '/library/metadata/' . $logContext['remote']['id'],
-                            'identifier' => 'com.plexapp.plugins.library',
-                            'state' => 'stopped',
-                            'time' => $entity->getPlayProgress(),
-                            // -- Without duration & client identifier ignore the update.
-                            'duration' => ag($remoteData, 'duration', 0),
-                            'X-Plex-Client-Identifier' => md5('WatchState/' . getAppVersion())
-                        ])
-                    );
+//                $url = $context->backendUrl
+//                    ->withPath('/:/timeline/')
+//                    ->withQuery(
+//                        http_build_query([
+//                            'ratingKey' => $logContext['remote']['id'],
+//                            'key' => '/library/metadata/' . $logContext['remote']['id'],
+//                            'identifier' => 'com.plexapp.plugins.library',
+//                            'state' => 'stopped',
+//                            'time' => $entity->getPlayProgress(),
+//                            // -- Without duration & client identifier plex ignore watch progress update.
+//                            'duration' => ag($remoteData, 'duration', 0),
+//                            'X-Plex-Client-Identifier' => md5('WatchState/' . getAppVersion())
+//                        ])
+//                    );
 
+                $url = $context->backendUrl->withPath('/:/progress/')->withQuery(
+                    http_build_query([
+                        'key' => $logContext['remote']['id'],
+                        'identifier' => 'com.plexapp.plugins.library',
+                        'state' => 'stopped',
+                        'time' => $entity->getPlayProgress(),
+                    ])
+                );
                 $logContext['remote']['url'] = (string)$url;
 
                 $this->logger->debug('Updating [{backend}] {item.type} [{item.title}] watch progress.', [

--- a/src/Backends/Plex/Action/Progress.php
+++ b/src/Backends/Plex/Action/Progress.php
@@ -9,6 +9,7 @@ use App\Backends\Common\Context;
 use App\Backends\Common\GuidInterface as iGuid;
 use App\Backends\Common\Response;
 use App\Backends\Plex\PlexActionTrait;
+use App\Libs\Container;
 use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Exceptions\Backends\InvalidArgumentException;
 use App\Libs\Exceptions\Backends\RuntimeException;
@@ -66,7 +67,37 @@ class Progress
         QueueRequests $queue,
         DateTimeInterface|null $after = null
     ): Response {
+        $sessions = [];
         $ignoreDate = (bool)ag($context->options, Options::IGNORE_DATE, false);
+
+        /**
+         * as plex act weird if we change the progress of a watched item while the item is playing,
+         * we need to check if the item is watched before changing its progress.
+         */
+        try {
+            $remoteSessions = Container::get(GetSessions::class)($context);
+            if (true === $remoteSessions->status) {
+                foreach (ag($remoteSessions->response, 'sessions', []) as $session) {
+                    $user_id = ag($session, 'user_id', null);
+                    $user_uuid = ag($session, 'user_uuid', null);
+
+                    /**
+                     * Plex is back at it again reporting admin user id as 1.
+                     * So, we have to resort to use the user uuid to identify the user.
+                     */
+                    $uid = $user_id && $context->backendUser === $user_id;
+                    $uuid = $user_uuid && ag($context->options, 'plex_user_uuid', 'non_set') === $user_uuid;
+
+                    if (true !== ($uid || $uuid)) {
+                        continue;
+                    }
+
+                    $sessions[ag($session, 'item_id')] = ag($session, 'item_offset_at', 0);
+                }
+            }
+        } catch (Throwable) {
+            // simply ignore this error as it's not important enough to interrupt the whole process.
+        }
 
         foreach ($entities as $key => $entity) {
             if (true !== ($entity instanceof iState)) {
@@ -119,7 +150,6 @@ class Progress
             $senderDate = makeDate($senderDate)->getTimestamp();
             $senderDate = $senderDate - (int)ag($context->options, 'progress.time_drift', self::DEFAULT_TIME_DRIFT);
 
-
             $datetime = ag($entity->getExtra($context->backendName), iState::COLUMN_EXTRA_DATE, null);
 
             if (false === $ignoreDate && null !== $datetime && makeDate($datetime)->getTimestamp() > $senderDate) {
@@ -134,6 +164,17 @@ class Progress
             }
 
             $logContext['remote']['id'] = ag($metadata, iState::COLUMN_ID);
+
+            if (array_key_exists($logContext['remote']['id'], $sessions)) {
+                $this->logger->notice(
+                    'Ignoring [{item.title}] watch progress update for [{backend}]. The item is being played right now.',
+                    [
+                        'backend' => $context->backendName,
+                        ...$logContext,
+                    ]
+                );
+                continue;
+            }
 
             try {
                 $remoteData = ag(

--- a/src/Backends/Plex/PlexClient.php
+++ b/src/Backends/Plex/PlexClient.php
@@ -16,6 +16,7 @@ use App\Backends\Plex\Action\GetInfo;
 use App\Backends\Plex\Action\GetLibrariesList;
 use App\Backends\Plex\Action\GetLibrary;
 use App\Backends\Plex\Action\GetMetaData;
+use App\Backends\Plex\Action\GetSessions;
 use App\Backends\Plex\Action\GetUsersList;
 use App\Backends\Plex\Action\GetUserToken;
 use App\Backends\Plex\Action\GetVersion;
@@ -447,6 +448,24 @@ class PlexClient implements iClient
     public function getUsersList(array $opts = []): array
     {
         $response = Container::get(GetUsersList::class)($this->context, $opts);
+
+        if (false === $response->isSuccessful()) {
+            if ($response->hasError()) {
+                $this->logger->log($response->error->level(), $response->error->message, $response->error->context);
+            }
+
+            $this->throwError($response);
+        }
+
+        return $response->response;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSessions(array $opts = []): array
+    {
+        $response = Container::get(GetSessions::class)($this->context, $opts);
 
         if (false === $response->isSuccessful()) {
             if ($response->hasError()) {

--- a/src/Backends/Plex/PlexManage.php
+++ b/src/Backends/Plex/PlexManage.php
@@ -59,7 +59,7 @@ class PlexManage implements ManageInterface
             $question = new Question(
                 r(
                     <<<HELP
-                    
+
                     <question>Enter [<value>{name}</value>] X-Plex-Token</question>. {default}
                     ------------------
                     to find your plex token. follow the steps described in the following link.
@@ -300,7 +300,7 @@ class PlexManage implements ManageInterface
                     '<info>Attempting to get users list from plex.tv API. Please wait...</info>'
                 );
 
-                $list = $map = $ids = $userInfo = [];
+                $list = $map = $ids = $uuid = $userInfo = [];
 
                 $custom = array_replace_recursive($backend, [
                     'options' => [
@@ -345,6 +345,7 @@ class PlexManage implements ManageInterface
                     $list[] = $val;
                     $ids[$uid] = $val;
                     $map[$val] = $uid;
+                    $uuid[$val] = ag($user, 'uuid', null);
                     $userInfo[$uid] = $user;
                 }
 
@@ -371,6 +372,7 @@ class PlexManage implements ManageInterface
 
                 $user = $this->questionHelper->ask($this->input, $this->output, $question);
                 $backend = ag_set($backend, 'user', $map[$user]);
+                $backend = ag_set($backend, 'options.plex_user_uuid', $uuid[$user]);
 
                 $this->output->writeln(
                     r('<info>Requesting plex token for [{user}] from plex.tv API.</info>', [

--- a/src/Command.php
+++ b/src/Command.php
@@ -297,7 +297,10 @@ class Command extends BaseCommand
             $suggestions->suggestValues($suggest);
         }
 
-        if ($input->mustSuggestOptionValuesFor('select-backends') || $input->mustSuggestArgumentValuesFor('backend')) {
+        if (
+            $input->mustSuggestOptionValuesFor('select-backends') ||
+            $input->mustSuggestOptionValuesFor('select-backend') ||
+            $input->mustSuggestArgumentValuesFor('backend')) {
             $currentValue = $input->getCompletionValue();
 
             $suggest = [];

--- a/src/Commands/Backend/Users/SessionsCommand.php
+++ b/src/Commands/Backend/Users/SessionsCommand.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands\Backend\Users;
+
+use App\Command;
+use App\Libs\Config;
+use App\Libs\Database\DatabaseInterface as iDB;
+use App\Libs\Entity\StateInterface as iState;
+use App\Libs\Options;
+use App\Libs\Routable;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Yaml\Yaml;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+
+/**
+ * Class ListCommand
+ *
+ */
+#[Routable(command: self::ROUTE)]
+final class SessionsCommand extends Command
+{
+    public const ROUTE = 'backend:users:sessions';
+
+    private const REMAP_FIELDS = [
+        'user_uid' => 'User ID',
+        'user_uuid' => 'User UUID',
+        'item_id' => 'Item ID',
+        'item_title' => 'Title',
+        'item_type' => 'Type',
+        'item_offset_at' => 'Progress',
+        'session_id' => 'Session ID',
+        'session_updated_at' => 'Session Activity',
+        'session_state' => 'Play State',
+    ];
+
+    public function __construct(private iDB $db)
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Configures the command.
+     */
+    protected function configure(): void
+    {
+        $this->setName(self::ROUTE)
+            ->setDescription('Get backend active sessions.')
+            ->addOption('include-raw-response', null, InputOption::VALUE_NONE, 'Include unfiltered raw response.')
+            ->addOption('config', 'c', InputOption::VALUE_REQUIRED, 'Use Alternative config file.')
+            ->addOption('select-backends', 's', InputOption::VALUE_REQUIRED, 'Select backends.')
+            ->setHelp(
+                r(
+                    <<<HELP
+
+                    Get active sessions for all users in a backend.
+
+                    -------
+                    <notice>[ FAQ ]</notice>
+                    -------
+
+                    <question># How to see the raw response?</question>
+
+                    {cmd} <cmd>{route}</cmd> <flag>--output</flag> <value>yaml</value> <flag>--include-raw-response</flag> <flag>-s</flag> <value>backend_name</value>
+
+                    HELP,
+                    [
+                        'cmd' => trim(commandContext()),
+                        'route' => self::ROUTE,
+                    ]
+                )
+            );
+    }
+
+    /**
+     * Runs the command.
+     *
+     * @param InputInterface $input The input interface.
+     * @param OutputInterface $output The output interface.
+     *
+     * @return int The exit status code.
+     * @throws ExceptionInterface When the request fails.
+     * @throws \JsonException When the response cannot be parsed.
+     */
+    protected function runCommand(InputInterface $input, OutputInterface $output): int
+    {
+        $mode = $input->getOption('output');
+        $backend = $input->getOption('select-backends');
+
+        if (null === $backend) {
+            $output->writeln(r('<error>ERROR: Backend not specified. Please use [-s, --select-backends].</error>'));
+            return self::FAILURE;
+        }
+
+        $backend = explode(',', $backend, 1)[0];
+
+        // -- Use Custom servers.yaml file.
+        if (($config = $input->getOption('config'))) {
+            try {
+                Config::save('servers', Yaml::parseFile($this->checkCustomBackendsFile($config)));
+            } catch (\App\Libs\Exceptions\RuntimeException $e) {
+                $output->writeln(r('<error>{message}</error>', ['message' => $e->getMessage()]));
+                return self::FAILURE;
+            }
+        }
+
+        if (null === ag(Config::get('servers', []), $backend, null)) {
+            $output->writeln(r("<error>ERROR: Backend '{backend}' not found.</error>", ['backend' => $backend]));
+            return self::FAILURE;
+        }
+
+        $opts = $backendOpts = [];
+
+        if ($input->getOption('include-raw-response')) {
+            $opts[Options::RAW_RESPONSE] = true;
+        }
+
+        if ($input->getOption('trace')) {
+            $backendOpts = ag_set($opts, 'options.' . Options::DEBUG_TRACE, true);
+        }
+
+        $sessions = $this->getBackend($backend, $backendOpts)->getSessions(opts: $opts);
+
+        if (count($sessions) < 1) {
+            $output->writeln(
+                r("<notice>No active sessions were found for '{backend}'.</notice>", ['backend' => $backend])
+            );
+            return self::FAILURE;
+        }
+
+        if ('table' === $mode) {
+            $items = [];
+
+            foreach (ag($sessions, 'sessions', []) as $item) {
+                $item['item_offset_at'] = formatDuration($item['item_offset_at']);
+                $item['item_type'] = ucfirst($item['item_type']);
+
+                $entity = $this->db->findByBackendId(
+                    backend: $backend,
+                    id: $item['item_id'],
+                    type: 'Episode' === $item['item_type'] ? iState::TYPE_EPISODE : iState::TYPE_MOVIE
+                );
+
+                if (null !== $entity) {
+                    $item['item_title'] = $entity->getName();
+                }
+
+                $i = [];
+
+                foreach ($item as $key => $val) {
+                    $i[self::REMAP_FIELDS[$key] ?? $key] = $val;
+                }
+
+                $items[] = $i;
+            }
+
+            $sessions = $items;
+        }
+
+        $this->displayContent($sessions, $output, $mode);
+
+        return self::SUCCESS;
+    }
+
+}

--- a/src/Libs/Database/DatabaseInterface.php
+++ b/src/Libs/Database/DatabaseInterface.php
@@ -74,6 +74,17 @@ interface DatabaseInterface
     public function find(StateInterface ...$items): array;
 
     /**
+     * Find database item using backend name and id.
+     *
+     * @param string $backend Backend name.
+     * @param int|string $id Backend id.
+     * @param string|null $type (Optional) Type of item will speed up lookups.
+     *
+     * @return StateInterface|null Return null if not found.
+     */
+    public function findByBackendId(string $backend, int|string $id, string|null $type = null): StateInterface|null;
+
+    /**
      * Update entity immediately.
      *
      * @param StateInterface $entity Entity to update.

--- a/src/Libs/Initializer.php
+++ b/src/Libs/Initializer.php
@@ -638,6 +638,10 @@ final class Initializer
             $context['attributes'] = $attributes;
         }
 
-        $this->accessLog->log($level, $message, $context);
+        if (true === (bool)Config::get('logs.context')) {
+            $this->accessLog->log($level, $message, $context);
+        } else {
+            $this->accessLog->log($level, r($message, $context));
+        }
     }
 }


### PR DESCRIPTION
Added safeguard to prevent updating items that are being played by the user right now. This changes fixes Plex showing loading screen when the sync happens even though it retains the play position.

While we are at it we added new command ` backend:users:sessions` to show active play sessions.

Unfortunately while we were developing this fix, we discovered that plex is reporting the user_id of the admin user as `1` again, as such we had to implement a workaround to make it work. Thus, we need to retrieve a new data from `plex.tv` to fill the new `options.plex_user_uuid` value, And to do so, just re-run the `config:manage` You dont have to change any thing just run the command and it will pull the user UUID. 

The previous workaround only needed on plex backends. Jellyfin & Emby aren't effected.