### PR TITLE
QoL improvements

### DIFF
--- a/src/Cli.php
+++ b/src/Cli.php
@@ -77,6 +77,15 @@ class Cli extends Application
             )
         );
 
+        $definition->addOption(
+            new InputOption(
+                'debug',
+                null,
+                InputOption::VALUE_NONE,
+                'Turn on the <comment>-vvv --context --trace</comment> flags.'
+            )
+        );
+
         return $definition;
     }
 }

--- a/src/Command.php
+++ b/src/Command.php
@@ -48,6 +48,16 @@ class Command extends BaseCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        if ($input->hasOption('debug') && $input->getOption('debug')) {
+            $input->setOption('context', true);
+            $input->setOption('trace', true);
+            $input->setOption('verbose', true);
+            if (function_exists('putenv')) {
+                @putenv('SHELL_VERBOSITY=3');
+            }
+            $output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
+        }
+
         if ($input->hasOption('context') && true === $input->getOption('context')) {
             Config::save('logs.context', true);
         }

--- a/src/Commands/State/ExportCommand.php
+++ b/src/Commands/State/ExportCommand.php
@@ -140,7 +140,7 @@ class ExportCommand extends Command
     protected function process(InputInterface $input, OutputInterface $output): int
     {
         if (null !== ($logfile = $input->getOption('logfile')) && true === ($this->logger instanceof Logger)) {
-            $this->logger->pushHandler(new StreamLogHandler(new Stream($logfile, 'a'), $output));
+            $this->logger->setHandlers([new StreamLogHandler(new Stream($logfile, 'w'), $output)]);
         }
 
         // -- Use Custom servers.yaml file.

--- a/src/Commands/State/ImportCommand.php
+++ b/src/Commands/State/ImportCommand.php
@@ -239,7 +239,7 @@ class ImportCommand extends Command
     protected function process(InputInterface $input, OutputInterface $output): int
     {
         if (null !== ($logfile = $input->getOption('logfile')) && true === ($this->logger instanceof Logger)) {
-            $this->logger->pushHandler(new StreamLogHandler(new Stream($logfile, 'a'), $output));
+            $this->logger->setHandlers([new StreamLogHandler(new Stream($logfile, 'w'), $output)]);
         }
 
         // -- Use Custom servers.yaml file.

--- a/src/Libs/Mappers/Import/DirectMapper.php
+++ b/src/Libs/Mappers/Import/DirectMapper.php
@@ -153,12 +153,15 @@ final class DirectMapper implements iImport
                 $this->actions[$entity->type]['failed']++;
                 Message::increment("{$entity->via}.{$entity->type}.failed");
 
-                $this->logger->notice('MAPPER: Ignoring [{backend}] [{title}]. Does not exist in database.', [
-                    'metaOnly' => true,
-                    'backend' => $entity->via,
-                    'title' => $entity->getName(),
-                    'data' => $entity->getAll(),
-                ]);
+                $this->logger->notice(
+                    'MAPPER: Ignoring [{backend}] [{title}]. Does not exist in database. And backend set as metadata source only.',
+                    [
+                        'metaOnly' => true,
+                        'backend' => $entity->via,
+                        'title' => $entity->getName(),
+                        'data' => $entity->getAll(),
+                    ]
+                );
 
                 return $this;
             }
@@ -241,7 +244,7 @@ final class DirectMapper implements iImport
         $cloned = clone $local;
 
         /**
-         * ONLY update backend metadata as requested by caller.
+         * ONLY update backend metadata
          * if metadataOnly is set or the event is tainted.
          */
         if (true === $metadataOnly || true === $entity->isTainted()) {
@@ -294,8 +297,33 @@ final class DirectMapper implements iImport
                 return $this;
             }
 
+            if ($entity->isWatched() !== $local->isWatched()) {
+                $reasons = [];
+
+                if (true === $entity->isTainted()) {
+                    $reasons[] = 'event marked as tainted';
+                }
+                if (true === $metadataOnly) {
+                    $reasons[] = 'Mapper is in metadata only mode';
+                }
+
+                $this->logger->notice(
+                    'MAPPER: [{backend}] item [{id}: {title}] is marked as [{state}] vs local state [{local_state}], However due to the following reason ({reason}) it was not considered as valid state.',
+                    [
+                        'id' => $cloned->id,
+                        'backend' => $entity->via,
+                        'state' => $entity->isWatched() ? 'played' : 'unplayed',
+                        'local_state' => $local->isWatched() ? 'played' : 'unplayed',
+                        'title' => $entity->getName(),
+                        'reasons' => implode(', ', $reasons),
+                    ]
+                );
+
+                return $this;
+            }
+
             if ($this->inTraceMode()) {
-                $this->logger->info('MAPPER: [{backend}] [{title}] No metadata changes detected.', [
+                $this->logger->info("MAPPER: Ignoring [{backend}] [{title}]. No metadata changes detected.", [
                     'id' => $cloned->id,
                     'backend' => $entity->via,
                     'title' => $cloned->getName(),
@@ -440,6 +468,24 @@ final class DirectMapper implements iImport
                     }
                 }
 
+                Message::increment("{$entity->via}.{$entity->type}.ignored_not_played_since_last_sync");
+
+                if ($entity->isWatched() !== $local->isWatched()) {
+                    $this->logger->notice(
+                        'MAPPER: [{backend}] item [{id}: {title}] is marked as [{state}] vs local state [{local_state}], However due the remote item date [{remote_date}] being older than the last backend sync date [{local_date}]. it was not considered as valid state.',
+                        [
+                            'id' => $cloned->id,
+                            'backend' => $entity->via,
+                            'remote_date' => makeDate($entity->updated),
+                            'local_date' => makeDate($opts['after']),
+                            'state' => $entity->isWatched() ? 'played' : 'unplayed',
+                            'local_state' => $local->isWatched() ? 'played' : 'unplayed',
+                            'title' => $entity->getName(),
+                        ]
+                    );
+                    return $this;
+                }
+
                 if ($this->inTraceMode()) {
                     $this->logger->debug('MAPPER: Ignoring [{backend}] [{title}]. No changes detected.', [
                         'id' => $cloned->id,
@@ -448,12 +494,13 @@ final class DirectMapper implements iImport
                     ]);
                 }
 
-                Message::increment("{$entity->via}.{$entity->type}.ignored_not_played_since_last_sync");
                 return $this;
             }
         }
+
         /**
-         * Fix for #329
+         * Fix for #329 {@see https://github.com/arabcoders/watchstate/issues/329}
+         *
          * This conditional block should proceed only if specific conditions are met.
          * 1- the backend state is [unwatched] while the db state is [watched]
          * 2- if the db.metadata.backend.played_at is equal to entity.updated or the db.metadata has no data.


### PR DESCRIPTION
This set of changes bring the following changes

- [x] Added new `--debug` flag that would turn on the following flags `-vvv --context --trace` automatically to reduce command entry bloat.
- [x] When the `--logfile` flag is used, output to the console is suppressed to reduce noise and I/O.
- [x] Added more relevant log messages on why a record state was not considered. This mostly boils down to three conditions `the item event is marked as tainted`, `the mapper is running in metadataOnly mode`, or the `local sync date > item event date`. 