### PR TITLE
Use RetryableHttpClient when using push mode for Plex backend

### DIFF
--- a/src/Backends/Plex/Action/GetLibrary.php
+++ b/src/Backends/Plex/Action/GetLibrary.php
@@ -230,8 +230,9 @@ final class GetLibrary
                 if (200 !== $response->getStatusCode()) {
                     if (false === $noLog) {
                         $this->logger->warning(
-                            'Request for [{backend}] {item.type} [{item.title}] metadata returned with unexpected [{status_code}] status code.',
+                            "Request for '{client}: {backend}' {item.type} '{item.title}' metadata returned with unexpected '{status_code}' status code.",
                             [
+                                'client' => $context->clientName,
                                 'backend' => $context->backendName,
                                 'status_code' => $response->getStatusCode(),
                                 'body' => $response->getContent(false),

--- a/src/Backends/Plex/Action/Push.php
+++ b/src/Backends/Plex/Action/Push.php
@@ -11,8 +11,9 @@ use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Options;
 use App\Libs\QueueRequests;
 use DateTimeInterface;
-use Psr\Log\LoggerInterface;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Psr\Log\LoggerInterface as iLogger;
+use Symfony\Component\HttpClient\RetryableHttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface as iHttp;
 use Throwable;
 
 final class Push
@@ -21,8 +22,11 @@ final class Push
 
     private string $action = 'plex.push';
 
-    public function __construct(protected HttpClientInterface $http, protected LoggerInterface $logger)
+    private iHttp $http;
+
+    public function __construct(iHttp $http, protected iLogger $logger)
     {
+        $this->http = new RetryableHttpClient($http, maxRetries: 3, logger: $this->logger);
     }
 
     /**

--- a/src/Commands/State/ExportCommand.php
+++ b/src/Commands/State/ExportCommand.php
@@ -33,9 +33,9 @@ use Throwable;
 #[Cli(command: self::ROUTE)]
 class ExportCommand extends Command
 {
-    public const ROUTE = 'state:export';
+    public const string ROUTE = 'state:export';
 
-    public const TASK_NAME = 'export';
+    public const string TASK_NAME = 'export';
 
     /**
      * Class Constructor.
@@ -338,18 +338,12 @@ class ExportCommand extends Command
                             }
 
                             $this->logger->info(
-                                'SYSTEM: Using export mode for [{backend}] as the backend did not register metadata for [{item.title}].',
+                                'SYSTEM: Using export mode for [{backend}] as the backend did not register metadata for [{item.id}: {item.title}].',
                                 [
                                     'backend' => $name,
                                     'item' => [
                                         'id' => $entity->id,
                                         'title' => $entity->getName(),
-                                    ],
-                                    'wait_period' => [
-                                        'added_at' => makeDate($addedDate),
-                                        'extra_margin' => $extraMargin,
-                                        'last_sync_at' => makeDate($lastSync),
-                                        'diff' => $lastSync - ($addedDate + $extraMargin),
                                     ],
                                 ]
                             );

--- a/src/Commands/State/ExportCommand.php
+++ b/src/Commands/State/ExportCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Commands\State;
 
+use App\Backends\Common\ClientInterface;
 use App\Command;
 use App\Libs\Attributes\Route\Cli;
 use App\Libs\Config;
@@ -478,6 +479,7 @@ class ExportCommand extends Command
         ]);
 
         foreach ($backends as $backend) {
+            assert($backend['class'] instanceof ClientInterface, 'Backend class must implement ClientInterface.');
             $backend['class']->push(
                 entities: $entities,
                 queue: $this->queue,
@@ -560,6 +562,7 @@ class ExportCommand extends Command
                 ]);
             }
 
+            assert($backend['class'] instanceof ClientInterface, 'Backend class must implement ClientInterface.');
             array_push($requests, ...$backend['class']->export($this->mapper, $this->queue, $after));
 
             if (false === $input->getOption('dry-run')) {


### PR DESCRIPTION
- [x][Fixed an exception that occurs when switching from push to export mode](https://github.com/arabcoders/watchstate/pull/488/commits/46a3f771b5b4902c01138147dd7927be85c9819e). Fixes #489 
- [x][se RetryableHttpClient when using push mode for Plex backend](https://github.com/arabcoders/watchstate/pull/488/commits/65051d0374158c524cbb4da89cfb63402b1413b9)