### PR TITLE
Experimental support for limited access tokens for Emby & jellyfin.

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -44,7 +44,8 @@ While we think they are reasonable defaults, you can change them by setting the 
 #### Via WebUI
 
 Go to the `env` page, click on `+` button, then select the key in this case `WS_CRON_IMPORT_AT`, `WS_CRON_EXPORT_AT`
-and set the value to a valid cron expression. Then click save to apply the new timer. This will be change later to be included with
+and set the value to a valid cron expression. Then click save to apply the new timer. This will be change later to be
+included with
 the tasks page.
 
 #### Via CLI
@@ -95,7 +96,8 @@ Use the ids as parameters for `user:` in this case it should be `user:"1000:1000
 
 ### How to find the apikey?
 
-You can find the apikey inside the following file `/config/config/.env`. The apikey is stored inside this variable `WS_API_KEY=`.
+You can find the apikey inside the following file `/config/config/.env`. The apikey is stored inside this
+variable `WS_API_KEY=`.
 Or you can run the following command to get it directly:
 
 ```bash
@@ -108,9 +110,11 @@ $ docker exec -ti console system:apikey
 
 The API key is used to authenticate the requests to the tool, it's used to prevent unauthorized access. The API key is
 required for all endpoints except the `/v1/api/[backend_name]/webhook` endpoint which is open by default unless you have
-enabled `WS_SECURE_API_ENDPOINTS` environment variable. which then you also need to use the apikey for it webhook endpoint.
+enabled `WS_SECURE_API_ENDPOINTS` environment variable. which then you also need to use the apikey for it webhook
+endpoint.
 
-The new `WebUI` will also require the API key to access data as it's decoupled from the backend and run in standalone mode.
+The new `WebUI` will also require the API key to access data as it's decoupled from the backend and run in standalone
+mode.
 
 ----
 
@@ -128,18 +132,33 @@ $ docker exec -ti console state:export -fi -s [BACKEND_NAME]
 
 ----
 
+### How to use Jellyfin, Emby oauth tokens?
+
+Due to limitation on jellyfin/emby side, the way we implemented support for oauth token require that you provide the
+username and password in `username:password` format, This is due to the API not providing a way for us to inquiry about
+the current user.
+
+Simply, when asked for API Key, provide the username and password in the following format `username:password`.
+`WatchState` will then generate the token for you. and replace the username and password with the generated token. This
+is a one time process, and you should not need to do it again. Your `username` and `password` will not be stored.
+
+----
+
 ### My new backend overriding my old backend state / My watch state is not correct?
 
 This likely due to the new backend reporting newer date than your old backend. as such the typical setup is to
 prioritize items with newer date compared to old ones. This is what you want to happen normally. However, if the new
-media backend state is not correct this might override your current watch state. The solution to get both in sync, and to do so follow these steps:
+media backend state is not correct this might override your current watch state. The solution to get both in sync, and
+to do so follow these steps:
 
 Add your backend that has correct watch state and enable full import. Second, add your new backend as metadata source.
 
-In `CLI` context Answer `N` to the question `Enable importing of metadata and play state from this backend?`. Make sure to select yes
+In `CLI` context Answer `N` to the question `Enable importing of metadata and play state from this backend?`. Make sure
+to select yes
 for export to get the option to select the backend as metadata source.
 
-In `WebUI` if you disable import, you will get an extra option that is normally hidden to select the backend as metadata source.
+In `WebUI` if you disable import, you will get an extra option that is normally hidden to select the backend as metadata
+source.
 
 After that, do single backend export by using the following command:
 
@@ -193,7 +212,8 @@ database state back to the selected backend.
 ### Is there support for Multi-user setup?
 
 No, The tool is designed to work for single user. However, It's possible to run container for each user. You can also
-use single container for all users, however it's not really easy refer to [issue #136](https://github.com/arabcoders/watchstate/issues/136).
+use single container for all users, however it's not really easy refer
+to [issue #136](https://github.com/arabcoders/watchstate/issues/136).
 
 For `Jellyfin` and `Emby`, you can just generate new API tokens and link it to a user.
 
@@ -213,7 +233,8 @@ $ docker exec -ti console backend:users:list -s backend_name --with-tokens
 ### How do i migrate invited friends i.e. (external user) data from from plex to emby/jellyfin?
 
 As this tool is designed to work with single user, You have to treat each invited friend as a separate user. what is
-needed, you need to contact that friend of yours and ask him/her to give you a copy of the [X-Plex-Token](https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/),
+needed, you need to contact that friend of yours and ask him/her to give you a copy of
+the [X-Plex-Token](https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/),
 then create new container and add the backend with the token you got from your friend.
 
 After that, add your other backends like emby/jellyfin using your regular API key. jellyfin/emby differentiate between
@@ -238,8 +259,10 @@ No, You can use the `task scheduler` or on `on demand sync` if you want.
 
 ### I get tired of writing the whole command everytime is there an easy way run the commands?
 
-Good News, There is a way to make your life easier, We recently added a `WebUI` which should cover most of the use cases.
-However, if you still want to use the `CLI` You can create a shell script to omit the `docker exec -ti watchstate console`
+Good News, There is a way to make your life easier, We recently added a `WebUI` which should cover most of the use
+cases.
+However, if you still want to use the `CLI` You can create a shell script to omit
+the `docker exec -ti watchstate console`
 
 ```bash
 $ echo 'docker exec -ti watchstate console "$@"' > ws
@@ -258,7 +281,8 @@ Sometimes there are problems related to HTTP/2, so before reporting bug please t
 $ docker exec -ti watchstate console config:edit --key options.client.http_version --set 1.0 -s backend_name 
 ```
 
-This will force set the internal http client to use `http/v1` if it does not fix your problem, please open bug report about it.
+This will force set the internal http client to use `http/v1` if it does not fix your problem, please open bug report
+about it.
 
 ---
 
@@ -310,8 +334,11 @@ $ mv /config/db/watchstate_v01-repaired.db /config/db/watchstate_v01.db
 * com.plexapp.agents.xbmcnfo://(id)?lang=en `(XBMC NFO Movies agent)`
 * com.plexapp.agents.xbmcnfotv://(id)?lang=en `(XBMC NFO TV agent)`
 * com.plexapp.agents.hama://(db)\d?-(id)?lang=en `(HAMA multi source db agent mainly for anime)`
-* com.plexapp.agents.ytinforeader://(id)?lang=en [ytinforeader.bundle](https://github.com/arabcoders/plex-ytdlp-info-reader-agent) With [jp_scanner.py](https://github.com/arabcoders/plex-daily-scanner) as scanner.
-* com.plexapp.agents.cmdb://(id)?lang=en [cmdb.bundle](https://github.com/arabcoders/cmdb.bundle) `(User custom metadata database)`.
+* com.plexapp.agents.ytinforeader://(id)
+  ?lang=en [ytinforeader.bundle](https://github.com/arabcoders/plex-ytdlp-info-reader-agent)
+  With [jp_scanner.py](https://github.com/arabcoders/plex-daily-scanner) as scanner.
+* com.plexapp.agents.cmdb://(id)
+  ?lang=en [cmdb.bundle](https://github.com/arabcoders/cmdb.bundle) `(User custom metadata database)`.
 
 ---
 
@@ -323,15 +350,18 @@ $ mv /config/db/watchstate_v01-repaired.db /config/db/watchstate_v01.db
 * tvmaze://(id)
 * tvrage://(id)
 * anidb://(id)
-* ytinforeader://(id) [jellyfin](https://github.com/arabcoders/jf-ytdlp-info-reader-plugin) & [Emby](https://github.com/arabcoders/emby-ytdlp-info-reader-plugin). `(A yt-dlp info reader plugin)`.
-* cmdb://(id) [jellyfin](https://github.com/arabcoders/jf-custom-metadata-db) & [Emby](https://github.com/arabcoders/emby-custom-metadata-db). `(User custom metadata database)`.
+* ytinforeader://(
+  id) [jellyfin](https://github.com/arabcoders/jf-ytdlp-info-reader-plugin) & [Emby](https://github.com/arabcoders/emby-ytdlp-info-reader-plugin). `(A yt-dlp info reader plugin)`.
+* cmdb://(
+  id) [jellyfin](https://github.com/arabcoders/jf-custom-metadata-db) & [Emby](https://github.com/arabcoders/emby-custom-metadata-db). `(User custom metadata database)`.
 
 ---
 
 ### Environment Variables
 
 The recommended approach is for keys that starts with `WS_` use the `WebUI > Env` page, or `system:env` command via CLI.
-For other keys that aren't directly related to the tool, you **MUST** load them via container environment or the `compose.yaml` file.
+For other keys that aren't directly related to the tool, you **MUST** load them via container environment or
+the `compose.yaml` file.
 
 to see list of loaded environment variables
 
@@ -347,7 +377,8 @@ $ docker exec -ti watchstate console system:env
 
 #### Tool specific environment variables.
 
-These environment variables relates to the tool itself, You should manage them via `WebUI > Env` page or `system:env` command via CLI.
+These environment variables relates to the tool itself, You should manage them via `WebUI > Env` page or `system:env`
+command via CLI.
 
 | Key                     | Type    | Description                                                             | Default                  |
 |-------------------------|---------|-------------------------------------------------------------------------|--------------------------|
@@ -391,7 +422,8 @@ $ docker exec -ti watchstate console system:env --list
 #### Container specific environment variables.
 
 > [!IMPORTANT]
-> These environment variables relates to the container itself, and MUST be added via container environment or by the `compose.yaml` file.
+> These environment variables relates to the container itself, and MUST be added via container environment or by
+> the `compose.yaml` file.
 
 | Key           | Type    | Description                          | Default  |
 |---------------|---------|--------------------------------------|----------|
@@ -408,7 +440,8 @@ $ docker exec -ti watchstate console system:env --list
 
 The Webhook URL is backend specific, the request path is `/v1/api/backend/[BACKEND_NAME]/webhook`,
 Where `[BACKEND_NAME]` is the name of the backend you want to add webhook for. Typically, the full URL
-is `http://localhost:8080/v1/api/backend/[BACKEND_NAME]/webhook`. Or simply go to the `WebUI > Backends` and click on `Copy Webhook URL`.
+is `http://localhost:8080/v1/api/backend/[BACKEND_NAME]/webhook`. Or simply go to the `WebUI > Backends` and click
+on `Copy Webhook URL`.
 
 > [!NOTE]
 > You will keep seeing the `webhook.token` key, it's being kept for backward compatibility, and will be removed in the
@@ -533,7 +566,8 @@ Those are some webhook limitations we discovered for the following media backend
 #### Emby
 
 * Emby does not send webhooks events for newly added items.
-  ~~[See feature request](https://emby.media/community/index.php?/topic/97889-new-content-notification-webhook/)~~ implemented in `4.7.9` still does not work as expected no metadata being sent when the item notification goes out.
+  ~~[See feature request](https://emby.media/community/index.php?/topic/97889-new-content-notification-webhook/)~~
+  implemented in `4.7.9` still does not work as expected no metadata being sent when the item notification goes out.
 * Emby webhook test event does not contain data. To test if your setup works, play something or do mark an item as
   played or unplayed you should see changes reflected in `docker exec -ti watchstate console db:list`.
 
@@ -578,40 +612,51 @@ https://watchstate.example.org {
 ```
 
 > [!IMPORTANT]
-> If you change the FastCGI Process Manager TCP port via FPM_PORT environment variable, you should change the port in the caddy file as well.
+> If you change the FastCGI Process Manager TCP port via FPM_PORT environment variable, you should change the port in
+> the caddy file as well.
 
 ---
 
 ### WS_API_AUTO
 
-The purpose of this environment variable is to automate the configuration process. It's mainly used for people who uses many browsers
-to access the `WebUI` and want to automate the configuration process. as it's requires the API settings to be configured before it
+The purpose of this environment variable is to automate the configuration process. It's mainly used for people who uses
+many browsers
+to access the `WebUI` and want to automate the configuration process. as it's requires the API settings to be configured
+before it
 can be used. This environment variable can be enabled by setting `WS_API_AUTO=true` in `${WS_DATA_PATH}/config/.env`.
 
 #### Why you should use it?
 
-You normally should not use it, as it's a **GREAT SECURITY RISK**. However, if you are using the tool in a secure environment
+You normally should not use it, as it's a **GREAT SECURITY RISK**. However, if you are using the tool in a secure
+environment
 and not worried about exposing your API key, you can use it to automate the configuration process.
 
 #### Why you should not use it?
 
-Because, by exposing your API key, you are also exposing every data you have in the tool. This is a **GREAT SECURITY RISK**,
-any person or bot that are able to access the `WebUI` will also be able to visit `/v1/api/system/auto` and get your API key. And with this key
+Because, by exposing your API key, you are also exposing every data you have in the tool. This is a **GREAT SECURITY
+RISK**,
+any person or bot that are able to access the `WebUI` will also be able to visit `/v1/api/system/auto` and get your API
+key. And with this key
 they can do anything they want with your data. including viewing your media servers api keys.
 
-So, please while we have this option available, we strongly recommend not to use it if `WatchState` is exposed to the internet.
+So, please while we have this option available, we strongly recommend not to use it if `WatchState` is exposed to the
+internet.
 
 > [!IMPORTANT]
-> This environment variable is **GREAT SECURITY RISK**, and we strongly recommend not to use it if `WatchState` is exposed to the internet.
+> This environment variable is **GREAT SECURITY RISK**, and we strongly recommend not to use it if `WatchState` is
+> exposed to the internet.
 > I cannot stress this enough, please do not use it unless you are in a secure environment.
 
 ---
 
 ### How to disable the included cache server and use external cache server?
 
-Set this environment variable in your `compose.yaml` file `DISABLE_CACHE` with value of `1`. to use external redis server
-you need to alter the value of `WS_CACHE_URL` environment variable. the format for this variable is `redis://host:port?password=auth&db=db_num`,
-for example to use redis from another container you could use something like `redis://172.23.1.10:6379?password=my_secert_password&db=8`.
+Set this environment variable in your `compose.yaml` file `DISABLE_CACHE` with value of `1`. to use external redis
+server
+you need to alter the value of `WS_CACHE_URL` environment variable. the format for this variable
+is `redis://host:port?password=auth&db=db_num`,
+for example to use redis from another container you could use something
+like `redis://172.23.1.10:6379?password=my_secert_password&db=8`.
 We only support `redis` and API compatible alternative.
 
 Once that done, restart the container.
@@ -621,7 +666,8 @@ Once that done, restart the container.
 ### How to get WatchState working with YouTube content/library?
 
 Due to the nature on how people name their youtube files i had to pick something specific for it to work cross supported
-media agents. Please visit [this link](https://github.com/arabcoders/jf-ytdlp-info-reader-plugin#usage) to know how to name your files. Please be aware these plugins and scanners `REQUIRE`
+media agents. Please visit [this link](https://github.com/arabcoders/jf-ytdlp-info-reader-plugin#usage) to know how to
+name your files. Please be aware these plugins and scanners `REQUIRE`
 that you have a `yt-dlp` `.info.json` files named exactly as your media file.
 
 For example, if you have `20231030 my awesome youtube video [youtube-RandomString].mkv`you should
@@ -636,11 +682,13 @@ I plan to make `.info.json` optional However at the moment the file is required 
 
 #### Jellyfin Setup
 
-* Download this plugin [jf-ytdlp-info-reader-plugin](https://github.com/arabcoders/jf-ytdlp-info-reader-plugin). Please refer to the link on how to install it.
+* Download this plugin [jf-ytdlp-info-reader-plugin](https://github.com/arabcoders/jf-ytdlp-info-reader-plugin). Please
+  refer to the link on how to install it.
 
 #### Emby Setup
 
-* Download this plugin [emby-ytdlp-info-reader-plugin](https://github.com/arabcoders/emby-ytdlp-info-reader-plugin). Please refer to the link on how to install it.
+* Download this plugin [emby-ytdlp-info-reader-plugin](https://github.com/arabcoders/emby-ytdlp-info-reader-plugin).
+  Please refer to the link on how to install it.
 
 If your media is not matching correctly or not marking it as expected, it's most likely scanners issues as plex and
 jellyfin/emby reports the GUID differently, and we try our best to match them. So, please hop on discord with the
@@ -693,8 +741,10 @@ If everything is working correctly you should see something like this previous j
 
 ### I keep receiving this warning in log `INFO: Ignoring [xxx] Episode range, and treating it as single episode. Backend says it covers [00-00]`?
 
-We recently added guard clause to prevent backends from sending possibly invalid episode ranges, as such if you see this,
-this likely means your backend mis-identified episodes range. By default, we allow an episode to cover up to `3` episodes.
+We recently added guard clause to prevent backends from sending possibly invalid episode ranges, as such if you see
+this,
+this likely means your backend mis-identified episodes range. By default, we allow an episode to cover up to `3`
+episodes.
 
 If this is not enough for your library content. fear not we have you covered you can increase the limit by running the
 following command:
@@ -786,7 +836,8 @@ ws:/opt/app/public$ ls
 exported   index.php
 ```
 
-There must be exactly one `index.php` file and one `exported` directory. inside that directory, or if you prefer, you can add `WS_WEBUI_PATH` environment variable to point to the `exported` directory.
+There must be exactly one `index.php` file and one `exported` directory. inside that directory, or if you prefer, you
+can add `WS_WEBUI_PATH` environment variable to point to the `exported` directory.
 
 * link the app to the frontend proxy. For caddy, you can use the following configuration.
 

--- a/README.md
+++ b/README.md
@@ -9,21 +9,39 @@ out of the box, this tool support `Jellyfin`, `Plex` and `Emby` media servers.
 
 ## Updates
 
+### 2024-07-06
+
+We recently added experimental support for jellyfin & emby oauth access tokens, This way you are able to sync your
+play state even if you don't own the server and cant generate API keys.
+
+The support is experimental and might not work as expected, but we are working on improving it. If you have any feedback
+or suggestions, please let us know.
+
+We have also added new `config:test` command to run functional tests on your backends, this will not alter your state,
+And it's quite useful to know if the tool is able to communicate with your backends. without problems, It will report
+the following, `OK` which mean the indicated test has passed, `FA` which mean the indicated test has failed. And `SK`
+which mean the indicated test has been skipped or not yet implemented.
+
 ### 2024-06-23
 
-WE are happy to announce that the `WebUI` is ready for wider usage and we are planning to release it in the next few months.
-We are actively working on it to improve it. If you have any feedback or suggestions, please let us know. We feel it's almost future complete
+WE are happy to announce that the `WebUI` is ready for wider usage and we are planning to release it in the next few
+months.
+We are actively working on it to improve it. If you have any feedback or suggestions, please let us know. We feel it's
+almost future complete
 for the things that we want.
 
 On another related news, we have added new environment variable `WS_API_AUTO` "disabled by default" which can be used
-to automatically expose your **API KEY/TOKEN**. This is useful for users who are using the `WebUI` from many different browsers
+to automatically expose your **API KEY/TOKEN**. This is useful for users who are using the `WebUI` from many different
+browsers
 and want to automate the configuration process.
 
-While the `WebUI` is included in the main project, it's a standalone feature and requires the API settings to be configured before it
+While the `WebUI` is included in the main project, it's a standalone feature and requires the API settings to be
+configured before it
 can be used. This environment variable can be enabled by setting `WS_API_AUTO=true` in `${WS_DATA_PATH}/config/.env`.
 
 > [!IMPORTANT]
-> This environment variable is **GREAT SECURITY RISK**, and we strongly recommend not to use it if `WatchState` is exposed to the internet.
+> This environment variable is **GREAT SECURITY RISK**, and we strongly recommend not to use it if `WatchState` is
+> exposed to the internet.
 
 Refer to [NEWS](NEWS.md) for old updates.
 
@@ -88,7 +106,8 @@ $ mkdir -p ./data && docker-compose pull && docker-compose up -d
 
 After starting the container, you can access the WebUI by visiting `http://localhost:8080` in your browser.
 
-At the start you won't see anything as the `WebUI` is decoupled from the WatchState and need to be configured to be able to access the API.
+At the start you won't see anything as the `WebUI` is decoupled from the WatchState and need to be configured to be able
+to access the API.
 In the top right corner, you will see a cogwheel icon, click on it and then Configure the connection settings.
 
 ![Connection settings](screenshots/api_settings.png)
@@ -99,21 +118,27 @@ As shown in the screenshot, to get your `API Token`, run the following command
 $ docker exec -ti watchstate console system:apikey 
 ```
 
-Copy the random string in dark yellow, into the `API Token` field Make sure to set the `API URL` or click the `current page URL` link. If everything is set, then the Status field will turn
+Copy the random string in dark yellow, into the `API Token` field Make sure to set the `API URL` or click
+the `current page URL` link. If everything is set, then the Status field will turn
 green. and `Status: OK` will be shown, and the reset of the navbar will show up. Which hopefully means everything is ok.
 
 To add a backend, click on the `Backends` link in the navbar, then `+` button. as showing in the following screenshot
 
 ![Add backend](screenshots/add_backend.png)
 
-Fill the required information, if you get a green notification, then the backend is added successfully. If you get a red/yellow notification, Then most likely incorrect information was provided.
-You can check the message in the notification itself to know what went wrong. Or check the logs page, Most likely an error has been logged to a file named `app.YYYYMMDD.log`.
+Fill the required information, if you get a green notification, then the backend is added successfully. If you get a
+red/yellow notification, Then most likely incorrect information was provided.
+You can check the message in the notification itself to know what went wrong. Or check the logs page, Most likely an
+error has been logged to a file named `app.YYYYMMDD.log`.
 
-If everything went ok, you should see the backend shows up in the same page. You can then go to the Tasks page and click on `Qeueu Task`, for first time import we recommand letting
+If everything went ok, you should see the backend shows up in the same page. You can then go to the Tasks page and click
+on `Qeueu Task`, for first time import we recommand letting
 the task run in the background, as it might take a while to import all the data.
 
-Once you have done all for your backends, You should go back again to `Tasks` page and enable the `Import` and `Export` tasks. This will make sure your data is always in sync.
-To enable/disable the task, simply click on the slider next to the task name if it's green then it's enabled, if it's gray then it's disabled.
+Once you have done all for your backends, You should go back again to `Tasks` page and enable the `Import` and `Export`
+tasks. This will make sure your data is always in sync.
+To enable/disable the task, simply click on the slider next to the task name if it's green then it's enabled, if it's
+gray then it's disabled.
 
 Once that is done, you can let the tool do its job, and you can start using the tool to track your play state.
 
@@ -124,8 +149,10 @@ Once that is done, you can let the tool do its job, and you can start using the 
 After starting the container you should start adding your backends and to do so run the following command:
 
 > [!NOTE]
-> to get your plex token, please visit [this plex page](https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/) to
-> know how to extract your plex token. For jellyfin & emby. Go to Dashboard > Advanced > API keys > then create new api keys.
+> to get your plex token, please
+> visit [this plex page](https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/) to
+> know how to extract your plex token. For jellyfin & emby. Go to Dashboard > Advanced > API keys > then create new api
+> keys.
 
 ```bash
 $ docker exec -ti watchstate console config:add
@@ -217,12 +244,14 @@ support and answers to many questions.
 
 # Social channels
 
-If you have short or quick questions, or just want to chat with other users, feel free to join my [discord server](https://discord.gg/haUXHJyj6Y).
+If you have short or quick questions, or just want to chat with other users, feel free to join
+my [discord server](https://discord.gg/haUXHJyj6Y).
 keep in mind it's solo project, as such it might take me a bit of time to reply to questions.
 
 ---
 
 # Donate
 
-If you feel like donating and appreciate my work, you can do so by donating to children charity. For example [Make-A-Wish](https://worldwish.org).
+If you feel like donating and appreciate my work, you can do so by donating to children charity. For
+example [Make-A-Wish](https://worldwish.org).
 I Personally don't need the money, but I do appreciate the gesture.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,15 @@ out of the box, this tool support `Jellyfin`, `Plex` and `Emby` media servers.
 
 ### 2024-07-06
 
-We recently added experimental support for jellyfin & emby oauth access tokens, This way you are able to sync your
-play state even if you don't own the server and cant generate API keys.
+Recently we have introduced a new feature that allows you to use Jellyfin and Emby OAuth access tokens for syncing
+your play state. This is especially handy if you're not the server owner and can't create API keys. Please note, this
+feature is in its experimental phase, so you might encounter some issues as we yet to explorer the full depth of the
+implementation. We're actively working on making it better, If you have any feedback or suggestions, please let us know.
 
-The support is experimental and might not work as expected, but we are working on improving it. If you have any feedback
-or suggestions, please let us know.
+Getting your OAuth token is easy. When prompted, simply enter your `username:password` in place of the API key through
+the `WebUI` or the `config:add/manage` command. `WatchState` will automatically contact the backend and generate the
+token for you, as this step is required to get more information like your `User ID` which is sadly inaccessible without
+us generating the token. Both Emby & Jellyfin doesn't provide an api to inquire about the current user.
 
 We have also added new `config:test` command to run functional tests on your backends, this will not alter your state,
 And it's quite useful to know if the tool is able to communicate with your backends. without problems, It will report

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ implementation. We're actively working on making it better, If you have any feed
 Getting your OAuth token is easy. When prompted, simply enter your `username:password` in place of the API key through
 the `WebUI` or the `config:add/manage` command. `WatchState` will automatically contact the backend and generate the
 token for you, as this step is required to get more information like your `User ID` which is sadly inaccessible without
-us generating the token. Both Emby & Jellyfin doesn't provide an api to inquire about the current user.
+us generating the token. Both Emby & Jellyfin doesn't provide an API endpoint to inquiry about the current user.
 
 We have also added new `config:test` command to run functional tests on your backends, this will not alter your state,
 And it's quite useful to know if the tool is able to communicate with your backends. without problems, It will report

--- a/config/servers.spec.php
+++ b/config/servers.spec.php
@@ -167,5 +167,11 @@ return [
         'visible' => false,
         'description' => 'Whether to use the old progress endpoint for plex progress sync.',
     ],
+    [
+        'key' => 'options.is_limited_token',
+        'type' => 'bool',
+        'visible' => false,
+        'description' => 'Whether the token has limited access.',
+    ],
 ];
 

--- a/frontend/pages/parity.vue
+++ b/frontend/pages/parity.vue
@@ -329,7 +329,7 @@ const loadContent = async (pageNumber, fromPopState = false, fromReload = false)
     pageNumber = 1
   }
 
-  let search = new URLSearchParams()
+  const search = new URLSearchParams()
   search.set('perpage', perpage.value)
   search.set('page', pageNumber)
 
@@ -360,7 +360,7 @@ const loadContent = async (pageNumber, fromPopState = false, fromReload = false)
       clearCache();
     }
 
-    if (sessionStorage.getItem(cacheKey.value)) {
+    if (sessionStorage?.getItem(cacheKey.value)) {
       json = JSON.parse(sessionStorage.getItem(cacheKey.value))
     } else {
       const response = await request(`/system/parity/?${search.toString()}`)
@@ -378,10 +378,7 @@ const loadContent = async (pageNumber, fromPopState = false, fromReload = false)
       await useRouter().push({
         path: '/parity',
         title: pageTitle,
-        query: search.entries().reduce((acc, [k, v]) => {
-          acc[k] = v
-          return acc
-        }, {})
+        query: Object.fromEntries(search)
       })
     }
 
@@ -427,7 +424,7 @@ const massDelete = async () => {
     } else {
       items.value = items.value.filter(i => !selected_ids.value.includes(i.id))
       try {
-        sessionStorage.removeItem(cacheKey.value)
+        sessionStorage?.removeItem(cacheKey.value)
       } catch (e) {
       }
     }
@@ -554,7 +551,7 @@ watch(filter, val => {
   })
 })
 
-const clearCache = () => Object.keys(sessionStorage).filter(k => /^parity/.test(k)).forEach(k => sessionStorage.removeItem(k))
+const clearCache = () => Object.keys(sessionStorage ?? {}).filter(k => /^parity/.test(k)).forEach(k => sessionStorage.removeItem(k))
 
 const stateCallBack = async e => {
   if (!e.state && !e.detail) {

--- a/frontend/utils/index.js
+++ b/frontend/utils/index.js
@@ -423,6 +423,35 @@ const makeSecret = (len = 8) => {
     return result;
 }
 
+/**
+ * Explode string by delimiter.
+ *
+ * @param {string} delimiter
+ * @param {string} string
+ * @param {number} limit
+ *
+ * @returns {string[]}
+ */
+const explode = (delimiter, string, limit = undefined) => {
+    if ('' === delimiter) {
+        return [string];
+    }
+
+    const parts = string.split(delimiter);
+
+    if (undefined === limit || 0 === limit) {
+        return parts;
+    }
+
+    if (limit > 0) {
+        return parts.slice(0, limit - 1).concat(parts.slice(limit - 1).join(delimiter));
+    }
+
+    if (limit < 0) {
+        return parts.slice(0, limit);
+    }
+}
+
 export {
     r,
     ag_set,
@@ -442,4 +471,5 @@ export {
     makePagination,
     TOOLTIP_DATE_FORMAT,
     makeSecret,
+    explode,
 }

--- a/src/API/Backends/AccessToken.php
+++ b/src/API/Backends/AccessToken.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\API\Backends;
+
+use App\Libs\Attributes\Route\Post;
+use App\Libs\DataUtil;
+use App\Libs\Exceptions\InvalidArgumentException;
+use App\Libs\HTTP_STATUS;
+use App\Libs\Traits\APITraits;
+use Psr\Http\Message\ResponseInterface as iResponse;
+use Psr\Http\Message\ServerRequestInterface as iRequest;
+use Throwable;
+
+final class AccessToken
+{
+    use APITraits;
+
+    public const string URL = Index::URL . '/accesstoken';
+
+    #[Post(self::URL . '/{type}[/]', name: 'backends.get.accesstoken')]
+    public function __invoke(iRequest $request, array $args = []): iResponse
+    {
+        if (null === ($type = ag($args, 'type'))) {
+            return api_error('Invalid value for type path parameter.', HTTP_STATUS::HTTP_BAD_REQUEST);
+        }
+
+        $params = DataUtil::fromRequest($request);
+        $username = $params->get('username');
+        $password = $params->get('password');
+
+        if (empty($username) || empty($password)) {
+            return api_error('Invalid username or password.', HTTP_STATUS::HTTP_BAD_REQUEST);
+        }
+
+        if (false === in_array($type, ['jellyfin', 'emby'])) {
+            return api_error('Access token endpoint only supported on jellyfin, emby.', HTTP_STATUS::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            $client = $this->getBasicClient($type, $params->with('token', 'accesstoken_request'));
+        } catch (InvalidArgumentException $e) {
+            return api_error($e->getMessage(), HTTP_STATUS::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            $info = $client->generateAccessToken($username, $password);
+        } catch (Throwable $e) {
+            return api_error($e->getMessage(), HTTP_STATUS::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        return api_response(HTTP_STATUS::HTTP_OK, $info);
+    }
+}

--- a/src/API/Backends/Users.php
+++ b/src/API/Backends/Users.php
@@ -24,14 +24,15 @@ final class Users
             return api_error('Invalid value for type path parameter.', HTTP_STATUS::HTTP_BAD_REQUEST);
         }
 
+        $params = DataUtil::fromRequest($request, true);
+
         try {
-            $client = $this->getBasicClient($type, DataUtil::fromRequest($request, true));
+            $client = $this->getBasicClient($type, $params);
         } catch (InvalidArgumentException $e) {
             return api_error($e->getMessage(), HTTP_STATUS::HTTP_BAD_REQUEST);
         }
 
         $users = $opts = [];
-        $params = DataUtil::fromRequest($request, true);
 
         if (true === (bool)$params->get('tokens', false)) {
             $opts['tokens'] = true;

--- a/src/Backends/Common/ClientInterface.php
+++ b/src/Backends/Common/ClientInterface.php
@@ -295,4 +295,15 @@ interface ClientInterface
      */
     public function getVersion(array $opts = []): string;
 
+    /**
+     * Generate Access Token
+     *
+     * @param string|int $identifier username.
+     * @param string $password password.
+     * @param array $opts options.
+     *
+     * @return array
+     */
+    public function generateAccessToken(string|int $identifier, string $password, array $opts = []): array;
+
 }

--- a/src/Backends/Common/ClientInterface.php
+++ b/src/Backends/Common/ClientInterface.php
@@ -306,4 +306,10 @@ interface ClientInterface
      */
     public function generateAccessToken(string|int $identifier, string $password, array $opts = []): array;
 
+    /**
+     * Get The client specific Guid parser.
+     *
+     * @return GuidInterface
+     */
+    public function getGuid(): GuidInterface;
 }

--- a/src/Backends/Common/Context.php
+++ b/src/Backends/Common/Context.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Backends\Common;
 
+use App\Libs\Options;
 use Psr\Http\Message\UriInterface;
 
 readonly class Context
@@ -34,5 +35,18 @@ readonly class Context
         public bool $trace = false,
         public array $options = []
     ) {
+    }
+
+    /**
+     * Check if the used token is limited access token.
+     *
+     * @param bool $withUser Include user check.
+     *
+     * @return bool
+     */
+    public function isLimitedToken(bool $withUser = false): bool
+    {
+        $status = true === (bool)ag($this->options, Options::IS_LIMITED_TOKEN, false);
+        return true === $withUser ? $status && null !== $this->backendUser : $status;
     }
 }

--- a/src/Backends/Emby/Action/GenerateAccessToken.php
+++ b/src/Backends/Emby/Action/GenerateAccessToken.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backends\Emby\Action;
+
+final class GenerateAccessToken extends \App\Backends\Jellyfin\Action\GenerateAccessToken
+{
+    protected string $action = 'emby.generateAccessToken';
+}

--- a/src/Backends/Emby/Action/GetUser.php
+++ b/src/Backends/Emby/Action/GetUser.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backends\Emby\Action;
+
+final class GetUser extends \App\Backends\Jellyfin\Action\GetUsersList
+{
+    protected string $action = 'emby.getUser';
+}

--- a/src/Backends/Emby/EmbyClient.php
+++ b/src/Backends/Emby/EmbyClient.php
@@ -629,6 +629,14 @@ class EmbyClient implements iClient
     }
 
     /**
+     * @inheritdoc
+     */
+    public function getGuid(): iGuid
+    {
+        return $this->guid;
+    }
+
+    /**
      * Throws an exception with the specified message and previous exception.
      *
      * @template T

--- a/src/Backends/Jellyfin/Action/GenerateAccessToken.php
+++ b/src/Backends/Jellyfin/Action/GenerateAccessToken.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backends\Jellyfin\Action;
+
+use App\Backends\Common\CommonTrait;
+use App\Backends\Common\Context;
+use App\Backends\Common\Error;
+use App\Backends\Common\Levels;
+use App\Backends\Common\Response;
+use App\Libs\Config;
+use App\Libs\Options;
+use JsonException;
+use Psr\Log\LoggerInterface as iLogger;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface as iHttp;
+
+/**
+ * Class Generate Access token.
+ *
+ * This class is responsible for generating the access token for Jellyfin API.
+ */
+class GenerateAccessToken
+{
+    use CommonTrait;
+
+    /**
+     * @var string Action name.
+     */
+    protected string $action = 'jellyfin.generateAccessToken';
+
+    /**
+     * Class Constructor.
+     *
+     * @param iHttp $http The HTTP client instance.
+     * @param iLogger $logger The logger instance.
+     */
+    public function __construct(protected iHttp $http, protected iLogger $logger)
+    {
+    }
+
+    /**
+     * Generate Access Token.
+     *
+     * @param Context $context The context instance.
+     * @param string|int $identifier
+     * @param string $password
+     * @param array $opts Additional options.
+     *
+     * @return Response The response received.
+     */
+    public function __invoke(Context $context, string|int $identifier, string $password, array $opts = []): Response
+    {
+        return $this->tryResponse(
+            context: $context,
+            fn: fn() => $this->generateToken($context, $identifier, $password, $opts),
+            action: $this->action
+        );
+    }
+
+    /**
+     * Generate Access Token.
+     *
+     * @param Context $context The context instance.
+     * @param string|int $identifier
+     * @param string $password
+     * @param array $opts Additional options.
+     *
+     * @return Response The response received.
+     * @throws JsonException When the response is not a valid JSON.
+     * @throws ExceptionInterface When the request fails.
+     */
+    private function generateToken(
+        Context $context,
+        string|int $identifier,
+        string $password,
+        array $opts = []
+    ): Response {
+        $url = $context->backendUrl->withPath('/Users/AuthenticateByName');
+
+        $this->logger->debug("Requesting '{backend}' to generate access token for '{username}'.", [
+            'username' => (string)$identifier,
+            'backend' => $context->backendName,
+            'url' => (string)$url,
+        ]);
+
+        $response = $this->http->request('POST', (string)$url, [
+            'json' => [
+                'Username' => (string)$identifier,
+                'Pw' => $password,
+            ],
+            'headers' => [
+                'Accept' => 'application/json',
+                'Authorization' => r(
+                    '{Agent} Client="{app}", Device="{os}", DeviceId="{id}", Version="{version}"',
+                    [
+                        'Agent' => 'Emby' == $context->clientName ? 'Emby' : 'MediaBrowser',
+                        'app' => Config::get('name') . '/' . $context->clientName,
+                        'os' => PHP_OS,
+                        'id' => md5(Config::get('name') . '/' . $context->clientName),
+                        'version' => getAppVersion(),
+                    ]
+                ),
+            ],
+        ]);
+
+        if (200 !== $response->getStatusCode()) {
+            return new Response(
+                status: false,
+                error: new Error(
+                    message: "Request for '{client}: {backend}' to generate access for '{username}' token returned with unexpected '{status_code}' status code. {body}",
+                    context: [
+                        'client' => $context->clientName,
+                        'backend' => $context->backendName,
+                        'username' => (string)$identifier,
+                        'status_code' => $response->getStatusCode(),
+                        'body' => $response->getContent(false),
+                    ],
+                    level: Levels::ERROR
+                ),
+            );
+        }
+
+        $json = json_decode(
+            json: $response->getContent(),
+            associative: true,
+            flags: JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_IGNORE
+        );
+
+        if ($context->trace) {
+            $this->logger->debug("Parsing '{backend}' access token response payload.", [
+                'backend' => $context->backendName,
+                'url' => (string)$url,
+                'trace' => $json,
+            ]);
+        }
+
+        $info = [
+            'user' => ag($json, 'User.Id'),
+            'identifier' => ag($json, 'ServerId'),
+            'accesstoken' => ag($json, 'AccessToken'),
+            'username' => ag($json, 'User.Name'),
+        ];
+
+        if (true === ag_exists($opts, Options::RAW_RESPONSE)) {
+            $info[Options::RAW_RESPONSE] = $json;
+        }
+
+        return new Response(status: true, response: $info);
+    }
+}

--- a/src/Backends/Jellyfin/Action/GetLibrary.php
+++ b/src/Backends/Jellyfin/Action/GetLibrary.php
@@ -126,6 +126,12 @@ class GetLibrary
             );
         }
 
+        $extraQueryParams = [];
+
+        if (null !== ($limit = ag($opts, Options::LIMIT_RESULTS))) {
+            $extraQueryParams['Limit'] = (int)$limit;
+        }
+
         $url = $context->backendUrl->withPath(
             r('/Users/{user_id}/items/', ['user_id' => $context->backendUser])
         )->withQuery(
@@ -135,7 +141,8 @@ class GetLibrary
                 'enableImages' => 'false',
                 'excludeLocationTypes' => 'Virtual',
                 'include' => implode(',', [JellyfinClient::TYPE_SHOW, JellyfinClient::TYPE_MOVIE]),
-                'fields' => implode(',', JellyfinClient::EXTRA_FIELDS)
+                'fields' => implode(',', JellyfinClient::EXTRA_FIELDS),
+                ...$extraQueryParams,
             ])
         );
 

--- a/src/Backends/Jellyfin/Action/GetUsersList.php
+++ b/src/Backends/Jellyfin/Action/GetUsersList.php
@@ -65,7 +65,7 @@ class GetUsersList
      */
     private function getUsers(Context $context, array $opts = []): Response
     {
-        if (true === (bool)ag($context->options, Options::IS_LIMITED_TOKEN, false) && null !== $context->backendUser) {
+        if ($context->isLimitedToken(true) && false === (bool)ag($opts, Options::NO_FALLBACK, false)) {
             $limited = Container::get(GetUser::class)($context);
             if ($limited->isSuccessful()) {
                 return new Response(status: true, response: [$limited->response]);

--- a/src/Backends/Jellyfin/JellyfinClient.php
+++ b/src/Backends/Jellyfin/JellyfinClient.php
@@ -656,6 +656,14 @@ class JellyfinClient implements iClient
     /**
      * @inheritdoc
      */
+    public function getGuid(): iGuid
+    {
+        return $this->guid;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public static function manage(array $backend, array $opts = []): array
     {
         return Container::get(JellyfinManage::class)->manage(backend: $backend, opts: $opts);

--- a/src/Backends/Plex/Action/GetLibrariesList.php
+++ b/src/Backends/Plex/Action/GetLibrariesList.php
@@ -10,6 +10,7 @@ use App\Backends\Common\Error;
 use App\Backends\Common\Levels;
 use App\Backends\Common\Response;
 use App\Backends\Plex\PlexClient;
+use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Exceptions\RuntimeException;
 use App\Libs\Options;
 use DateInterval;
@@ -112,6 +113,12 @@ final class GetLibrariesList
                 ])
             );
 
+            $contentType = match ($type) {
+                PlexClient::TYPE_SHOW => iState::TYPE_SHOW,
+                PlexClient::TYPE_MOVIE => iState::TYPE_MOVIE,
+                default => 'Unknown',
+            };
+
             $builder = [
                 'id' => $key,
                 'title' => ag($section, 'title', '???'),
@@ -120,6 +127,7 @@ final class GetLibrariesList
                 'supported' => $supportedType && true === in_array($agent, PlexClient::SUPPORTED_AGENTS),
                 'agent' => ag($section, 'agent'),
                 'scanner' => ag($section, 'scanner'),
+                'contentType' => $contentType,
                 'webUrl' => (string)$webUrl,
             ];
 

--- a/src/Backends/Plex/Action/GetLibrary.php
+++ b/src/Backends/Plex/Action/GetLibrary.php
@@ -110,6 +110,15 @@ final class GetLibrary
             );
         }
 
+        $extraHeaders = [
+            'headers' => [],
+        ];
+
+        if (null !== ($limit = ag($opts, Options::LIMIT_RESULTS))) {
+            $extraHeaders['headers']['X-Plex-Container-Start'] = 0;
+            $extraHeaders['headers']['X-Plex-Container-Size'] = (int)$limit;
+        }
+
         $url = $context->backendUrl
             ->withPath(r('/library/sections/{library_id}/all', ['library_id' => $id]))
             ->withQuery(
@@ -126,7 +135,11 @@ final class GetLibrary
             ...$logContext,
         ]);
 
-        $response = $this->http->request('GET', (string)$url, $context->backendHeaders);
+        $response = $this->http->request(
+            'GET',
+            (string)$url,
+            array_replace_recursive($context->backendHeaders, $extraHeaders)
+        );
 
         if (200 !== $response->getStatusCode()) {
             return new Response(

--- a/src/Backends/Plex/PlexClient.php
+++ b/src/Backends/Plex/PlexClient.php
@@ -761,6 +761,14 @@ class PlexClient implements iClient
     }
 
     /**
+     * @inheritdoc
+     */
+    public function getGuid(): iGuid
+    {
+        return $this->guid;
+    }
+
+    /**
      * Throws an exception with the specified message and previous exception.
      *
      * @template T

--- a/src/Backends/Plex/PlexClient.php
+++ b/src/Backends/Plex/PlexClient.php
@@ -632,6 +632,14 @@ class PlexClient implements iClient
     /**
      * @inheritdoc
      */
+    public function generateAccessToken(string|int $identifier, string $password, array $opts = []): array
+    {
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
     public static function manage(array $backend, array $opts = []): array
     {
         return Container::get(PlexManage::class)->manage(backend: $backend, opts: $opts);

--- a/src/Commands/Config/AddCommand.php
+++ b/src/Commands/Config/AddCommand.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Question\Question;
 #[Cli(command: self::ROUTE)]
 final class AddCommand extends Command
 {
-    public const ROUTE = 'config:add';
+    public const string ROUTE = 'config:add';
 
     /**
      * Configures the command.

--- a/src/Commands/Config/TestCommand.php
+++ b/src/Commands/Config/TestCommand.php
@@ -10,23 +10,37 @@ use App\Backends\Emby\Action\GetUser as jf_GetUser;
 use App\Backends\Jellyfin\Action\GetIdentifier as jf_GetIdentifier;
 use App\Backends\Jellyfin\Action\GetInfo as jf_GetInfo;
 use App\Backends\Jellyfin\Action\GetLibrariesList as jf_GetLibrariesList;
+use App\Backends\Jellyfin\Action\GetLibrary as jf_GetLibrary;
+use App\Backends\Jellyfin\Action\GetMetaData as jf_GetMetaData;
 use App\Backends\Jellyfin\Action\GetSessions as jf_GetSessions;
 use App\Backends\Jellyfin\Action\GetUsersList as jf_GetUsersList;
 use App\Backends\Jellyfin\Action\GetVersion as jf_GetVersion;
+use App\Backends\Jellyfin\Action\GetWebUrl as jf_GetWebUrl;
+use App\Backends\Jellyfin\Action\SearchId as jf_SearchId;
+use App\Backends\Jellyfin\Action\SearchQuery as jf_SearchQuery;
+use App\Backends\Jellyfin\Action\ToEntity as jf_ToEntity;
 use App\Backends\Plex\Action\GetIdentifier as plex_GetIdentifier;
 use App\Backends\Plex\Action\GetInfo as plex_GetInfo;
 use App\Backends\Plex\Action\GetLibrariesList as plex_GetLibrariesList;
+use App\Backends\Plex\Action\GetLibrary as plex_GetLibrary;
+use App\Backends\Plex\Action\GetMetaData as plex_GetMetaData;
 use App\Backends\Plex\Action\GetSessions as plex_GetSessions;
 use App\Backends\Plex\Action\GetUser as plex_GetUser;
 use App\Backends\Plex\Action\GetUsersList as plex_GetUsersList;
-use App\Backends\Plex\Action\GetVersion as plex_GetVersionAlias;
+use App\Backends\Plex\Action\GetVersion as plex_GetVersion;
+use App\Backends\Plex\Action\GetWebUrl as plex_GetWebUrl;
+use App\Backends\Plex\Action\SearchId as plex_SearchId;
+use App\Backends\Plex\Action\SearchQuery as plex_SearchQuery;
+use App\Backends\Plex\Action\ToEntity as plex_ToEntity;
 use App\Command;
 use App\Libs\Attributes\Route\Cli;
 use App\Libs\Config;
 use App\Libs\ConfigFile;
 use App\Libs\Container;
+use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Options;
 use Closure;
+use InvalidArgumentException;
 use Psr\Log\LoggerInterface as iLogger;
 use Symfony\Component\Console\Input\InputInterface as iInput;
 use Symfony\Component\Console\Input\InputOption;
@@ -48,6 +62,8 @@ final class TestCommand extends Command
 
     private const string SKIP = '<notice>SK</notice>';
 
+    private bool $runExtended = false;
+
     private iOutput|null $output = null;
 
     public function __construct(private iLogger $logger)
@@ -67,6 +83,12 @@ final class TestCommand extends Command
                 's',
                 InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL,
                 'Select backend.'
+            )
+            ->addOption(
+                'run-extended',
+                'e',
+                InputOption::VALUE_NONE,
+                'Run extended tests. It will be slower as it will test all possible actions.'
             )
             ->setHelp(
                 <<<HELP
@@ -103,6 +125,8 @@ final class TestCommand extends Command
     protected function process(iInput $input, iOutput $output): int
     {
         $this->output = $output;
+        $this->runExtended = (bool)$input->getOption('run-extended');
+
         $configFile = ConfigFile::open(Config::get('backends_file'), 'yaml');
         $configFile->setLogger($this->logger);
 
@@ -143,14 +167,23 @@ final class TestCommand extends Command
         return self::SUCCESS;
     }
 
-    private function assert(Closure|bool|null $fn, string $message): void
+    private function assert(Closure|bool|null $fn, string $message = ''): void
     {
-        $status = null === $fn ? null : (is_bool($fn) ? $fn : $fn());
+        if (empty($message)) {
+            if (false === ($fn instanceof Closure)) {
+                throw new InvalidArgumentException(
+                    'When no message is provided, the first argument must be a closure.'
+                );
+            }
+            $fn();
+            return;
+        }
 
+        $status = null === $fn ? null : (is_bool($fn) ? $fn : $fn());
         $this->output?->writeln(r('[{status}] {message}', [
             'message' => trim($message),
             'status' => null === $status ? self::SKIP : ($status ? self::OK : self::ERROR)
-        ]));
+        ]), null === $status ? iOutput::VERBOSITY_VERY_VERBOSE : iOutput::OUTPUT_NORMAL);
     }
 
     private function test_plex_client(iClient $client, Context $context): void
@@ -159,26 +192,158 @@ final class TestCommand extends Command
         $this->assert($client->getType() === $context->clientName, 'getType');
         $this->assert($client->getName() === $context->backendName, 'getName');
 
-        $this->assert(Container::get(plex_GetInfo::class)($context)->isSuccessful(), 'getInfo');
-        $this->assert(Container::get(plex_GetIdentifier::class)($context)->isSuccessful(), 'getIdentifier');
-        $this->assert(Container::get(plex_GetLibrariesList::class)($context)->isSuccessful(), 'getLibrariesList');
-        $this->assert(Container::get(plex_GetSessions::class)($context)->isSuccessful(), 'getSessions');
-        $this->assert(Container::get(plex_GetUser::class)($context)->isSuccessful(), 'getUser');
-        $this->assert(Container::get(plex_GetUsersList::class)($context)->isSuccessful(), 'getUsersList');
-        $this->assert(Container::get(plex_GetVersionAlias::class)($context)->isSuccessful(), 'getVersion');
+        $getInfo = Container::get(plex_GetInfo::class)($context);
+        $this->assert($getInfo->isSuccessful(), 'getInfo');
+        if (false === $getInfo->isSuccessful()) {
+            $this->output->writeln(r('<error>{error}</error>', [
+                'error' => $getInfo->hasError() ? $getInfo->error->format() : '',
+            ]), iOutput::VERBOSITY_VERBOSE);
+        }
+        $getIdentifier = Container::get(plex_GetIdentifier::class)($context);
+        $this->assert($getIdentifier->isSuccessful(), 'getIdentifier');
+        if (false === $getIdentifier->isSuccessful()) {
+            $this->output->writeln(r('<error>{error}</error>', [
+                'error' => $getIdentifier->hasError() ? $getIdentifier->error->format() : '',
+            ]), iOutput::VERBOSITY_VERBOSE);
+        }
+
+        $getSessions = Container::get(plex_GetSessions::class)($context);
+        $this->assert($getSessions->isSuccessful(), 'getSessions');
+        if (false === $getSessions->isSuccessful()) {
+            $this->output->writeln(r('<error>{error}</error>', [
+                'error' => $getSessions->hasError() ? $getSessions->error->format() : '',
+            ]), iOutput::VERBOSITY_VERBOSE);
+        }
+
+        $getUser = Container::get(plex_GetUser::class)($context);
+        $this->assert($getUser->isSuccessful(), 'getUser');
+        if (false === $getUser->isSuccessful()) {
+            $this->output->writeln(r('<error>{error}</error>', [
+                'error' => $getUser->hasError() ? $getUser->error->format() : '',
+            ]), iOutput::VERBOSITY_VERBOSE);
+        }
+
+        $getUsersList = Container::get(plex_GetUsersList::class)($context);
+        $this->assert($getUsersList->isSuccessful(), 'getUsersList');
+        if (false === $getUsersList->isSuccessful()) {
+            $this->output->writeln(r('<error>{error}</error>', [
+                'error' => $getUsersList->hasError() ? $getUsersList->error->format() : '',
+            ]), iOutput::VERBOSITY_VERBOSE);
+        }
+
+        $getVersion = Container::get(plex_GetVersion::class)($context);
+        $this->assert($getVersion->isSuccessful(), 'getVersion');
+        if (false === $getVersion->isSuccessful()) {
+            $this->output->writeln(r('<error>{error}</error>', [
+                'error' => $getVersion->hasError() ? $getVersion->error->format() : '',
+            ]), iOutput::VERBOSITY_VERBOSE);
+        }
+
+        $this->assert(function () use ($context, $client) {
+            $libraries = Container::get(plex_GetLibrariesList::class)($context, [Options::NO_CACHE => true]);
+            $this->assert($libraries->isSuccessful(), 'GetLibrariesList');
+
+            if (false === $libraries->isSuccessful()) {
+                $this->output->writeln(r('<error>{error}</error>', [
+                    'error' => $libraries->hasError() ? $libraries->error->format() : '',
+                ]), iOutput::VERBOSITY_VERBOSE);
+                return false;
+            }
+
+            // -- get first library that isn't ignored and is supported.
+            $lib = current(array_filter($libraries->response, function ($i) {
+                return true === (bool)ag($i, 'supported', false) && false === (bool)ag($i, 'ignored');
+            }));
+
+            if (empty($lib)) {
+                $this->assert(null, 'GetLibrary');
+                return $libraries->isSuccessful();
+            }
+
+            $library = Container::get(plex_GetLibrary::class)($context, $client->getGuid(), ag($lib, 'id'), [
+                Options::LIMIT_RESULTS => 10,
+                Options::NO_CACHE => true,
+            ]);
+
+            $this->assert($library->isSuccessful(), 'GetLibrary');
+
+            if (false === $library->isSuccessful()) {
+                $this->output->writeln(r('<error>{error}</error>', [
+                    'error' => $libraries->hasError() ? $libraries->error->format() : '',
+                ]), iOutput::VERBOSITY_VERBOSE);
+                return false;
+            }
+
+            $item = current($library->response);
+            if (empty($item)) {
+                $this->assert(null, 'GetMetaData');
+            }
+
+            $item = Container::get(plex_GetMetaData::class)($context, ag($item, 'id'));
+            $this->assert($item->isSuccessful(), 'GetMetaData');
+
+            if (false === $item->isSuccessful()) {
+                $this->output->writeln(r('<error>{error}</error>', [
+                    'error' => $item->hasError() ? $item->error->format() : '',
+                ]), iOutput::VERBOSITY_VERBOSE);
+                return false;
+            }
+
+            $toEntity = Container::get(plex_ToEntity::class)(
+                $context,
+                ag($item->response, 'MediaContainer.Metadata.0')
+            );
+            $this->assert($toEntity->isSuccessful(), 'ToEntity');
+            if (false === $toEntity->isSuccessful()) {
+                $this->output->writeln(r('<error>{error}</error>', [
+                    'error' => $toEntity->hasError() ? $toEntity->error->format() : '',
+                ]), iOutput::VERBOSITY_VERBOSE);
+                return false;
+            }
+
+            $entity = $toEntity->response;
+            assert($entity instanceof iState);
+
+            $itemId = ag($entity->getMetadata($entity->via), iState::COLUMN_ID);
+
+            $getWebUrl = Container::get(plex_GetWebUrl::class)($context, $entity->type, $itemId);
+            $this->assert($getWebUrl->isSuccessful(), 'GetWebUrl');
+            if (false === $getWebUrl->isSuccessful()) {
+                $this->output->writeln(r('<error>{error}</error>', [
+                    'error' => $getWebUrl->hasError() ? $getWebUrl->error->format() : '',
+                ]), iOutput::VERBOSITY_VERBOSE);
+            }
+            $searchId = Container::get(plex_SearchId::class)($context, $itemId);
+            $this->assert($searchId->isSuccessful(), 'SearchId');
+            if (false === $searchId->isSuccessful()) {
+                $this->output->writeln(r('<error>{error}</error>', [
+                    'error' => $searchId->hasError() ? $searchId->error->format() : '',
+                ]), iOutput::VERBOSITY_VERBOSE);
+            }
+
+            $searchQuery = Container::get(plex_SearchQuery::class)($context, $entity->title, 1);
+            $this->assert($searchQuery->isSuccessful(), 'SearchQuery');
+            if (false === $searchQuery->isSuccessful()) {
+                $this->output->writeln(r('<error>{error}</error>', [
+                    'error' => $searchQuery->hasError() ? $searchQuery->error->format() : '',
+                ]), iOutput::VERBOSITY_VERBOSE);
+            }
+
+            return true;
+        });
+
+        if (false === $this->runExtended) {
+            return;
+        }
 
         // -- unimplemented tests
-        $this->assert(null, 'GetLibrary');
-        $this->assert(null, 'GetMetaData');
-        $this->assert(null, 'GetWebUrl');
         $this->assert(null, 'Import');
+        $this->assert(null, 'Export');
+        $this->assert(null, 'Backup');
         $this->assert(null, 'InspectRequest');
         $this->assert(null, 'ParseWebhook');
         $this->assert(null, 'Progress');
         $this->assert(null, 'Push');
-        $this->assert(null, 'SearchId');
-        $this->assert(null, 'SearchQuery');
-        $this->assert(null, 'ToEntity');
     }
 
     private function test_emby_client(iClient $client, Context $context): void
@@ -192,32 +357,174 @@ final class TestCommand extends Command
         $this->assert($client->getType() === $context->clientName, 'getType');
         $this->assert($client->getName() === $context->backendName, 'getName');
 
-        $this->assert(Container::get(jf_GetInfo::class)($context)->isSuccessful(), 'getInfo');
-        $this->assert(Container::get(jf_GetIdentifier::class)($context)->isSuccessful(), 'getIdentifier');
-        $this->assert(Container::get(jf_GetLibrariesList::class)($context)->isSuccessful(), 'getLibrariesList');
-        $this->assert(Container::get(jf_GetSessions::class)($context)->isSuccessful(), 'getSessions');
-        $this->assert(Container::get(jf_GetUser::class)($context)->isSuccessful(), 'getUser');
-        $this->assert(Container::get(jf_GetUsersList::class)($context)->isSuccessful(), 'getUsersList with fallback');
+        $getInfo = Container::get(jf_GetInfo::class)($context);
+        $this->assert($getInfo->isSuccessful(), 'getInfo');
+        if (false === $getInfo->isSuccessful()) {
+            $this->output->writeln(r('<error>{error}</error>', [
+                'error' => $getInfo->hasError() ? $getInfo->error->format() : '',
+            ]), iOutput::VERBOSITY_VERBOSE);
+        }
+
+        $getIdentifier = Container::get(jf_GetIdentifier::class)($context);
+        $this->assert($getIdentifier->isSuccessful(), 'getIdentifier');
+        if (false === $getIdentifier->isSuccessful()) {
+            $this->output->writeln(r('<error>{error}</error>', [
+                'error' => $getIdentifier->hasError() ? $getIdentifier->error->format() : '',
+            ]), iOutput::VERBOSITY_VERBOSE);
+        }
+
+        $getSessions = Container::get(jf_GetSessions::class)($context);
+        $this->assert($getSessions->isSuccessful(), 'getSessions');
+        if (false === $getSessions->isSuccessful()) {
+            $this->output->writeln(r('<error>{error}</error>', [
+                'error' => $getSessions->hasError() ? $getSessions->error->format() : '',
+            ]), iOutput::VERBOSITY_VERBOSE);
+        }
+
+        $getUser = Container::get(jf_GetUser::class)($context);
+        $this->assert($getUser->isSuccessful(), 'getUser');
+        if (false === $getUser->isSuccessful()) {
+            $this->output->writeln(r('<error>{error}</error>', [
+                'error' => $getUser->hasError() ? $getUser->error->format() : '',
+            ]), iOutput::VERBOSITY_VERBOSE);
+        }
+
+        $getUsersWithFallBack = Container::get(jf_GetUsersList::class)($context);
+        $this->assert($getUsersWithFallBack->isSuccessful(), 'getUsersList with fallback');
+        if (false === $getUsersWithFallBack->isSuccessful()) {
+            $this->output->writeln(r('<error>{error}</error>', [
+                'error' => $getUsersWithFallBack->hasError() ? $getUsersWithFallBack->error->format() : '',
+            ]), iOutput::VERBOSITY_VERBOSE);
+        }
 
         // -- if the token is limited and with no_fallback, the test should return false as the token doesn't have
         // -- access to the users list.
-        $gul = Container::get(jf_GetUsersList::class)($context, [Options::NO_FALLBACK => true])->isSuccessful();
-        $gul = ($context->isLimitedToken()) ? !(true === $gul) : $gul;
-        $this->assert($gul, 'getUsersList no_fallback');
+        $getUsersWithOutFallBack = Container::get(jf_GetUsersList::class)($context, [
+            Options::NO_FALLBACK => true
+        ]);
+        $gul_status = ($context->isLimitedToken()) ? !(true === $getUsersWithOutFallBack->isSuccessful(
+            )) : $getUsersWithOutFallBack->isSuccessful();
+        $this->assert($gul_status, 'getUsersList with no fallback');
+        if (false === $gul_status) {
+            $this->output->writeln(r('<error>{error}</error>', [
+                'error' => $getUsersWithOutFallBack->hasError() ? $getUsersWithOutFallBack->error->format() : '',
+            ]), iOutput::VERBOSITY_VERBOSE);
+        }
 
-        $this->assert(Container::get(jf_GetVersion::class)($context)->isSuccessful(), 'getVersion');
+        $getVersion = Container::get(jf_GetVersion::class)($context);
+        $this->assert($getVersion->isSuccessful(), 'getVersion');
+        if (false === $getVersion->isSuccessful()) {
+            $this->output->writeln(r('<error>{error}</error>', [
+                'error' => $getVersion->hasError() ? $getVersion->error->format() : '',
+            ]), iOutput::VERBOSITY_VERBOSE);
+        }
+
+        // -- Library related tests, they are grouped as they need each other to run.
+        $this->assert(function () use ($context, $client) {
+            $libraries = Container::get(jf_GetLibrariesList::class)($context, [Options::NO_CACHE => true]);
+            $status = $libraries->isSuccessful();
+
+            $this->assert($status, 'GetLibrariesList');
+
+            if (false === $status) {
+                $this->output->writeln(r('<error>{error}</error>', [
+                    'error' => $libraries->hasError() ? $libraries->error->format() : '',
+                ]), iOutput::VERBOSITY_VERBOSE);
+                return false;
+            }
+
+            // -- get first library that isn't ignored and is supported.
+            $lib = current(array_filter($libraries->response, function ($i) {
+                return true === (bool)ag($i, 'supported', false) && false === (bool)ag($i, 'ignored');
+            }));
+
+            if (empty($lib)) {
+                $this->assert(null, 'GetLibrary');
+                return false;
+            }
+
+            $library = Container::get(jf_GetLibrary::class)($context, $client->getGuid(), ag($lib, 'id'), [
+                Options::LIMIT_RESULTS => 10,
+            ]);
+
+            $this->assert($library->isSuccessful(), 'GetLibrary');
+
+            if (false === $library->isSuccessful()) {
+                $this->output->writeln(r('<error>{error}</error>', [
+                    'error' => $library->hasError() ? $library->error->format() : '',
+                ]), iOutput::VERBOSITY_VERBOSE);
+                return false;
+            }
+
+            $item = current($library->response);
+            if (empty($item)) {
+                $this->assert(null, 'GetMetaData');
+                return false;
+            }
+
+            $item = Container::get(jf_GetMetaData::class)($context, ag($item, 'id'));
+            $this->assert($item->isSuccessful(), 'GetMetaData');
+
+            if (false === $item->isSuccessful()) {
+                $this->output->writeln(r('<error>{error}</error>', [
+                    'error' => $item->hasError() ? $item->error->format() : '',
+                ]), iOutput::VERBOSITY_VERBOSE);
+                return false;
+            }
+
+            $toEntity = Container::get(jf_ToEntity::class)($context, $item->response);
+            $this->assert($toEntity->isSuccessful(), 'ToEntity');
+
+            if (false === $toEntity->isSuccessful()) {
+                $this->output->writeln(r('<error>{error}</error>', [
+                    'error' => $toEntity->hasError() ? $toEntity->error->format() : '',
+                ]), iOutput::VERBOSITY_VERBOSE);
+                return false;
+            }
+
+            $entity = $toEntity->response;
+            assert($entity instanceof iState);
+
+            $itemId = ag($entity->getMetadata($entity->via), iState::COLUMN_ID);
+
+            $getWebUrl = Container::get(jf_GetWebUrl::class)($context, $entity->type, $itemId);
+            $this->assert($getWebUrl->isSuccessful(), 'GetWebUrl');
+            if (false === $getWebUrl->isSuccessful()) {
+                $this->output->writeln(r('<error>{error}</error>', [
+                    'error' => $getWebUrl->hasError() ? $getWebUrl->error->format() : '',
+                ]), iOutput::VERBOSITY_VERBOSE);
+            }
+
+            $searchId = Container::get(jf_SearchId::class)($context, ag($item->response, 'Id'));
+            $this->assert($searchId->isSuccessful(), 'SearchId');
+            if (false === $searchId->isSuccessful()) {
+                $this->output->writeln(r('<error>{error}</error>', [
+                    'error' => $searchId->hasError() ? $searchId->error->format() : '',
+                ]), iOutput::VERBOSITY_VERBOSE);
+            }
+
+            $searchQuery = Container::get(jf_SearchQuery::class)($context, $entity->title, 1);
+            $this->assert($searchQuery->isSuccessful(), 'SearchQuery');
+            if (false === $searchQuery->isSuccessful()) {
+                $this->output->writeln(r('<error>{error}</error>', [
+                    'error' => $searchQuery->hasError() ? $searchQuery->error->format() : '',
+                ]), iOutput::VERBOSITY_VERBOSE);
+            }
+
+            return true;
+        });
+
+        if (false === $this->runExtended) {
+            return;
+        }
 
         // -- unimplemented tests
-        $this->assert(null, 'GetLibrary');
-        $this->assert(null, 'GetMetaData');
-        $this->assert(null, 'GetWebUrl');
         $this->assert(null, 'Import');
+        $this->assert(null, 'Export');
+        $this->assert(null, 'Backup');
         $this->assert(null, 'InspectRequest');
         $this->assert(null, 'ParseWebhook');
         $this->assert(null, 'Progress');
         $this->assert(null, 'Push');
-        $this->assert(null, 'SearchId');
-        $this->assert(null, 'SearchQuery');
-        $this->assert(null, 'ToEntity');
     }
 }

--- a/src/Commands/Config/TestCommand.php
+++ b/src/Commands/Config/TestCommand.php
@@ -144,7 +144,7 @@ final class TestCommand extends Command
         foreach ($backends as $backendName => $backend) {
             $backend = $this->getBackend($backendName);
             $context = $backend->getContext();
-            $output->writeln(r("Running '{client}' functional tests on '{backend}'.", [
+            $output->writeln(r("Running '{client}' client functional tests on '{backend}'.", [
                 'client' => $context->clientName,
                 'backend' => $context->backendName,
             ]));

--- a/src/Commands/Config/TestCommand.php
+++ b/src/Commands/Config/TestCommand.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands\Config;
+
+use App\Backends\Common\ClientInterface as iClient;
+use App\Backends\Common\Context;
+use App\Backends\Emby\Action\GetUser as jf_GetUser;
+use App\Backends\Jellyfin\Action\GetIdentifier as jf_GetIdentifier;
+use App\Backends\Jellyfin\Action\GetInfo as jf_GetInfo;
+use App\Backends\Jellyfin\Action\GetLibrariesList as jf_GetLibrariesList;
+use App\Backends\Jellyfin\Action\GetSessions as jf_GetSessions;
+use App\Backends\Jellyfin\Action\GetUsersList as jf_GetUsersList;
+use App\Backends\Jellyfin\Action\GetVersion as jf_GetVersion;
+use App\Backends\Plex\Action\GetIdentifier as plex_GetIdentifier;
+use App\Backends\Plex\Action\GetInfo as plex_GetInfo;
+use App\Backends\Plex\Action\GetLibrariesList as plex_GetLibrariesList;
+use App\Backends\Plex\Action\GetSessions as plex_GetSessions;
+use App\Backends\Plex\Action\GetUser as plex_GetUser;
+use App\Backends\Plex\Action\GetUsersList as plex_GetUsersList;
+use App\Backends\Plex\Action\GetVersion as plex_GetVersionAlias;
+use App\Command;
+use App\Libs\Attributes\Route\Cli;
+use App\Libs\Config;
+use App\Libs\ConfigFile;
+use App\Libs\Container;
+use App\Libs\Options;
+use Closure;
+use Psr\Log\LoggerInterface as iLogger;
+use Symfony\Component\Console\Input\InputInterface as iInput;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface as iOutput;
+
+/**
+ * Class CheckCommand
+ *
+ * Perform a check on all possible actions.
+ */
+#[Cli(command: self::ROUTE)]
+final class TestCommand extends Command
+{
+    public const string ROUTE = 'config:test';
+
+    private const string OK = '<info>OK</info>';
+
+    private const string ERROR = '<error>FA</error>';
+
+    private const string SKIP = '<notice>SK</notice>';
+
+    private iOutput|null $output = null;
+
+    public function __construct(private iLogger $logger)
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Configure the command.
+     */
+    protected function configure(): void
+    {
+        $this->setName(self::ROUTE)
+            ->setDescription('Run functional tests on the current configurations.')
+            ->addOption(
+                'select-backend',
+                's',
+                InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL,
+                'Select backend.'
+            )
+            ->setHelp(
+                <<<HELP
+
+                This command will check all possible actions against the current configurations.
+                It will check whether we are able to execute the actions in dry mode of course
+                for state changing requests.
+
+                HELP,
+            );
+    }
+
+    /**
+     * Make sure the command is not running in parallel.
+     *
+     * @param iInput $input The input interface instance.
+     * @param iOutput $output The output interface instance.
+     *
+     * @return int The exit code of the command.
+     */
+    protected function runCommand(iInput $input, iOutput $output): int
+    {
+        return $this->single(fn(): int => $this->process($input, $output), $output);
+    }
+
+    /**
+     * Executes a command.
+     *
+     * @param iInput $input The input object used for retrieving the command arguments and options.
+     * @param iOutput $output The output object used for displaying messages.
+     *
+     * @return int The exit code of the command execution. Returns "SUCCESS" constant value.
+     */
+    protected function process(iInput $input, iOutput $output): int
+    {
+        $this->output = $output;
+        $configFile = ConfigFile::open(Config::get('backends_file'), 'yaml');
+        $configFile->setLogger($this->logger);
+
+        $backends = [];
+        $selected = $input->getOption('select-backend');
+        $isCustom = !empty($selected) && count($selected) > 0;
+
+        foreach ($configFile->getAll() as $backendName => $backend) {
+            if ($isCustom && false === in_array($backendName, $selected)) {
+                continue;
+            }
+            $backends[$backendName] = $backend;
+        }
+
+        foreach ($backends as $backendName => $backend) {
+            $backend = $this->getBackend($backendName);
+            $context = $backend->getContext();
+            $output->writeln(r("Running '{client}' functional tests on '{backend}'.", [
+                'client' => $context->clientName,
+                'backend' => $context->backendName,
+            ]));
+            switch ($context->clientName) {
+                case 'Emby':
+                    $this->test_emby_client($backend, $context);
+                    break;
+                case 'Jellyfin':
+                    $this->test_jellyfin_client($backend, $context);
+                    break;
+                case 'Plex':
+                    $this->test_plex_client($backend, $context);
+                    break;
+                default:
+                    $output->writeln(r("Unknown client '{client}'.", ['client' => $context->clientName]));
+                    break;
+            }
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function assert(Closure|bool|null $fn, string $message): void
+    {
+        $status = null === $fn ? null : (is_bool($fn) ? $fn : $fn());
+
+        $this->output?->writeln(r('[{status}] {message}', [
+            'message' => trim($message),
+            'status' => null === $status ? self::SKIP : ($status ? self::OK : self::ERROR)
+        ]));
+    }
+
+    private function test_plex_client(iClient $client, Context $context): void
+    {
+        $this->assert($client->getContext() === $context, 'getContext');
+        $this->assert($client->getType() === $context->clientName, 'getType');
+        $this->assert($client->getName() === $context->backendName, 'getName');
+
+        $this->assert(Container::get(plex_GetInfo::class)($context)->isSuccessful(), 'getInfo');
+        $this->assert(Container::get(plex_GetIdentifier::class)($context)->isSuccessful(), 'getIdentifier');
+        $this->assert(Container::get(plex_GetLibrariesList::class)($context)->isSuccessful(), 'getLibrariesList');
+        $this->assert(Container::get(plex_GetSessions::class)($context)->isSuccessful(), 'getSessions');
+        $this->assert(Container::get(plex_GetUser::class)($context)->isSuccessful(), 'getUser');
+        $this->assert(Container::get(plex_GetUsersList::class)($context)->isSuccessful(), 'getUsersList');
+        $this->assert(Container::get(plex_GetVersionAlias::class)($context)->isSuccessful(), 'getVersion');
+
+        // -- unimplemented tests
+        $this->assert(null, 'GetLibrary');
+        $this->assert(null, 'GetMetaData');
+        $this->assert(null, 'GetWebUrl');
+        $this->assert(null, 'Import');
+        $this->assert(null, 'InspectRequest');
+        $this->assert(null, 'ParseWebhook');
+        $this->assert(null, 'Progress');
+        $this->assert(null, 'Push');
+        $this->assert(null, 'SearchId');
+        $this->assert(null, 'SearchQuery');
+        $this->assert(null, 'ToEntity');
+    }
+
+    private function test_emby_client(iClient $client, Context $context): void
+    {
+        $this->test_jellyfin_client($client, $context);
+    }
+
+    private function test_jellyfin_client(iClient $client, Context $context): void
+    {
+        $this->assert($client->getContext() === $context, 'getContext');
+        $this->assert($client->getType() === $context->clientName, 'getType');
+        $this->assert($client->getName() === $context->backendName, 'getName');
+
+        $this->assert(Container::get(jf_GetInfo::class)($context)->isSuccessful(), 'getInfo');
+        $this->assert(Container::get(jf_GetIdentifier::class)($context)->isSuccessful(), 'getIdentifier');
+        $this->assert(Container::get(jf_GetLibrariesList::class)($context)->isSuccessful(), 'getLibrariesList');
+        $this->assert(Container::get(jf_GetSessions::class)($context)->isSuccessful(), 'getSessions');
+        $this->assert(Container::get(jf_GetUser::class)($context)->isSuccessful(), 'getUser');
+        $this->assert(Container::get(jf_GetUsersList::class)($context)->isSuccessful(), 'getUsersList with fallback');
+
+        // -- if the token is limited and with no_fallback, the test should return false as the token doesn't have
+        // -- access to the users list.
+        $gul = Container::get(jf_GetUsersList::class)($context, [Options::NO_FALLBACK => true])->isSuccessful();
+        $gul = ($context->isLimitedToken()) ? !(true === $gul) : $gul;
+        $this->assert($gul, 'getUsersList no_fallback');
+
+        $this->assert(Container::get(jf_GetVersion::class)($context)->isSuccessful(), 'getVersion');
+
+        // -- unimplemented tests
+        $this->assert(null, 'GetLibrary');
+        $this->assert(null, 'GetMetaData');
+        $this->assert(null, 'GetWebUrl');
+        $this->assert(null, 'Import');
+        $this->assert(null, 'InspectRequest');
+        $this->assert(null, 'ParseWebhook');
+        $this->assert(null, 'Progress');
+        $this->assert(null, 'Push');
+        $this->assert(null, 'SearchId');
+        $this->assert(null, 'SearchQuery');
+        $this->assert(null, 'ToEntity');
+    }
+}

--- a/src/Libs/Middlewares/APIKeyRequiredMiddleware.php
+++ b/src/Libs/Middlewares/APIKeyRequiredMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Libs\Middlewares;
 
+use App\API\Backends\AccessToken;
 use App\API\System\AutoConfig;
 use App\API\System\HealthCheck;
 use App\Libs\Config;
@@ -24,6 +25,7 @@ final class APIKeyRequiredMiddleware implements MiddlewareInterface
     private const array PUBLIC_ROUTES = [
         HealthCheck::URL,
         AutoConfig::URL,
+        AccessToken::URL,
     ];
 
     /**

--- a/src/Libs/Options.php
+++ b/src/Libs/Options.php
@@ -32,6 +32,7 @@ final class Options
     public const string MAX_EPISODE_RANGE = 'MAX_EPISODE_RANGE';
     public const string IGNORE = 'ignore';
     public const string PLEX_USE_OLD_PROGRESS_ENDPOINT = 'use_old_progress_endpoint';
+    public const string IS_LIMITED_TOKEN = 'is_limited_token';
     public const string TO_ENTITY = 'TO_ENTITY';
 
     private function __construct()

--- a/src/Libs/Options.php
+++ b/src/Libs/Options.php
@@ -34,6 +34,7 @@ final class Options
     public const string PLEX_USE_OLD_PROGRESS_ENDPOINT = 'use_old_progress_endpoint';
     public const string IS_LIMITED_TOKEN = 'is_limited_token';
     public const string TO_ENTITY = 'TO_ENTITY';
+    public const string NO_FALLBACK = 'NO_FALLBACK';
 
     private function __construct()
     {

--- a/src/Libs/Options.php
+++ b/src/Libs/Options.php
@@ -35,6 +35,8 @@ final class Options
     public const string IS_LIMITED_TOKEN = 'is_limited_token';
     public const string TO_ENTITY = 'TO_ENTITY';
     public const string NO_FALLBACK = 'NO_FALLBACK';
+    public const string LIMIT_RESULTS = 'LIMIT_RESULTS';
+    public const string NO_CHECK = 'NO_CHECK';
 
     private function __construct()
     {

--- a/src/Libs/Traits/APITraits.php
+++ b/src/Libs/Traits/APITraits.php
@@ -129,6 +129,10 @@ trait APITraits
             $options[Options::ADMIN_TOKEN] = $data->get('options.' . Options::ADMIN_TOKEN);
         }
 
+        if (null !== $data->get('options.' . Options::IS_LIMITED_TOKEN)) {
+            $options[Options::IS_LIMITED_TOKEN] = (bool)$data->get('options.' . Options::IS_LIMITED_TOKEN, false);
+        }
+
         $instance = Container::getNew($class);
         assert($instance instanceof ClientInterface, new InvalidArgumentException('Invalid client class.'));
         return $instance->withContext(

--- a/tests/Backends/Plex/GetLibrariesListTest.php
+++ b/tests/Backends/Plex/GetLibrariesListTest.php
@@ -87,6 +87,7 @@ class GetLibrariesListTest extends TestCase
                 'supported' => $supportedType && true === in_array($agent, PlexClient::SUPPORTED_AGENTS),
                 'agent' => $agent,
                 'scanner' => ag($item, 'scanner'),
+                'contentType' => strtolower($type),
                 'webUrl' => (string)$webUrl,
             ];
         }


### PR DESCRIPTION
This PR, add limited support for using emby&jellyfin access tokens, the way they are handled right now is when you add a new backend instead of using an api key you use `username:password` instead, this will trigger a different workflow where we request limited token from the server and preset the settings.

Sadly, i don't have time to test all functions, but at least the basic import, export should work ok