### PR TITLE
Improving burning text subtitles into the stream.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,12 +45,11 @@ COPY ./ /opt/app
 # Copy frontend to public directory.
 COPY --chown=app:app --from=npm_builder /frontend/exported/ /opt/app/public/exported/
 
-# Link PHP if needed.
-RUN if [ ! -f /usr/bin/php ]; then ln -s /usr/bin/php${PHP_V:3} /usr/bin/php; fi
-
 # install composer & packages.
 #
 RUN echo '' && \
+    # Link PHP if needed. \
+    if [ ! -f /usr/bin/php ]; then ln -s /usr/bin/php${PHP_V:3} /usr/bin/php; fi && \
     # Create basic directories.
     bash -c 'umask 0000 && mkdir -p /temp_data/ /opt/{app,bin,config} /config/{backup,cache,config,db,debug,logs,webhooks,profiler}' && \
     # Link console & php.

--- a/frontend/pages/play/[id].vue
+++ b/frontend/pages/play/[id].vue
@@ -86,9 +86,12 @@
                     <option value="">Select audio stream...</option>
                     <template v-for="item in filterStreams('audio')" :key="`audio-${item.index}`">
                       <option :value="item.index">
-                        {{ item.index }} - {{ item.codec_name }} - {{ ag(item.tags, 'title') }}
+                        {{ item.index }} - {{ String(item.codec_name).toUpperCase() }}
+                        <template v-if="ag(item.tags, 'title')">
+                          - {{ ucFirst(String(ag(item.tags, 'title'))) }}
+                        </template>
                         <template v-if="ag(item.tags, 'language')">
-                          - {{ ag(item.tags, 'language') }}
+                          - ({{ String(ag(item.tags, 'language')).toUpperCase() }})
                         </template>
                       </option>
                     </template>
@@ -110,14 +113,17 @@
                       <optgroup label="Internal Subtitles">
                         <option v-for="item in filterStreams('subtitle')" :key="`subtitle-${item.index}`"
                                 :value="item.index">
-                          {{ item.index }} - {{ item.codec_name }} - {{ ag(item.tags, 'title') }}
+                          {{ item.index }} - {{ String(item.codec_name).toUpperCase() }}
+                          <template v-if="ag(item.tags, 'title')">
+                            - {{ ucFirst(String(ag(item.tags, 'title'))) }}
+                          </template>
                           <template v-if="ag(item.tags, 'language')">
-                            - {{ ag(item.tags, 'language') }}
+                            - ({{ String(ag(item.tags, 'language')).toUpperCase() }})
                           </template>
                         </option>
                       </optgroup>
                     </template>
-                    <template v-if="selectedItem?.subtitles">
+                    <template v-if="selectedItem?.subtitles.length > 0">
                       <optgroup label="External Subtitles">
                         <option v-for="item in selectedItem.subtitles" :key="`subtitle-${item}`" :value="item">
                           {{ basename(item) }}


### PR DESCRIPTION
This update brings changes to how we handle internal subtitle streams, if the file is big or large or the stream is rather large, the streaming will stale as we try to burn the subtitle into the stream piece by piece.

However, With this new changes we are able to extract the internal subtitle and store it into the cache, thereby reducing the time it takes to burn subtitle and segmenting the file by more then 1000% for large files and 100% for regular normal 23min episode files.

However this change has single drawback, the initial segment 0  will be little slower as we extract the subtitle on this initial stage if burning subtitle is required. However, we still recommend using the player built-in subtitles for text based subs.