### PR TITLE
Initial support for adding plex users with PIN.

### DIFF
--- a/config/servers.spec.php
+++ b/config/servers.spec.php
@@ -173,5 +173,11 @@ return [
         'visible' => false,
         'description' => 'Whether the token has limited access.',
     ],
+    [
+        'key' => 'options.PLEX_USER_PIN',
+        'type' => 'int',
+        'visible' => false,
+        'description' => 'Plex user PIN.',
+    ],
 ];
 

--- a/frontend/components/BackendAdd.vue
+++ b/frontend/components/BackendAdd.vue
@@ -175,6 +175,16 @@
               <NuxtLink @click="getUsers" v-text="'Retrieve User ids from backend.'" v-if="stage < 4"/>
             </p>
           </div>
+          <template v-if="'plex' === backend.type">
+            <label class="label">User PIN</label>
+            <div class="control has-icons-left">
+              <input class="input" type="text" v-model="backend.options.PLEX_USER_PIN" :disabled="stage > 3">
+              <div class="icon is-left"><i class="fas fa-key"></i></div>
+              <p class="help">
+                If the selected user is using <code>PIN</code> to login, enter the PIN here.
+              </p>
+            </div>
+          </template>
         </div>
 
         <template v-if="stage >= 4">
@@ -272,11 +282,17 @@
       </div>
 
       <div class="card-footer">
+
+        <div class="card-footer-item" v-if="stage >= 1">
+          <button class="button is-fullwidth is-warning" type="button" @click="stage = stage-1">
+            <span class="icon"><i class="fas fa-arrow-left"></i></span>
+            <span>Previous Step</span>
+          </button>
+        </div>
+
         <div class="card-footer-item" v-if="stage < maxStages">
-          <button class="button is-fullwidth is-primary" type="submit" @click="changeStep()">
-            <span class="icon">
-              <i class="fas fa-arrow-right"></i>
-            </span>
+          <button class="button is-fullwidth is-info" type="submit" @click="changeStep()">
+            <span class="icon"><i class="fas fa-arrow-right"></i></span>
             <span>Next Step</span>
           </button>
         </div>
@@ -499,10 +515,6 @@ onMounted(async () => {
   supported.value = await response.json()
   backend.value.type = supported.value[0]
 })
-
-watch(stage, v => {
-  console.log(v);
-}, {immediate: true})
 
 const changeStep = async () => {
   let _

--- a/frontend/pages/backend/[backend]/edit.vue
+++ b/frontend/pages/backend/[backend]/edit.vue
@@ -590,6 +590,12 @@ const getServers = async () => {
     url: window.location.origin,
   };
 
+  if (backend.value?.options && backend.value.options?.ADMIN_TOKEN) {
+    data.options = {
+      ADMIN_TOKEN: backend.value.options.ADMIN_TOKEN
+    }
+  }
+
   const response = await request(`/backends/discover/${backend.value.type}`, {
     method: 'POST',
     body: JSON.stringify(data)

--- a/src/API/Backend/Discover.php
+++ b/src/API/Backend/Discover.php
@@ -8,6 +8,7 @@ use App\Backends\Plex\PlexClient;
 use App\Libs\Attributes\Route\Get;
 use App\Libs\Enums\Http\Status;
 use App\Libs\Exceptions\InvalidArgumentException;
+use App\Libs\Options;
 use App\Libs\Traits\APITraits;
 use Psr\Http\Message\ResponseInterface as iResponse;
 use Psr\Http\Message\ServerRequestInterface as iRequest;
@@ -42,7 +43,14 @@ final class Discover
 
             assert($client instanceof PlexClient);
 
-            $list = $client::discover($this->http, $client->getContext()->backendToken);
+            $context = $client->getContext();
+            $opts = [];
+
+            if (null !== ($adminToken = ag($context->options, Options::ADMIN_TOKEN))) {
+                $opts[Options::ADMIN_TOKEN] = $adminToken;
+            }
+
+            $list = $client::discover($this->http, $context->backendToken, $opts);
             return api_response(Status::OK, ag($list, 'list', []));
         } catch (InvalidArgumentException $e) {
             return api_error($e->getMessage(), Status::NOT_FOUND);

--- a/src/API/Backends/Discover.php
+++ b/src/API/Backends/Discover.php
@@ -9,6 +9,7 @@ use App\Libs\Attributes\Route\Route;
 use App\Libs\DataUtil;
 use App\Libs\Enums\Http\Status;
 use App\Libs\Exceptions\InvalidArgumentException;
+use App\Libs\Options;
 use App\Libs\Traits\APITraits;
 use Psr\Http\Message\ResponseInterface as iResponse;
 use Psr\Http\Message\ServerRequestInterface as iRequest;
@@ -42,7 +43,13 @@ final class Discover
         }
 
         try {
-            $list = $client::discover($this->http, $client->getContext()->backendToken);
+            $opts = [];
+
+            if (null !== ($adminToken = ag($request->getParsedBody(), 'options.' . Options::ADMIN_TOKEN))) {
+                $opts[Options::ADMIN_TOKEN] = $adminToken;
+            }
+
+            $list = $client::discover($this->http, $client->getContext()->backendToken, $opts);
             return api_response(Status::OK, ag($list, 'list', []));
         } catch (Throwable $e) {
             return api_error($e->getMessage(), Status::INTERNAL_SERVER_ERROR);

--- a/src/Backends/Plex/PlexManage.php
+++ b/src/Backends/Plex/PlexManage.php
@@ -409,9 +409,31 @@ class PlexManage implements ManageInterface
                 $backend = ag_set($backend, 'user', $map[$user]);
                 $backend = ag_set($backend, 'options.plex_user_uuid', $uuid[$user]);
 
+                $question = new Question(
+                    r(
+                        <<<HELP
+                        <question>[<value>{name}</value>] User PIN</question>. {default}
+                        ------------------
+                        <notice>Leave empty if the user doesn't have a PIN.</notice>
+                        ------------------
+                        HELP. PHP_EOL . '> ',
+                        [
+                            'name' => ag($backend, 'name'),
+                            'default' => null !== $choice ? "<value>[Default: {$choice}]</value>" : ''
+                        ]
+                    ),
+                    ag($backend, 'options.' . Options::PLEX_USER_PIN)
+                );
+
+                $pin = $this->questionHelper->ask($this->input, $this->output, $question);
+                if (!empty($pin)) {
+                    $backend = ag_set($backend, 'options.' . Options::PLEX_USER_PIN, $pin);
+                }
+
                 $this->output->writeln(
-                    r('<info>Requesting plex token for [{user}] from plex.tv API.</info>', [
+                    r("<info>Requesting plex token for '{user}'{pin} from plex.tv API.</info>", [
                         'user' => ag($userInfo[$map[$user]], 'name') ?? 'None',
+                        'pin' => empty($pin) ? '' : ' with PIN'
                     ])
                 );
 

--- a/src/Libs/Options.php
+++ b/src/Libs/Options.php
@@ -38,6 +38,7 @@ final class Options
     public const string LIMIT_RESULTS = 'LIMIT_RESULTS';
     public const string NO_CHECK = 'NO_CHECK';
     public const string LOG_WRITER = 'LOG_WRITER';
+    public const string PLEX_USER_PIN = 'PLEX_USER_PIN';
 
     private function __construct()
     {


### PR DESCRIPTION
In certain cases, when adding a backend some of the Plex admin tokens lack the authority of generating limited access token for users, as such when you select a user from the list as we attempt to generate accesstoken for the selected user. PIN is required error is thrown. So this PR includes a partial support for adding a PIN while creating new backend via both Web and CLI.

This also fixes the issue the user in #542 is facing. 