### PR TITLE
Fully implemented Custom GUIDs support and added WebUI page to manage it.

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -952,11 +952,12 @@ Note: the tip about adding the group_add came from the user `binarypancakes` in 
 
 ### Advanced: How to extend the GUID parser to support more GUIDs or custom ones?
 
-You can extend the parser by creating new file at `/config/config/guid.yaml` with the following content.
+By going to `More > Custom GUIDs` in the WebUI, you can add custom GUIDs to the parser. We know not all people,
+like using GUI, as such You can extend the parser by creating new file at `/config/config/guid.yaml` with the following content.
 
 ```yaml
-# The version of the guid file. right now in beta so it's 0.0. not required to be present.
-version: 0.0
+# (Optional) The version of the guid file. If omitted, it will default to the latest version.
+version: 1.0
 
 # The key must be in lower case. and it's an array.
 guids:
@@ -982,10 +983,6 @@ links:
         type: plex    # the client to link the guid to. plex, jellyfin, emby.
         options: # options used by the client.
             legacy: true  # Tag the mapper as legacy GUID for mapping.
-        # Required map object. to map the new guid to WatchState guid.
-        map:
-            from: com.plexapp.agents.foo # map.from this string.
-            to: guid_mydb                # map.to this guid.
             # (Optional) Replace helper. Sometimes you need to replace the guid identifier to another.
             # The replacement happens before the mapping, so if you replace the guid identifier, you should also
             # update the map.from to match the new identifier.
@@ -993,6 +990,10 @@ links:
             replace:
                 from: com.plexapp.agents.foobar://  # Replace from this string
                 to: com.plexapp.agents.foo://       # Into this string.
+        # Required map object. to map the new guid to WatchState guid.
+        map:
+            from: com.plexapp.agents.foo # map.from this string.
+            to: guid_mydb                # map.to this guid.
 
     # mapping the foo guid from jellyfin backends into the guid_mydb in WatchState.
     -   id: universally-unique-identifier # the link id. example, 1ef83f5d-1686-60f0-96d6-3eb5c18f2aed
@@ -1010,11 +1011,11 @@ links:
 ```
 
 As you can see from the config, it's roughly how we expected it to be. The `guids` array is where you define your new
-guids. the `links` array is where you map from backends guids to the new guid into the WatchState guid.
+custom GUIDs. the `links` array is where you map from client/backends GUIDs to the custom GUID in `WatchState`.
 
 Everything in this file should be in lower case. If error occurs, the tool will log a warning and ignore the guid,
 By default, we only show `ERROR` levels in log file, You can lower it by setting `WS_LOGGER_FILE_LEVEL` environment variable
 to `WARNING`.
 
-If you added or removed a guid from the `guid.yaml` file, you should run `system:reindex --force-reindex` command to update the
+If you added or removed a guid from the `guid.yaml` file, you should run `system:index --force-reindex` command to update the
 database indexes with the new guids.

--- a/FAQ.md
+++ b/FAQ.md
@@ -960,14 +960,14 @@ version: 0.0
 
 # The key must be in lower case. and it's an array.
 guids:
-    -   id: universally-unique-identifier       # the guid id
+    -   id: universally-unique-identifier       # the guid id. Example, 1ef83f5d-1686-60f0-96d6-3eb5c18f2aed
         type: string                            # must be exactly string do not change it.
         name: guid_mydb                         # the name must start with guid_ with no spaces and lower case.
-        description: "My custom database guid"  # description of the guid.
+        description: "My custom database guid"  # description of the guid. For informational purposes only.
         # Validator object. to validate the guid.
         validator:
-            pattern: /^[0-9\/]+$/i  # regex pattern to match the guid. The pattern must also support / being in the guid. as we use the same object to generate relative guid.
-            example: "(number)"     # example of the guid.
+            pattern: "/^[0-9\/]+$/i"  # regex pattern to match the guid. The pattern must also support / being in the guid. as we use the same object to generate relative guid.
+            example: "(number)"     # example of the guid. For informational purposes only.
             tests:
                 valid:
                     - "1234567"     # valid guid examples.
@@ -978,7 +978,7 @@ guids:
 links:
     # mapping the com.plexapp.agents.foo guid from plex backends into the guid_mydb in WatchState.
     # plex legacy guids starts with com.plexapp.agents., you must set options.legacy to true.
-    -   id: universally-unique-identifier       # the link id
+    -   id: universally-unique-identifier # the link id. example, 1ef83f5d-1686-60f0-96d6-3eb5c18f2aed
         type: plex    # the client to link the guid to. plex, jellyfin, emby.
         options: # options used by the client.
             legacy: true  # Tag the mapper as legacy GUID for mapping.
@@ -989,19 +989,20 @@ links:
             # (Optional) Replace helper. Sometimes you need to replace the guid identifier to another.
             # The replacement happens before the mapping, so if you replace the guid identifier, you should also
             # update the map.from to match the new identifier.
+            # This "replace" object only works with plex legacy guids.
             replace:
                 from: com.plexapp.agents.foobar://  # Replace from this string
                 to: com.plexapp.agents.foo://       # Into this string.
 
     # mapping the foo guid from jellyfin backends into the guid_mydb in WatchState.
-    -   id: universally-unique-identifier # the link id
+    -   id: universally-unique-identifier # the link id. example, 1ef83f5d-1686-60f0-96d6-3eb5c18f2aed
         type: jellyfin # the client to link the guid to. plex, jellyfin, emby.
         map:
             from: foo     # map.from this string.
             to: guid_mydb # map.to this guid.
 
     # mapping the foo guid from emby backends into the guid_mydb in WatchState.
-    -   id: universally-unique-identifier       # the link id
+    -   id: universally-unique-identifier # the link id. example, 1ef83f5d-1686-60f0-96d6-3eb5c18f2aed
         type: emby    # the client to link the guid to. plex, jellyfin, emby.
         map:
             from: foo     # map.from this string.

--- a/FAQ.md
+++ b/FAQ.md
@@ -960,7 +960,8 @@ version: 0.0
 
 # The key must be in lower case. and it's an array.
 guids:
-    -   type: string                            # must be exactly string do not change it.
+    -   id: universally-unique-identifier       # the guid id
+        type: string                            # must be exactly string do not change it.
         name: guid_mydb                         # the name must start with guid_ with no spaces and lower case.
         description: "My custom database guid"  # description of the guid.
         # Validator object. to validate the guid.
@@ -974,37 +975,41 @@ guids:
                     - "1234567a"    # invalid guid examples.
                     - "a111234567"  # invalid guid examples.
 
-# Extend Plex client to support the new guid.
-plex:
-    -   legacy: true  # Tag the mapper as legacy GUID for mapping.
+links:
+    # mapping the com.plexapp.agents.foo guid from plex backends into the guid_mydb in WatchState.
+    # plex legacy guids starts with com.plexapp.agents., you must set options.legacy to true.
+    -   id: universally-unique-identifier       # the link id
+        type: plex    # the client to link the guid to. plex, jellyfin, emby.
+        options: # options used by the client.
+            legacy: true  # Tag the mapper as legacy GUID for mapping.
         # Required map object. to map the new guid to WatchState guid.
         map:
             from: com.plexapp.agents.foo # map.from this string.
             to: guid_mydb                # map.to this guid.
-        # (Optional) Replace helper. Sometimes you need to replace the guid identifier to another.
-        # The replacement happens before the mapping, so if you replace the guid identifier, you should also
-        # update the map.from to match the new identifier.
-        replace:
-            from: com.plexapp.agents.foobar://  # Replace from this string
-            to: com.plexapp.agents.foo://       # Into this string.
+            # (Optional) Replace helper. Sometimes you need to replace the guid identifier to another.
+            # The replacement happens before the mapping, so if you replace the guid identifier, you should also
+            # update the map.from to match the new identifier.
+            replace:
+                from: com.plexapp.agents.foobar://  # Replace from this string
+                to: com.plexapp.agents.foo://       # Into this string.
 
-# Extend Jellyfin client to support the new guid.
-jellyfin:
-    # Required map object. to map the new guid to WatchState guid.
-    -   map:
+    # mapping the foo guid from jellyfin backends into the guid_mydb in WatchState.
+    -   id: universally-unique-identifier # the link id
+        type: jellyfin # the client to link the guid to. plex, jellyfin, emby.
+        map:
             from: foo     # map.from this string.
             to: guid_mydb # map.to this guid.
 
-# Extend Emby client to support the new guid.
-emby:
-    # Required map object. to map the new guid to WatchState guid.
-    -   map:
+    # mapping the foo guid from emby backends into the guid_mydb in WatchState.
+    -   id: universally-unique-identifier       # the link id
+        type: emby    # the client to link the guid to. plex, jellyfin, emby.
+        map:
             from: foo     # map.from this string.
             to: guid_mydb # map.to this guid.
 ```
 
 As you can see from the config, it's roughly how we expected it to be. The `guids` array is where you define your new
-guids. The `plex`, `jellyfin` and `emby` objects are where you map the new guid to the WatchState guid.
+guids. the `links` array is where you map from backends guids to the new guid into the WatchState guid.
 
 Everything in this file should be in lower case. If error occurs, the tool will log a warning and ignore the guid,
 By default, we only show `ERROR` levels in log file, You can lower it by setting `WS_LOGGER_FILE_LEVEL` environment variable

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # Old Updates
 
+### 2024-08-19
+
+We have migrated the `state:push` task into the new events system, as such the old task `state:push` is now gone.
+To enable the new event handler for push events, use the new environment variable `WS_PUSH_ENABLED` and set it to `true`.
+Right now, it's disabled by default. However, for people who had the old task enabled, it will reuse that setting.
+
+Keep in mind, the new event handler is more efficient and will only push data when there is a change in the play state. And it's much faster
+than the old task. This event handler will push data within a minute of the change.
+
+PS: Please enable the task by setting its new environment variable `WS_PUSH_ENABLED` to `true`. The old `WS_CRON_PUSH` is now gone.
+and will be removed in the future releases.
+
 ### 2024-08-18
 
 We have started migrating the old events system to a new one, so far we have migrated the `progress` and `requests` to it. As such,

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ out of the box, this tool support `Jellyfin`, `Plex` and `Emby` media servers.
 
 ## Updates
 
+### 2024-10-07
+
+We have added a WebUI page for Custom GUIDs and stabilized on `v1.0` for the `guid.yaml` file spec. We strongly recommend
+to use the `WebUI` to manage the GUIDs, as it's much easier to use than editing the `guid.yaml` file directly. and both the
+`WebUI` and `API` have safeguards to prevent you from breaking the parser. For more information please check out the associated
+FAQ entry about it at [this link](FAQ.md#advanced-how-to-extend-the-guid-parser-to-support-more-guids-or-custom-ones).
+
 ### 2024-09-14
 
 We have recently added support for extending WatchState with more GUIDs, as of now, the support for it is done via
@@ -17,18 +24,6 @@ FAQ entry about it at [this link](FAQ.md#advanced-how-to-extend-the-guid-parser-
 
 The mapping should work for all officially supported clients. If you have a client that is not supported, you have to manually add support for that client,
 or request the maintainer to add support for it.
-
-### 2024-08-19
-
-We have migrated the `state:push` task into the new events system, as such the old task `state:push` is now gone.
-To enable the new event handler for push events, use the new environment variable `WS_PUSH_ENABLED` and set it to `true`.
-Right now, it's disabled by default. However, for people who had the old task enabled, it will reuse that setting.
-
-Keep in mind, the new event handler is more efficient and will only push data when there is a change in the play state. And it's much faster
-than the old task. This event handler will push data within a minute of the change.
-
-PS: Please enable the task by setting its new environment variable `WS_PUSH_ENABLED` to `true`. The old `WS_CRON_PUSH` is now gone.
-and will be removed in the future releases.
 
 --- 
 Refer to [NEWS](NEWS.md) for old updates.

--- a/config/config.php
+++ b/config/config.php
@@ -192,9 +192,9 @@ return (function () {
     ];
 
     $config['supported'] = [
-        'plex' => PlexClient::class,
-        'emby' => EmbyClient::class,
-        'jellyfin' => JellyfinClient::class,
+        strtolower(PlexClient::CLIENT_NAME) => PlexClient::class,
+        strtolower(EmbyClient::CLIENT_NAME) => EmbyClient::class,
+        strtolower(JellyfinClient::CLIENT_NAME) => JellyfinClient::class,
     ];
 
     $config['servers'] = [];

--- a/frontend/components/Player.vue
+++ b/frontend/components/Player.vue
@@ -18,7 +18,7 @@
 </style>
 
 <template>
-  <video ref="video" :poster="poster" :controls="isControls" :title="title" preload="auto">
+  <video ref="video" :poster="poster" :controls="isControls" :title="title" preload="auto" playsinline>
     <source :src="link" type="application/x-mpegURL"/>
   </video>
 </template>

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -99,10 +99,18 @@
                 <span>Log Suppression</span>
               </NuxtLink>
 
+              <NuxtLink class="navbar-item" to="/custom" @click.native="(e) => changeRoute(e)">
+                <span class="icon"><i class="fas fa-map"></i></span>
+                <span>Custom GUIDs</span>
+              </NuxtLink>
+
+              <hr class="navbar-divider">
+
               <NuxtLink class="navbar-item" to="/backup" @click.native="(e) => changeRoute(e)">
                 <span class="icon"><i class="fas fa-sd-card"></i></span>
                 <span>Backups</span>
               </NuxtLink>
+
               <hr class="navbar-divider">
 
               <NuxtLink class="navbar-item" to="/reset" @click.native="(e) => changeRoute(e)">
@@ -341,7 +349,6 @@ import 'assets/css/all.css'
 import {useStorage} from '@vueuse/core'
 import request from '~/utils/request.js'
 import Markdown from '~/components/Markdown.vue'
-import {dEvent} from '~/utils/index.js'
 import TaskRunnerStatus from "~/components/TaskRunnerStatus.vue";
 
 const selectedTheme = useStorage('theme', (() => window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')())

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
         "preview": "nuxt preview",
         "postinstall": "nuxt prepare"
     },
+    "web-types": "./web-types.json",
     "dependencies": {
         "@vueuse/core": "^10.9.0",
         "@vueuse/nuxt": "^10.9.0",

--- a/frontend/pages/console.vue
+++ b/frontend/pages/console.vue
@@ -307,7 +307,9 @@ onMounted(async () => {
     allEnabled.value = false
   }
 
-  if (Boolean(route.query?.run ?? '0') || '' === command.value) {
+  const run = route.query?.run ? Boolean(route.query.run) : false
+
+  if (run || '' === command.value) {
     await RunCommand()
   }
 })

--- a/frontend/pages/custom/add.vue
+++ b/frontend/pages/custom/add.vue
@@ -7,192 +7,178 @@
           Add Custom GUID
         </span>
         <div class="is-hidden-mobile">
-          <span class="subtitle"></span>
+          <span class="subtitle">
+            This custom GUID allows you to extend <code>WatchState</code> GUID parser with your custom GUIDs. Using this
+            feature, You are able to use more metadata databases for references between the backends.
+          </span>
         </div>
       </div>
       <div class="column is-12">
         <form id="page_form" @submit.prevent="addNewGuid">
-          <div class="card">
-            <header class="card-header">
-              <p class="card-header-title is-unselectable is-justify-center">Add Custom GUID</p>
-            </header>
+          <div class="field">
+            <label class="label is-unselectable" for="form_guid_name">Name</label>
+            <div class="control has-icons-left">
+              <input class="input" id="form_guid_name" type="text" v-model="form.name" placeholder="foobar">
+              <div class="icon is-small is-left"><i class="fas fa-passport"></i></div>
+            </div>
+            <p class="help">
+              <span class="icon"><i class="fas fa-info"></i></span>
+              <span>The internal GUID reference name. The rules are <code>lower case [a-z]</code>, <code>0-9</code>,
+                <code>no space</code>.
+                For example, <code>guid_imdb</code>. The guid name will be automatically prefixed with
+                <code>guid_</code>.
+              </span>
+            </p>
+          </div>
 
-            <div class="card-content">
+          <div class="field">
+            <label class="label is-unselectable" for="form_description">Description</label>
+            <div class="control has-icons-left">
+              <input class="input" id="form_description" type="text" v-model="form.description"
+                     placeholder="This GUID is based on ... db reference">
+              <div class="icon is-small is-left"><i class="fas fa-envelope-open-text"></i></div>
+            </div>
+            <p class="help">
+              <span class="icon"><i class="fas fa-info"></i></span>
+              <span>GUID description, For information purposes only.</span>
+            </p>
+          </div>
 
-              <div class="field">
-                <label class="label is-unselectable" for="form_guid_name">Name</label>
-                <div class="control has-icons-left">
-                  <input class="input" id="form_guid_name" type="text" v-model="form.name" placeholder="foobar">
-                  <div class="icon is-small is-left"><i class="fas fa-passport"></i></div>
-                </div>
-                <p class="help">
-                  <span class="icon"><i class="fas fa-info"></i></span>
-                  <span>The internal GUID reference name. The rules are <code>lower case [a-z]</code>, <code>0-9</code>,
-                    <code>no space</code>.
-                    For example, <code>guid_imdb</code>. The guid name will be automatically prefixed with
-                    <code>guid_</code>.
-                  </span>
-                </p>
+          <div class="field">
+            <label class="label is-unselectable" for="form_select_type">Type</label>
+            <div class="control has-icons-left">
+              <div class="select is-fullwidth">
+                <select id="form_select_type" v-model="form.type">
+                  <option value="" disabled>Select Type</option>
+                  <option value="string">String</option>
+                </select>
               </div>
-
-              <div class="field">
-                <label class="label is-unselectable" for="form_description">Description</label>
-                <div class="control has-icons-left">
-                  <input class="input" id="form_description" type="text" v-model="form.description"
-                         placeholder="This GUID is based on ... db reference">
-                  <div class="icon is-small is-left"><i class="fas fa-envelope-open-text"></i></div>
-                </div>
-                <p class="help">
-                  <span class="icon"><i class="fas fa-info"></i></span>
-                  <span>GUID description, For information purposes only.</span>
-                </p>
-              </div>
-
-              <div class="field">
-                <label class="label is-unselectable" for="form_select_type">Type</label>
-                <div class="control has-icons-left">
-                  <div class="select is-fullwidth">
-                    <select id="form_select_type" v-model="form.type">
-                      <option value="" disabled>Select Type</option>
-                      <option value="string">String</option>
-                    </select>
-                  </div>
-                  <div class="icon is-left">
-                    <i class="fas fa-cog"></i>
-                  </div>
-                </div>
-                <p class="help">
-                  <span class="icon"><i class="fas fa-info"></i></span>
-                  <span>We currently only support <code>string</code> type.</span>
-                </p>
-              </div>
-
-              <div class="field">
-                <label class="label is-unselectable" for="form_validation_pattern">Regex validation pattern</label>
-                <div class="control has-icons-left">
-                  <input class="input" id="form_validation_pattern" type="text" v-model="form.validator.pattern"
-                         placeholder="/^[0-9\\/]+$/i">
-                  <div class="icon is-small is-left"><i class="fas fa-check"></i></div>
-                </div>
-                <p class="help">
-                  <span class="icon"><i class="fas fa-info"></i></span>
-                  <span>
-                    A Valid regular expression to check the value GUID value. To test your patterns, you can use this
-                    website
-                    <NuxtLink target="_blank" to="https://regex101.com/#php73" v-text="'regex101.com'"/>
-                    .
-                  </span>
-                </p>
-              </div>
-              <div class="field">
-                <label class="label is-unselectable" for="form_validation_example">Value example</label>
-                <div class="control has-icons-left">
-                  <input class="input" id="form_validation_example" type="text" v-model="form.validator.example"
-                         placeholder="(number)">
-                  <div class="icon is-small is-left"><i class="fas fa-ear-deaf"></i></div>
-                </div>
-                <p class="help">
-                  <span class="icon"><i class="fas fa-info"></i></span>
-                  <span>The example to show when invalid value was checked. For example, <code>(number)</code>. For
-                    information purposes only.</span>
-                </p>
-              </div>
-
-              <div class="field">
-                <label class="label is-unselectable">
-                  Correct values.
-                  <NuxtLink class="has-text-primary" @click="form.validator.tests.valid.push('')" v-text="'Add'"/>
-                </label>
-                <div class="columns is-multiline">
-                  <template v-for="(_, index) in form.validator.tests.valid" :key="`valid-${index}`">
-                    <div class="column is-11">
-                      <div class="control has-icons-left">
-                        <input class="input" type="text" :id="`valid-${index}`"
-                               v-model="form.validator.tests.valid[index]">
-                        <div class="icon is-small is-left"><i class="fas fa-check"></i></div>
-                      </div>
-                    </div>
-                    <div class="column">
-                      <button class="button is-danger" type="button"
-                              @click="form.validator.tests.valid.splice(index, 1)"
-                              :disabled="index < 1 || form.validator.tests.valid < 1">
-                        <span class="icon"><i class="fas fa-trash"></i></span>
-                      </button>
-                    </div>
-                  </template>
-                </div>
-                <p class="help">
-                  <span class="icon"><i class="fas fa-info"></i></span>
-                  <span>
-                    The values added here must match the pattern defined above. Example: <code>123</code>.
-                    Additionally, the pattern also must support <code>/</code> being part of the value. as we used it
-                    for relative GUIDs. The <code>(number)/1/1</code> refers to a relative GUID.
-                    There must be a minimum of 1 correct value.
-                  </span>
-                </p>
-              </div>
-
-              <div class="field">
-                <label class="label is-unselectable">
-                  Incorrect values.
-                  <NuxtLink class="has-text-danger" @click="form.validator.tests.invalid.push('')" v-text="'Add'"/>
-                </label>
-                <div class="columns is-multiline">
-                  <template v-for="(_, index) in form.validator.tests.invalid" :key="`valid-${index}`">
-                    <div class="column is-11">
-                      <div class="control has-icons-left">
-                        <input class="input" type="text" :id="`invalid-${index}`"
-                               v-model="form.validator.tests.invalid[index]">
-                        <div class="icon is-small is-left"><i class="fas fa-check"></i></div>
-                      </div>
-                    </div>
-                    <div class="column">
-                      <button class="button is-danger" type="button"
-                              @click="form.validator.tests.invalid.splice(index, 1)"
-                              :disabled="index < 1 || form.validator.tests.invalid < 1">
-                        <span class="icon"><i class="fas fa-trash"></i></span>
-                      </button>
-                    </div>
-                  </template>
-                </div>
-                <p class="help">
-                  <span class="icon"><i class="fas fa-info"></i></span>
-                  <span>GUID values with should not match the pattern defined above. Example: <code>abc</code>. There
-                    must be a minimum of 1 incorrect value.</span>
-                </p>
+              <div class="icon is-left">
+                <i class="fas fa-cog"></i>
               </div>
             </div>
+            <p class="help">
+              <span class="icon"><i class="fas fa-info"></i></span>
+              <span>We currently only support <code>string</code> type.</span>
+            </p>
+          </div>
 
-            <div class="card-footer">
-              <div class="card-footer-item">
-                <button class="button is-fullwidth is-primary" type="submit" :disabled="false === validForm || isSaving"
-                        :class="{'is-loading':isSaving}">
-                  <span class="icon-text">
-                    <span class="icon"><i class="fas fa-save"></i></span>
-                    <span>Save</span>
-                  </span>
-                </button>
-              </div>
-              <div class="card-footer-item">
-                <button class="button is-fullwidth is-danger" type="button" @click="navigateTo('/custom')">
-                  <span class="icon-text">
-                    <span class="icon"><i class="fas fa-cancel"></i></span>
-                    <span>Cancel</span>
-                  </span>
-                </button>
-              </div>
+          <div class="field">
+            <label class="label is-unselectable" for="form_validation_pattern">Regex validation pattern</label>
+            <div class="control has-icons-left">
+              <input class="input" id="form_validation_pattern" type="text" v-model="form.validator.pattern"
+                     placeholder="/^[0-9\\/]+$/i">
+              <div class="icon is-small is-left"><i class="fas fa-check"></i></div>
+            </div>
+            <p class="help">
+              <span class="icon"><i class="fas fa-info"></i></span>
+              <span>
+                A Valid regular expression to check the value GUID value. To test your patterns, you can use this
+                website
+                <NuxtLink target="_blank" to="https://regex101.com/#php73" v-text="'regex101.com'"/>
+                .
+              </span>
+            </p>
+          </div>
+          <div class="field">
+            <label class="label is-unselectable" for="form_validation_example">Value example</label>
+            <div class="control has-icons-left">
+              <input class="input" id="form_validation_example" type="text" v-model="form.validator.example"
+                     placeholder="(number)">
+              <div class="icon is-small is-left"><i class="fas fa-ear-deaf"></i></div>
+            </div>
+            <p class="help">
+              <span class="icon"><i class="fas fa-info"></i></span>
+              <span>The example to show when invalid value was checked. For example, <code>(number)</code>. For
+                information purposes only.</span>
+            </p>
+          </div>
+
+          <div class="field">
+            <label class="label is-unselectable">
+              Correct values.
+              <NuxtLink class="has-text-primary" @click="form.validator.tests.valid.push('')" v-text="'Add'"/>
+            </label>
+            <div class="columns is-multiline">
+              <template v-for="(_, index) in form.validator.tests.valid" :key="`valid-${index}`">
+                <div class="column is-11">
+                  <div class="control has-icons-left">
+                    <input class="input" type="text" :id="`valid-${index}`"
+                           v-model="form.validator.tests.valid[index]">
+                    <div class="icon is-small is-left"><i class="fas fa-check"></i></div>
+                  </div>
+                </div>
+                <div class="column">
+                  <button class="button is-danger" type="button"
+                          @click="form.validator.tests.valid.splice(index, 1)"
+                          :disabled="index < 1 || form.validator.tests.valid < 1">
+                    <span class="icon"><i class="fas fa-trash"></i></span>
+                  </button>
+                </div>
+              </template>
+            </div>
+            <p class="help">
+              <span class="icon"><i class="fas fa-info"></i></span>
+              <span>
+                The values added here must match the pattern defined above. Example: <code>123</code>.
+                Additionally, the pattern also must support <code>/</code> being part of the value. as we used it
+                for relative GUIDs. The <code>(number)/1/1</code> refers to a relative GUID.
+                There must be a minimum of 1 correct value.
+              </span>
+            </p>
+          </div>
+
+          <div class="field">
+            <label class="label is-unselectable">
+              Incorrect values.
+              <NuxtLink class="has-text-danger" @click="form.validator.tests.invalid.push('')" v-text="'Add'"/>
+            </label>
+            <div class="columns is-multiline">
+              <template v-for="(_, index) in form.validator.tests.invalid" :key="`valid-${index}`">
+                <div class="column is-11">
+                  <div class="control has-icons-left">
+                    <input class="input" type="text" :id="`invalid-${index}`"
+                           v-model="form.validator.tests.invalid[index]">
+                    <div class="icon is-small is-left"><i class="fas fa-check"></i></div>
+                  </div>
+                </div>
+                <div class="column">
+                  <button class="button is-danger" type="button"
+                          @click="form.validator.tests.invalid.splice(index, 1)"
+                          :disabled="index < 1 || form.validator.tests.invalid < 1">
+                    <span class="icon"><i class="fas fa-trash"></i></span>
+                  </button>
+                </div>
+              </template>
+            </div>
+            <p class="help">
+              <span class="icon"><i class="fas fa-info"></i></span>
+              <span>GUID values with should not match the pattern defined above. Example: <code>abc</code>. There
+                must be a minimum of 1 incorrect value.</span>
+            </p>
+          </div>
+
+          <div class="field is-grouped">
+            <div class="control is-expanded">
+              <button class="button is-fullwidth is-primary" type="submit" :disabled="false === validForm || isSaving"
+                      :class="{'is-loading':isSaving}">
+                <span class="icon-text">
+                  <span class="icon"><i class="fas fa-save"></i></span>
+                  <span>Save</span>
+                </span>
+              </button>
+            </div>
+            <div class="control is-expanded">
+              <button class="button is-fullwidth is-danger" type="button" @click="navigateTo('/custom')">
+                <span class="icon-text">
+                  <span class="icon"><i class="fas fa-cancel"></i></span>
+                  <span>Cancel</span>
+                </span>
+              </button>
             </div>
           </div>
         </form>
       </div>
-
-      <!--      <div class="column is-12">-->
-      <!--        <Message message_class="has-background-info-90 has-text-dark" :toggle="show_page_tips"-->
-      <!--                 @toggle="show_page_tips = !show_page_tips" :use-toggle="true" title="Tips" icon="fas fa-info-circle">-->
-      <!--          <ul>-->
-      <!--          </ul>-->
-      <!--        </Message>-->
-      <!--      </div>-->
     </div>
   </div>
 </template>
@@ -218,6 +204,7 @@ const empty_form = {
     }
   }
 }
+
 const show_page_tips = useStorage('show_page_tips', true)
 const form = ref(JSON.parse(JSON.stringify(empty_form)))
 const guids = ref([])
@@ -256,7 +243,7 @@ const addNewGuid = async () => {
     notification('error', 'Error', `GUID name must not contain spaces.`, 5000)
     return
   }
-  
+
   data.type = data.type.trim().toLowerCase();
   if (!['string'].includes(data.type)) {
     notification('error', 'Error', `Invalid GUID type.`, 5000)
@@ -264,12 +251,12 @@ const addNewGuid = async () => {
   }
 
   try {
-    toRaw(guids.value).forEach(g => {
-      const name = data.name.split('_')[1]
-      if (g.guid === name) {
-        throw new Error(`GUID with name '${data.name}' already exists.`)
+    for (const g of guids.value) {
+      if (g.guid === data.name) {
+        notification('error', 'Error', `GUID with name '${data.name}' already exists.`, 5000)
+        return false
       }
-    })
+    }
   } catch (e) {
     notification('error', 'Error', `${e}`, 5000)
     return false

--- a/frontend/pages/custom/add.vue
+++ b/frontend/pages/custom/add.vue
@@ -11,7 +11,7 @@
         </div>
       </div>
       <div class="column is-12">
-        <form id="page_form" @submit.prevent="addIgnoreRule">
+        <form id="page_form" @submit.prevent="addNewGuid">
           <div class="card">
             <header class="card-header">
               <p class="card-header-title is-unselectable is-justify-center">Add Custom GUID</p>
@@ -20,18 +20,30 @@
             <div class="card-content">
 
               <div class="field">
-                <label class="label is-unselectable" for="form_ignore_id">Name</label>
+                <label class="label is-unselectable" for="form_guid_name">Name</label>
                 <div class="control has-icons-left">
                   <input class="input" id="form_guid_name" type="text" v-model="form.name" placeholder="guid_foobar">
                   <div class="icon is-small is-left"><i class="fas fa-passport"></i></div>
                 </div>
                 <p class="help">
-                  <span class="icon-text">
-                    <span class="icon"><i class="fas fa-info"></i></span>
-                    <span>All GUIDs names must start with <code>guid_</code>. For example,
-                      <code>guid_foobar</code>. You cannot use the same name as an existing GUID.
-                    </span>
+                  <span class="icon"><i class="fas fa-info"></i></span>
+                  <span>The internal GUID reference name. The name must starts with <code>guid</code>, followed by
+                    <code>_</code>, <code>lower case [a-z]</code>, <code>0-9</code>, <code>no space</code>.
+                    For example, <code>guid_imdb</code>.
                   </span>
+                </p>
+              </div>
+
+              <div class="field">
+                <label class="label is-unselectable" for="form_description">Description</label>
+                <div class="control has-icons-left">
+                  <input class="input" id="form_description" type="text" v-model="form.description"
+                         placeholder="This GUID is based on ... db reference">
+                  <div class="icon is-small is-left"><i class="fas fa-envelope-open-text"></i></div>
+                </div>
+                <p class="help">
+                  <span class="icon"><i class="fas fa-info"></i></span>
+                  <span>GUID description, For information purposes only.</span>
                 </p>
               </div>
 
@@ -49,25 +61,8 @@
                   </div>
                 </div>
                 <p class="help">
-                  <span class="icon-text">
-                    <span class="icon"><i class="fas fa-info"></i></span>
-                    <span>We currently only support <code>string</code> type.</span>
-                  </span>
-                </p>
-              </div>
-
-              <div class="field">
-                <label class="label is-unselectable" for="form_description">Description</label>
-                <div class="control has-icons-left">
-                  <input class="input" id="form_description" type="text" v-model="form.description"
-                         placeholder="This GUID is based on ... db reference">
-                  <div class="icon is-small is-left"><i class="fas fa-envelope-open-text"></i></div>
-                </div>
-                <p class="help">
-                  <span class="icon-text">
-                    <span class="icon"><i class="fas fa-info"></i></span>
-                    <span>GUID description, For information purposes only.</span>
-                  </span>
+                  <span class="icon"><i class="fas fa-info"></i></span>
+                  <span>We currently only support <code>string</code> type.</span>
                 </p>
               </div>
 
@@ -79,15 +74,26 @@
                   <div class="icon is-small is-left"><i class="fas fa-check"></i></div>
                 </div>
                 <p class="help">
-                  <span class="icon-text">
-                    <span class="icon"><i class="fas fa-info"></i></span>
-                    <span>
-                      A Valid regular expression to check the value GUID value. To test your patterns, you can use this
-                      website
-                      <NuxtLink target="_blank" to="https://regex101.com/#php73" v-text="'regex101.com'"/>
-                      .
-                    </span>
+                  <span class="icon"><i class="fas fa-info"></i></span>
+                  <span>
+                    A Valid regular expression to check the value GUID value. To test your patterns, you can use this
+                    website
+                    <NuxtLink target="_blank" to="https://regex101.com/#php73" v-text="'regex101.com'"/>
+                    .
                   </span>
+                </p>
+              </div>
+              <div class="field">
+                <label class="label is-unselectable" for="form_validation_example">Value example</label>
+                <div class="control has-icons-left">
+                  <input class="input" id="form_validation_example" type="text" v-model="form.validator.example"
+                         placeholder="(number)">
+                  <div class="icon is-small is-left"><i class="fas fa-ear-deaf"></i></div>
+                </div>
+                <p class="help">
+                  <span class="icon"><i class="fas fa-info"></i></span>
+                  <span>The example to show when invalid value was checked. For example, <code>(number)</code>. For
+                    information purposes only.</span>
                 </p>
               </div>
 
@@ -100,7 +106,8 @@
                   <template v-for="(_, index) in form.validator.tests.valid" :key="`valid-${index}`">
                     <div class="column is-11">
                       <div class="control has-icons-left">
-                        <input class="input" type="text" v-model="form.validator.tests.valid[index]">
+                        <input class="input" type="text" :id="`valid-${index}`"
+                               v-model="form.validator.tests.valid[index]">
                         <div class="icon is-small is-left"><i class="fas fa-check"></i></div>
                       </div>
                     </div>
@@ -114,13 +121,12 @@
                   </template>
                 </div>
                 <p class="help">
-                  <span class="icon-text">
-                    <span class="icon"><i class="fas fa-info"></i></span>
-                    <span>
-                      The values added here must match the pattern defined above. Example: <code>123</code>.
-                      Additionally, the pattern also must support <code>/</code> being part of the value. as we used it
-                      for relative GUIDs. There must be a minimum of 1 correct value.
-                    </span>
+                  <span class="icon"><i class="fas fa-info"></i></span>
+                  <span>
+                    The values added here must match the pattern defined above. Example: <code>123</code>.
+                    Additionally, the pattern also must support <code>/</code> being part of the value. as we used it
+                    for relative GUIDs. The <code>(number)/1/1</code> refers to a relative GUID.
+                    There must be a minimum of 1 correct value.
                   </span>
                 </p>
               </div>
@@ -134,7 +140,8 @@
                   <template v-for="(_, index) in form.validator.tests.invalid" :key="`valid-${index}`">
                     <div class="column is-11">
                       <div class="control has-icons-left">
-                        <input class="input" type="text" v-model="form.validator.tests.invalid[index]">
+                        <input class="input" type="text" :id="`invalid-${index}`"
+                               v-model="form.validator.tests.invalid[index]">
                         <div class="icon is-small is-left"><i class="fas fa-check"></i></div>
                       </div>
                     </div>
@@ -148,18 +155,17 @@
                   </template>
                 </div>
                 <p class="help">
-                  <span class="icon-text">
-                    <span class="icon"><i class="fas fa-info"></i></span>
-                    <span>GUID values with should not match the pattern defined above. Example: <code>abc</code>. There
-                      must be a minimum of 1 incorrect value.</span>
-                  </span>
+                  <span class="icon"><i class="fas fa-info"></i></span>
+                  <span>GUID values with should not match the pattern defined above. Example: <code>abc</code>. There
+                    must be a minimum of 1 incorrect value.</span>
                 </p>
               </div>
             </div>
 
             <div class="card-footer">
               <div class="card-footer-item">
-                <button class="button is-fullwidth is-primary" type="submit" :disabled="false === checkForm">
+                <button class="button is-fullwidth is-primary" type="submit" :disabled="false === validForm || isSaving"
+                        :class="{'is-loading':isSaving}">
                   <span class="icon-text">
                     <span class="icon"><i class="fas fa-save"></i></span>
                     <span>Save</span>
@@ -167,7 +173,7 @@
                 </button>
               </div>
               <div class="card-footer-item">
-                <button class="button is-fullwidth is-danger" type="button" @click="cancelForm">
+                <button class="button is-fullwidth is-danger" type="button" @click="navigateTo('/custom')">
                   <span class="icon-text">
                     <span class="icon"><i class="fas fa-cancel"></i></span>
                     <span>Cancel</span>
@@ -201,15 +207,21 @@ useHead({title: 'Add Custom GUID'})
 
 const empty_form = {
   name: '',
-  type: '',
+  type: 'string',
   description: '',
-  validator: {pattern: '', example: '', tests: {valid: [''], invalid: ['']}}
+  validator: {
+    pattern: '/^[0-9\\\\/]+$/i',
+    example: '(number)',
+    tests: {
+      valid: ['1234567', '1234567/1/1'],
+      invalid: ['1234567a', 'a1234567']
+    }
+  }
 }
 const show_page_tips = useStorage('show_page_tips', true)
-
-const items = ref([])
 const form = ref(JSON.parse(JSON.stringify(empty_form)))
 const guids = ref([])
+const isSaving = ref(false)
 
 onMounted(async () => {
   try {
@@ -220,38 +232,121 @@ onMounted(async () => {
   }
 })
 
-const addIgnoreRule = async () => {
-  const val = guids.value.find(g => g.guid === form.value.db)
-  if (val && val?.validator && val.validator.pattern) {
-    if (!stringToRegex(val.validator.pattern).test(form.value.id)) {
-      notification('error', 'Error', `Invalid GUID value, must match the pattern: '${val.validator.pattern}'. Example ${val.validator.example}`, 5000)
-      return
-    }
+const addNewGuid = async () => {
+  if (!validForm.value) {
+    notification('error', 'Error', 'Invalid form data.', 5000)
+    return
+  }
+
+  let data = form.value
+
+  data.name = data.name.trim();
+
+  if (data.name.toLowerCase() !== data.name) {
+    notification('error', 'Error', `GUID name must be lowercase.`, 5000)
+    return
+  }
+
+  if (false === stringToRegex('/^[a-z0-9_]+$/').test(data.name)) {
+    notification('error', 'Error', `GUID name must be in ASCII, rules are [lower case, a-z, 0-9, no space] starts with guid_`, 5000)
+    return
+  }
+
+  if (data.name.includes(' ')) {
+    notification('error', 'Error', `GUID name must not contain spaces.`, 5000)
+    return
+  }
+
+  if (!data.name.startsWith('guid_')) {
+    notification('error', 'Error', `GUID name must start with 'guid_'.`, 5000)
+    return
+  }
+
+
+  data.type = data.type.trim().toLowerCase();
+  if (!['string'].includes(data.type)) {
+    notification('error', 'Error', `Invalid GUID type.`, 5000)
+    return
   }
 
   try {
-    const response = await request(`/ignore`, {
-      method: 'POST',
-      body: JSON.stringify(form.value)
+    toRaw(guids.value).forEach(g => {
+      const name = data.name.split('_')[1]
+      if (g.guid === name) {
+        throw new Error(`GUID with name '${data.name}' already exists.`)
+      }
+    })
+  } catch (e) {
+    notification('error', 'Error', `${e}`, 5000)
+    return false
+  }
+
+  try {
+    const validator = stringToRegex(data.validator.pattern);
+
+    for (let i = 0; i < data.validator.tests.valid.length; i++) {
+      if (!validator.test(data.validator.tests.valid[i])) {
+        notification('error', 'Error', `Correct value '${i}' '${data.validator.tests.valid[i]}' did not match '${data.validator.pattern}'.`, 5000)
+        return false
+      }
+      if (!validator.test(data.validator.tests.valid[i] + '/1')) {
+        notification('error', 'Error', `Correct value '${i}' with relative info '${data.validator.tests.valid[i] + '/1'}' did not match '${data.validator.pattern}'.`, 5000)
+        return false
+      }
+    }
+
+    for (let i = 0; i < data.validator.tests.invalid.length; i++) {
+      const invalid = data.validator.tests.invalid[i]
+      if (validator.test(data.validator.tests.invalid[i])) {
+        notification('error', 'Error', `Incorrect value '${i}' '${invalid}' matched '${data.validator.pattern}'.`, 5000)
+        return false
+      }
+    }
+
+  } catch (e) {
+    notification('error', 'Error', `Invalid regex pattern.`, 5000)
+    return false
+  }
+
+  isSaving.value = true
+
+  try {
+    const response = await request('/system/guids/custom', {
+      method: 'PUT',
+      body: JSON.stringify(data)
     })
 
-    const json = await response.json()
+    const json = await parse_api_response(response)
 
     if (!response.ok) {
       notification('error', 'Error', `${json.error.code}: ${json.error.message}`, 5000)
       return
     }
 
-    items.value.push(json)
-
-    notification('success', 'Success', 'Successfully added new ignore rule.', 5000)
+    notification('success', 'Success', 'Successfully added new GUID.', 5000)
+    await navigateTo('/custom')
   } catch (e) {
     notification('error', 'Error', `Request error. ${e.message}`, 5000)
+  } finally {
+    isSaving.value = false
   }
 }
 
-const checkForm = computed(() => {
-  const {id, type, backend, db} = form.value
-  return '' !== id && '' !== type && '' !== backend && '' !== db
+const validForm = computed(() => {
+  const data = form.value
+
+  if (!data.name || !data.type || !data.description) {
+    return false
+  }
+
+  if (!data.validator.pattern || !data.validator.example) {
+    return false
+  }
+
+  if (!data.validator.tests.valid.length || !data.validator.tests.invalid.length) {
+    return false
+  }
+
+  return !(!data.validator.tests.valid[0] || !data.validator.tests.invalid[0]);
 })
 </script>

--- a/frontend/pages/custom/add.vue
+++ b/frontend/pages/custom/add.vue
@@ -22,14 +22,15 @@
               <div class="field">
                 <label class="label is-unselectable" for="form_guid_name">Name</label>
                 <div class="control has-icons-left">
-                  <input class="input" id="form_guid_name" type="text" v-model="form.name" placeholder="guid_foobar">
+                  <input class="input" id="form_guid_name" type="text" v-model="form.name" placeholder="foobar">
                   <div class="icon is-small is-left"><i class="fas fa-passport"></i></div>
                 </div>
                 <p class="help">
                   <span class="icon"><i class="fas fa-info"></i></span>
-                  <span>The internal GUID reference name. The name must starts with <code>guid</code>, followed by
-                    <code>_</code>, <code>lower case [a-z]</code>, <code>0-9</code>, <code>no space</code>.
-                    For example, <code>guid_imdb</code>.
+                  <span>The internal GUID reference name. The rules are <code>lower case [a-z]</code>, <code>0-9</code>,
+                    <code>no space</code>.
+                    For example, <code>guid_imdb</code>. The guid name will be automatically prefixed with
+                    <code>guid_</code>.
                   </span>
                 </p>
               </div>
@@ -185,13 +186,13 @@
         </form>
       </div>
 
-      <div class="column is-12">
-        <Message message_class="has-background-info-90 has-text-dark" :toggle="show_page_tips"
-                 @toggle="show_page_tips = !show_page_tips" :use-toggle="true" title="Tips" icon="fas fa-info-circle">
-          <ul>
-          </ul>
-        </Message>
-      </div>
+      <!--      <div class="column is-12">-->
+      <!--        <Message message_class="has-background-info-90 has-text-dark" :toggle="show_page_tips"-->
+      <!--                 @toggle="show_page_tips = !show_page_tips" :use-toggle="true" title="Tips" icon="fas fa-info-circle">-->
+      <!--          <ul>-->
+      <!--          </ul>-->
+      <!--        </Message>-->
+      <!--      </div>-->
     </div>
   </div>
 </template>
@@ -201,7 +202,6 @@ import 'assets/css/bulma-switch.css'
 import request from '~/utils/request'
 import {notification, stringToRegex} from '~/utils/index'
 import {useStorage} from '@vueuse/core'
-import Message from '~/components/Message'
 
 useHead({title: 'Add Custom GUID'})
 
@@ -256,13 +256,7 @@ const addNewGuid = async () => {
     notification('error', 'Error', `GUID name must not contain spaces.`, 5000)
     return
   }
-
-  if (!data.name.startsWith('guid_')) {
-    notification('error', 'Error', `GUID name must start with 'guid_'.`, 5000)
-    return
-  }
-
-
+  
   data.type = data.type.trim().toLowerCase();
   if (!['string'].includes(data.type)) {
     notification('error', 'Error', `Invalid GUID type.`, 5000)

--- a/frontend/pages/custom/add.vue
+++ b/frontend/pages/custom/add.vue
@@ -1,0 +1,257 @@
+<template>
+  <div>
+    <div class="columns is-multiline">
+      <div class="column is-12 is-clearfix is-unselectable">
+        <span id="env_page_title" class="title is-4">
+          <span class="icon"><i class="fas fa-map"></i></span>
+          Add Custom GUID
+        </span>
+        <div class="is-hidden-mobile">
+          <span class="subtitle"></span>
+        </div>
+      </div>
+      <div class="column is-12">
+        <form id="page_form" @submit.prevent="addIgnoreRule">
+          <div class="card">
+            <header class="card-header">
+              <p class="card-header-title is-unselectable is-justify-center">Add Custom GUID</p>
+            </header>
+
+            <div class="card-content">
+
+              <div class="field">
+                <label class="label is-unselectable" for="form_ignore_id">Name</label>
+                <div class="control has-icons-left">
+                  <input class="input" id="form_guid_name" type="text" v-model="form.name" placeholder="guid_foobar">
+                  <div class="icon is-small is-left"><i class="fas fa-passport"></i></div>
+                </div>
+                <p class="help">
+                  <span class="icon-text">
+                    <span class="icon"><i class="fas fa-info"></i></span>
+                    <span>All GUIDs names must start with <code>guid_</code>. For example,
+                      <code>guid_foobar</code>. You cannot use the same name as an existing GUID.
+                    </span>
+                  </span>
+                </p>
+              </div>
+
+              <div class="field">
+                <label class="label is-unselectable" for="form_select_type">Type</label>
+                <div class="control has-icons-left">
+                  <div class="select is-fullwidth">
+                    <select id="form_select_type" v-model="form.type">
+                      <option value="" disabled>Select Type</option>
+                      <option value="string">String</option>
+                    </select>
+                  </div>
+                  <div class="icon is-left">
+                    <i class="fas fa-cog"></i>
+                  </div>
+                </div>
+                <p class="help">
+                  <span class="icon-text">
+                    <span class="icon"><i class="fas fa-info"></i></span>
+                    <span>We currently only support <code>string</code> type.</span>
+                  </span>
+                </p>
+              </div>
+
+              <div class="field">
+                <label class="label is-unselectable" for="form_description">Description</label>
+                <div class="control has-icons-left">
+                  <input class="input" id="form_description" type="text" v-model="form.description"
+                         placeholder="This GUID is based on ... db reference">
+                  <div class="icon is-small is-left"><i class="fas fa-envelope-open-text"></i></div>
+                </div>
+                <p class="help">
+                  <span class="icon-text">
+                    <span class="icon"><i class="fas fa-info"></i></span>
+                    <span>GUID description, For information purposes only.</span>
+                  </span>
+                </p>
+              </div>
+
+              <div class="field">
+                <label class="label is-unselectable" for="form_validation_pattern">Regex validation pattern</label>
+                <div class="control has-icons-left">
+                  <input class="input" id="form_validation_pattern" type="text" v-model="form.validator.pattern"
+                         placeholder="/^[0-9\\/]+$/i">
+                  <div class="icon is-small is-left"><i class="fas fa-check"></i></div>
+                </div>
+                <p class="help">
+                  <span class="icon-text">
+                    <span class="icon"><i class="fas fa-info"></i></span>
+                    <span>
+                      A Valid regular expression to check the value GUID value. To test your patterns, you can use this
+                      website
+                      <NuxtLink target="_blank" to="https://regex101.com/#php73" v-text="'regex101.com'"/>
+                      .
+                    </span>
+                  </span>
+                </p>
+              </div>
+
+              <div class="field">
+                <label class="label is-unselectable">
+                  Correct values.
+                  <NuxtLink class="has-text-primary" @click="form.validator.tests.valid.push('')" v-text="'Add'"/>
+                </label>
+                <div class="columns is-multiline">
+                  <template v-for="(_, index) in form.validator.tests.valid" :key="`valid-${index}`">
+                    <div class="column is-11">
+                      <div class="control has-icons-left">
+                        <input class="input" type="text" v-model="form.validator.tests.valid[index]">
+                        <div class="icon is-small is-left"><i class="fas fa-check"></i></div>
+                      </div>
+                    </div>
+                    <div class="column">
+                      <button class="button is-danger" type="button"
+                              @click="form.validator.tests.valid.splice(index, 1)"
+                              :disabled="index < 1 || form.validator.tests.valid < 1">
+                        <span class="icon"><i class="fas fa-trash"></i></span>
+                      </button>
+                    </div>
+                  </template>
+                </div>
+                <p class="help">
+                  <span class="icon-text">
+                    <span class="icon"><i class="fas fa-info"></i></span>
+                    <span>
+                      The values added here must match the pattern defined above. Example: <code>123</code>.
+                      Additionally, the pattern also must support <code>/</code> being part of the value. as we used it
+                      for relative GUIDs. There must be a minimum of 1 correct value.
+                    </span>
+                  </span>
+                </p>
+              </div>
+
+              <div class="field">
+                <label class="label is-unselectable">
+                  Incorrect values.
+                  <NuxtLink class="has-text-danger" @click="form.validator.tests.invalid.push('')" v-text="'Add'"/>
+                </label>
+                <div class="columns is-multiline">
+                  <template v-for="(_, index) in form.validator.tests.invalid" :key="`valid-${index}`">
+                    <div class="column is-11">
+                      <div class="control has-icons-left">
+                        <input class="input" type="text" v-model="form.validator.tests.invalid[index]">
+                        <div class="icon is-small is-left"><i class="fas fa-check"></i></div>
+                      </div>
+                    </div>
+                    <div class="column">
+                      <button class="button is-danger" type="button"
+                              @click="form.validator.tests.invalid.splice(index, 1)"
+                              :disabled="index < 1 || form.validator.tests.invalid < 1">
+                        <span class="icon"><i class="fas fa-trash"></i></span>
+                      </button>
+                    </div>
+                  </template>
+                </div>
+                <p class="help">
+                  <span class="icon-text">
+                    <span class="icon"><i class="fas fa-info"></i></span>
+                    <span>GUID values with should not match the pattern defined above. Example: <code>abc</code>. There
+                      must be a minimum of 1 incorrect value.</span>
+                  </span>
+                </p>
+              </div>
+            </div>
+
+            <div class="card-footer">
+              <div class="card-footer-item">
+                <button class="button is-fullwidth is-primary" type="submit" :disabled="false === checkForm">
+                  <span class="icon-text">
+                    <span class="icon"><i class="fas fa-save"></i></span>
+                    <span>Save</span>
+                  </span>
+                </button>
+              </div>
+              <div class="card-footer-item">
+                <button class="button is-fullwidth is-danger" type="button" @click="cancelForm">
+                  <span class="icon-text">
+                    <span class="icon"><i class="fas fa-cancel"></i></span>
+                    <span>Cancel</span>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+
+      <div class="column is-12">
+        <Message message_class="has-background-info-90 has-text-dark" :toggle="show_page_tips"
+                 @toggle="show_page_tips = !show_page_tips" :use-toggle="true" title="Tips" icon="fas fa-info-circle">
+          <ul>
+          </ul>
+        </Message>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import 'assets/css/bulma-switch.css'
+import request from '~/utils/request'
+import {notification, stringToRegex} from '~/utils/index'
+import {useStorage} from '@vueuse/core'
+import Message from '~/components/Message'
+
+useHead({title: 'Add Custom GUID'})
+
+const empty_form = {
+  name: '',
+  type: '',
+  description: '',
+  validator: {pattern: '', example: '', tests: {valid: [''], invalid: ['']}}
+}
+const show_page_tips = useStorage('show_page_tips', true)
+
+const items = ref([])
+const form = ref(JSON.parse(JSON.stringify(empty_form)))
+const guids = ref([])
+
+onMounted(async () => {
+  try {
+    const response = await request('/system/guids')
+    guids.value = await response.json()
+  } catch (e) {
+    notification('error', 'Error', `Request error. ${e.message}`, 5000)
+  }
+})
+
+const addIgnoreRule = async () => {
+  const val = guids.value.find(g => g.guid === form.value.db)
+  if (val && val?.validator && val.validator.pattern) {
+    if (!stringToRegex(val.validator.pattern).test(form.value.id)) {
+      notification('error', 'Error', `Invalid GUID value, must match the pattern: '${val.validator.pattern}'. Example ${val.validator.example}`, 5000)
+      return
+    }
+  }
+
+  try {
+    const response = await request(`/ignore`, {
+      method: 'POST',
+      body: JSON.stringify(form.value)
+    })
+
+    const json = await response.json()
+
+    if (!response.ok) {
+      notification('error', 'Error', `${json.error.code}: ${json.error.message}`, 5000)
+      return
+    }
+
+    items.value.push(json)
+
+    notification('success', 'Success', 'Successfully added new ignore rule.', 5000)
+  } catch (e) {
+    notification('error', 'Error', `Request error. ${e.message}`, 5000)
+  }
+}
+
+const checkForm = computed(() => {
+  const {id, type, backend, db} = form.value
+  return '' !== id && '' !== type && '' !== backend && '' !== db
+})
+</script>

--- a/frontend/pages/custom/addlink.vue
+++ b/frontend/pages/custom/addlink.vue
@@ -7,159 +7,147 @@
           Add new client GUID link
         </span>
         <div class="is-hidden-mobile">
-          <span class="subtitle"></span>
+          <span class="subtitle">
+            This page allows you to add a new client GUID link. The client GUID link is used to link the client/backend
+            GUID to the <code>WatchState</code> GUID or your custom GUID.
+          </span>
         </div>
       </div>
 
       <div class="column is-12">
         <form id="page_form" @submit.prevent="addNewLink">
-          <div class="card">
-            <header class="card-header">
-              <p class="card-header-title is-unselectable is-justify-center">Add new client GUID link</p>
-            </header>
 
-            <div class="card-content">
+          <div class="field">
+            <label class="label is-unselectable" for="form_select_type">Client</label>
+            <div class="control has-icons-left">
+              <div class="select is-fullwidth">
+                <select id="form_select_type" v-model="form.type">
+                  <option value="" disabled>Select client type</option>
+                  <option v-for="client in supported" :value="client" :key="`client-${client}`">
+                    {{ ucFirst(client) }}
+                  </option>
+                </select>
+              </div>
+              <div class="icon is-left">
+                <i class="fas fa-server"></i>
+              </div>
+            </div>
+            <p class="help">
+              <span class="icon"><i class="fas fa-info"></i></span>
+              <span>Select which client this link association for.</span>
+            </p>
+          </div>
+
+          <div class="field">
+            <label class="label is-unselectable" for="form_map_from">Link client GUID</label>
+            <div class="control has-icons-left">
+              <input class="input" id="form_map_from" type="text" v-model="form.map.from">
+              <div class="icon is-small is-left"><i class="fas fa-a"></i></div>
+            </div>
+            <p class="help">
+              <span class="icon"><i class="fas fa-info"></i></span>
+              <span>Write the <code>{{ form.type.length > 0 ? ucFirst(form.type) : 'client' }}</code> GUID
+                identifier.</span>
+            </p>
+          </div>
+
+          <div class="field">
+            <label class="label is-unselectable" for="form_map_to">To This GUID</label>
+            <div class="control has-icons-left">
+              <div class="select is-fullwidth">
+                <select id="form_map_to" v-model="form.map.to">
+                  <option value="" disabled>Select the associated GUID</option>
+                  <option v-for="(g) in guids" :value="g.guid" :key="`guid-${g.guid}`">
+                    {{ g.guid }}
+                  </option>
+                </select>
+              </div>
+              <div class="icon is-left">
+                <i class="fas fa-b"></i>
+              </div>
+            </div>
+            <p class="help">
+              <span class="icon"><i class="fas fa-info"></i></span>
+              <span>
+                Select which <code>WatchState</code> GUID should link with this
+                <code>{{ form.type.length > 0 ? ucFirst(form.type) : 'client' }}</code> GUID identifier.
+              </span>
+            </p>
+          </div>
+
+          <div class="field" v-if="'plex' === form.type">
+            <label class="label" for="backend_import">Is this a Plex legacy agent GUID?</label>
+            <div class="control">
+              <input id="backend_import" type="checkbox" class="switch is-success" v-model="form.options.legacy">
+              <label for="backend_import">Enable</label>
+              <p class="help">Plex legacy agents starts with <code>com.plexapp.agents.</code></p>
+            </div>
+          </div>
+
+          <template v-if="'plex' === form.type && true === form.options.legacy">
+            <div class="field">
+              <label class="label is-clickable is-unselectable" @click="toggleReplace = !toggleReplace">
+                <span class="icon">
+                  <i class="fas" :class="{ 'fa-arrow-up': toggleReplace, 'fa-arrow-down': !toggleReplace }"></i>
+                </span>
+                Toggle Text replacement.
+              </label>
+              <p class="help">
+                <span class="icon"><i class="fas fa-info"></i></span>
+                <span>Text replacement only works for plex legacy agents.</span>
+              </p>
+            </div>
+
+            <template v-if="toggleReplace">
               <div class="field">
-                <label class="label is-unselectable" for="form_select_type">Client</label>
+                <label class="label is-unselectable" for="form_replace_from">Search for</label>
                 <div class="control has-icons-left">
-                  <div class="select is-fullwidth">
-                    <select id="form_select_type" v-model="form.type">
-                      <option value="" disabled>Select client type</option>
-                      <option v-for="client in supported" :value="client" :key="`client-${client}`">
-                        {{ ucFirst(client) }}
-                      </option>
-                    </select>
-                  </div>
-                  <div class="icon is-left">
-                    <i class="fas fa-server"></i>
-                  </div>
+                  <input class="input" id="form_replace_from" type="text" v-model="form.replace.from">
+                  <div class="icon is-small is-left"><i class="fas fa-passport"></i></div>
                 </div>
                 <p class="help">
                   <span class="icon"><i class="fas fa-info"></i></span>
-                  <span>Select which client this link association for.</span>
+                  <span>The text string to replace. Sometimes it's necessary to replace legacy agent GUID into
+                    something else. Leave it empty to ignore it.</span>
                 </p>
               </div>
-
               <div class="field">
-                <label class="label is-unselectable" for="form_map_from">Link client GUID</label>
+                <label class="label is-unselectable" for="form_replace_to">Replace with</label>
                 <div class="control has-icons-left">
-                  <input class="input" id="form_map_from" type="text" v-model="form.map.from">
-                  <div class="icon is-small is-left"><i class="fas fa-a"></i></div>
+                  <input class="input" id="form_replace_to" type="text" v-model="form.replace.to">
+                  <div class="icon is-small is-left"><i class="fas fa-passport"></i></div>
                 </div>
                 <p class="help">
                   <span class="icon"><i class="fas fa-info"></i></span>
-                  <span>Write the <code>{{ form.type.length > 0 ? ucFirst(form.type) : 'client' }}</code> GUID
-                    identifier.</span>
+                  <span>The string replacement. If <code>replace.from</code> is empty this field will be
+                    ignored.</span>
                 </p>
               </div>
+            </template>
+          </template>
 
-              <div class="field">
-                <label class="label is-unselectable" for="form_map_to">To This GUID</label>
-                <div class="control has-icons-left">
-                  <div class="select is-fullwidth">
-                    <select id="form_map_to" v-model="form.map.to">
-                      <option value="" disabled>Select the associated GUID</option>
-                      <option v-for="(g) in guids" :value="g.guid" :key="`guid-${g.guid}`">
-                        {{ g.guid }}
-                      </option>
-                    </select>
-                  </div>
-                  <div class="icon is-left">
-                    <i class="fas fa-b"></i>
-                  </div>
-                </div>
-                <p class="help">
-                  <span class="icon"><i class="fas fa-info"></i></span>
-                  <span>
-                    Select which <code>WatchState</code> GUID should link with this
-                    <code>{{ form.type.length > 0 ? ucFirst(form.type) : 'client' }}</code> GUID identifier.
-                  </span>
-                </p>
-              </div>
-
-              <div class="field" v-if="'plex' === form.type">
-                <label class="label" for="backend_import">Is this a Plex legacy agent GUID?</label>
-                <div class="control">
-                  <input id="backend_import" type="checkbox" class="switch is-success" v-model="form.options.legacy">
-                  <label for="backend_import">Enable</label>
-                  <p class="help">Plex legacy agents starts with <code>com.plexapp.agents.</code></p>
-                </div>
-              </div>
-
-              <template v-if="'plex' === form.type && true === form.options.legacy">
-                <div class="field">
-                  <label class="label is-clickable is-unselectable" @click="toggleReplace = !toggleReplace">
-                    <span class="icon">
-                      <i class="fas" :class="{ 'fa-arrow-up': toggleReplace, 'fa-arrow-down': !toggleReplace }"></i>
-                    </span>
-                    Toggle Text replacement.
-                  </label>
-                  <p class="help">
-                    <span class="icon"><i class="fas fa-info"></i></span>
-                    <span>Text replacement only works for plex legacy agents.</span>
-                  </p>
-                </div>
-
-                <template v-if="toggleReplace">
-                  <div class="field">
-                    <label class="label is-unselectable" for="form_replace_from">Search for</label>
-                    <div class="control has-icons-left">
-                      <input class="input" id="form_replace_from" type="text" v-model="form.replace.from">
-                      <div class="icon is-small is-left"><i class="fas fa-passport"></i></div>
-                    </div>
-                    <p class="help">
-                      <span class="icon"><i class="fas fa-info"></i></span>
-                      <span>The text string to replace. Sometimes it's necessary to replace legacy agent GUID into
-                        something else. Leave it empty to ignore it.</span>
-                    </p>
-                  </div>
-                  <div class="field">
-                    <label class="label is-unselectable" for="form_replace_to">Replace with</label>
-                    <div class="control has-icons-left">
-                      <input class="input" id="form_replace_to" type="text" v-model="form.replace.to">
-                      <div class="icon is-small is-left"><i class="fas fa-passport"></i></div>
-                    </div>
-                    <p class="help">
-                      <span class="icon"><i class="fas fa-info"></i></span>
-                      <span>The string replacement. If <code>replace.from</code> is empty this field will be
-                        ignored.</span>
-                    </p>
-                  </div>
-                </template>
-              </template>
-
-              <div class="card-footer">
-                <div class="card-footer-item">
-                  <button class="button is-fullwidth is-primary" type="submit"
-                          :disabled="false === validForm || isSaving"
-                          :class="{'is-loading':isSaving}">
-                    <span class="icon-text">
-                      <span class="icon"><i class="fas fa-save"></i></span>
-                      <span>Save</span>
-                    </span>
-                  </button>
-                </div>
-                <div class="card-footer-item">
-                  <button class="button is-fullwidth is-danger" type="button" @click="navigateTo('/custom')">
-                    <span class="icon-text">
-                      <span class="icon"><i class="fas fa-cancel"></i></span>
-                      <span>Cancel</span>
-                    </span>
-                  </button>
-                </div>
-              </div>
+          <div class="field is-grouped">
+            <div class="control is-expanded">
+              <button class="button is-fullwidth is-primary" type="submit"
+                      :disabled="false === validForm || isSaving"
+                      :class="{'is-loading':isSaving}">
+                <span class="icon-text">
+                  <span class="icon"><i class="fas fa-save"></i></span>
+                  <span>Save</span>
+                </span>
+              </button>
+            </div>
+            <div class="control is-expanded">
+              <button class="button is-fullwidth is-danger" type="button" @click="navigateTo('/custom')">
+                <span class="icon-text">
+                  <span class="icon"><i class="fas fa-cancel"></i></span>
+                  <span>Cancel</span>
+                </span>
+              </button>
             </div>
           </div>
         </form>
       </div>
-
-      <!--      <div class="column is-12">-->
-      <!--        <Message message_class="has-background-info-90 has-text-dark" :toggle="show_page_tips"-->
-      <!--                 @toggle="show_page_tips = !show_page_tips" :use-toggle="true" title="Tips" icon="fas fa-info-circle">-->
-      <!--          <ul>-->
-      <!--          </ul>-->
-      <!--        </Message>-->
-      <!--      </div>-->
     </div>
   </div>
 </template>
@@ -197,15 +185,15 @@ const toggleReplace = ref(false)
 onMounted(async () => {
   try {
 
-    /** @type {Array<Promise>} */
+    /** @type {Array<Promise<Response>>} */
     const responses = await Promise.all([
       request('/system/guids'),
       request('/system/supported'),
       request('/system/guids/custom'),
     ])
 
-    guids.value = await parse_api_response(responses[0])
-    supported.value = await parse_api_response(responses[1])
+    guids.value = await parse_api_response(responses[0]) ?? []
+    supported.value = await parse_api_response(responses[1]) ?? []
     links.value = (await parse_api_response(responses[2])).links ?? []
 
   } catch (e) {
@@ -288,13 +276,5 @@ const addNewLink = async () => {
   }
 }
 
-const validForm = computed(() => {
-  const data = form.value
-
-  if (!data.map.to || !data.map.from || !data.type) {
-    return false
-  }
-
-  return true
-})
+const validForm = computed(() => !(!form.value.map.to || !form.value.map.from || !form.value.type))
 </script>

--- a/frontend/pages/custom/addlink.vue
+++ b/frontend/pages/custom/addlink.vue
@@ -1,0 +1,300 @@
+<template>
+  <div>
+    <div class="columns is-multiline">
+      <div class="column is-12 is-clearfix is-unselectable">
+        <span id="env_page_title" class="title is-4">
+          <span class="icon"><i class="fas fa-exchange-alt"></i></span>
+          Add new client GUID link
+        </span>
+        <div class="is-hidden-mobile">
+          <span class="subtitle"></span>
+        </div>
+      </div>
+
+      <div class="column is-12">
+        <form id="page_form" @submit.prevent="addNewLink">
+          <div class="card">
+            <header class="card-header">
+              <p class="card-header-title is-unselectable is-justify-center">Add new client GUID link</p>
+            </header>
+
+            <div class="card-content">
+              <div class="field">
+                <label class="label is-unselectable" for="form_select_type">Client</label>
+                <div class="control has-icons-left">
+                  <div class="select is-fullwidth">
+                    <select id="form_select_type" v-model="form.type">
+                      <option value="" disabled>Select client type</option>
+                      <option v-for="client in supported" :value="client" :key="`client-${client}`">
+                        {{ ucFirst(client) }}
+                      </option>
+                    </select>
+                  </div>
+                  <div class="icon is-left">
+                    <i class="fas fa-server"></i>
+                  </div>
+                </div>
+                <p class="help">
+                  <span class="icon"><i class="fas fa-info"></i></span>
+                  <span>Select which client this link association for.</span>
+                </p>
+              </div>
+
+              <div class="field">
+                <label class="label is-unselectable" for="form_map_from">Link client GUID</label>
+                <div class="control has-icons-left">
+                  <input class="input" id="form_map_from" type="text" v-model="form.map.from">
+                  <div class="icon is-small is-left"><i class="fas fa-a"></i></div>
+                </div>
+                <p class="help">
+                  <span class="icon"><i class="fas fa-info"></i></span>
+                  <span>Write the <code>{{ form.type.length > 0 ? ucFirst(form.type) : 'client' }}</code> GUID
+                    identifier.</span>
+                </p>
+              </div>
+
+              <div class="field">
+                <label class="label is-unselectable" for="form_map_to">To This GUID</label>
+                <div class="control has-icons-left">
+                  <div class="select is-fullwidth">
+                    <select id="form_map_to" v-model="form.map.to">
+                      <option value="" disabled>Select the associated GUID</option>
+                      <option v-for="(g) in guids" :value="g.guid" :key="`guid-${g.guid}`">
+                        {{ g.guid }}
+                      </option>
+                    </select>
+                  </div>
+                  <div class="icon is-left">
+                    <i class="fas fa-b"></i>
+                  </div>
+                </div>
+                <p class="help">
+                  <span class="icon"><i class="fas fa-info"></i></span>
+                  <span>
+                    Select which <code>WatchState</code> GUID should link with this
+                    <code>{{ form.type.length > 0 ? ucFirst(form.type) : 'client' }}</code> GUID identifier.
+                  </span>
+                </p>
+              </div>
+
+              <div class="field" v-if="'plex' === form.type">
+                <label class="label" for="backend_import">Is this a Plex legacy agent GUID?</label>
+                <div class="control">
+                  <input id="backend_import" type="checkbox" class="switch is-success" v-model="form.options.legacy">
+                  <label for="backend_import">Enable</label>
+                  <p class="help">Plex legacy agents starts with <code>com.plexapp.agents.</code></p>
+                </div>
+              </div>
+
+              <template v-if="'plex' === form.type && true === form.options.legacy">
+                <div class="field">
+                  <label class="label is-clickable is-unselectable" @click="toggleReplace = !toggleReplace">
+                    <span class="icon">
+                      <i class="fas" :class="{ 'fa-arrow-up': toggleReplace, 'fa-arrow-down': !toggleReplace }"></i>
+                    </span>
+                    Toggle Text replacement.
+                  </label>
+                  <p class="help">
+                    <span class="icon"><i class="fas fa-info"></i></span>
+                    <span>Text replacement only works for plex legacy agents.</span>
+                  </p>
+                </div>
+
+                <template v-if="toggleReplace">
+                  <div class="field">
+                    <label class="label is-unselectable" for="form_replace_from">Search for</label>
+                    <div class="control has-icons-left">
+                      <input class="input" id="form_replace_from" type="text" v-model="form.replace.from">
+                      <div class="icon is-small is-left"><i class="fas fa-passport"></i></div>
+                    </div>
+                    <p class="help">
+                      <span class="icon"><i class="fas fa-info"></i></span>
+                      <span>The text string to replace. Sometimes it's necessary to replace legacy agent GUID into
+                        something else. Leave it empty to ignore it.</span>
+                    </p>
+                  </div>
+                  <div class="field">
+                    <label class="label is-unselectable" for="form_replace_to">Replace with</label>
+                    <div class="control has-icons-left">
+                      <input class="input" id="form_replace_to" type="text" v-model="form.replace.to">
+                      <div class="icon is-small is-left"><i class="fas fa-passport"></i></div>
+                    </div>
+                    <p class="help">
+                      <span class="icon"><i class="fas fa-info"></i></span>
+                      <span>The string replacement. If <code>replace.from</code> is empty this field will be
+                        ignored.</span>
+                    </p>
+                  </div>
+                </template>
+              </template>
+
+              <div class="card-footer">
+                <div class="card-footer-item">
+                  <button class="button is-fullwidth is-primary" type="submit"
+                          :disabled="false === validForm || isSaving"
+                          :class="{'is-loading':isSaving}">
+                    <span class="icon-text">
+                      <span class="icon"><i class="fas fa-save"></i></span>
+                      <span>Save</span>
+                    </span>
+                  </button>
+                </div>
+                <div class="card-footer-item">
+                  <button class="button is-fullwidth is-danger" type="button" @click="navigateTo('/custom')">
+                    <span class="icon-text">
+                      <span class="icon"><i class="fas fa-cancel"></i></span>
+                      <span>Cancel</span>
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+
+      <!--      <div class="column is-12">-->
+      <!--        <Message message_class="has-background-info-90 has-text-dark" :toggle="show_page_tips"-->
+      <!--                 @toggle="show_page_tips = !show_page_tips" :use-toggle="true" title="Tips" icon="fas fa-info-circle">-->
+      <!--          <ul>-->
+      <!--          </ul>-->
+      <!--        </Message>-->
+      <!--      </div>-->
+    </div>
+  </div>
+</template>
+
+<script setup>
+import 'assets/css/bulma-switch.css'
+import request from '~/utils/request'
+import {notification, parse_api_response} from '~/utils/index'
+import {useStorage} from '@vueuse/core'
+
+useHead({title: 'Add new client GUID link'})
+
+const empty_form = {
+  type: '',
+  options: {
+    legacy: true,
+  },
+  map: {
+    from: '',
+    to: ''
+  },
+  replace: {
+    from: '',
+    to: ''
+  },
+}
+const show_page_tips = useStorage('show_page_tips', true)
+const form = ref(JSON.parse(JSON.stringify(empty_form)))
+const guids = ref([])
+const supported = ref([])
+const isSaving = ref(false)
+const links = ref([])
+const toggleReplace = ref(false)
+
+onMounted(async () => {
+  try {
+
+    /** @type {Array<Promise>} */
+    const responses = await Promise.all([
+      request('/system/guids'),
+      request('/system/supported'),
+      request('/system/guids/custom'),
+    ])
+
+    guids.value = await parse_api_response(responses[0])
+    supported.value = await parse_api_response(responses[1])
+    links.value = (await parse_api_response(responses[2])).links ?? []
+
+  } catch (e) {
+    notification('error', 'Error', `Request error. ${e.message}`, 5000)
+  }
+})
+
+const addNewLink = async () => {
+  if (!validForm.value) {
+    notification('error', 'Error', 'Invalid form data.', 5000)
+    return
+  }
+
+  let data = form.value
+
+  if (!supported.value.includes(data.type)) {
+    notification('error', 'Error', `Invalid client type.`, 5000)
+    return
+  }
+
+  if (!data.map.from) {
+    notification('error', 'Error', `map.from must not be empty.`, 5000)
+    return
+  }
+
+  if (!guids.value.find(g => g.guid === data.map.to)) {
+    notification('error', 'Error', `Invalid map.to value '${data.map.to}'.`, 5000)
+    return
+  }
+
+  for (let i = 0; i < links.value.length; i++) {
+    if (links.value[i].type === data.type && links.value[i].map.from === data.map.from) {
+      notification('error', 'Error', `Link with map.from '${data.map.from}' already exists.`, 5000)
+      return
+    }
+  }
+
+  let formData = {
+    type: data.type,
+    map: {
+      from: data.map.from,
+      to: data.map.to
+    }
+  }
+
+  if ('plex' === data.type) {
+    formData.options = {
+      legacy: Boolean(data.options.legacy),
+    }
+
+    if (data.replace.from && data.replace.to) {
+      formData.replace = {
+        from: data.replace.from,
+        to: data.replace.to
+      }
+    }
+  }
+
+  isSaving.value = true
+
+  try {
+    const response = await request(`/system/guids/custom/${formData.type}`, {
+      method: 'PUT',
+      body: JSON.stringify(formData)
+    })
+
+    const json = await parse_api_response(response)
+
+    if (!response.ok) {
+      notification('error', 'Error', `${json.error.code}: ${json.error.message}`, 5000)
+      return
+    }
+
+    notification('success', 'Success', 'Successfully added new client link.', 5000)
+    await navigateTo('/custom')
+  } catch (e) {
+    notification('error', 'Error', `Request error. ${e.message}`, 5000)
+  } finally {
+    isSaving.value = false
+  }
+}
+
+const validForm = computed(() => {
+  const data = form.value
+
+  if (!data.map.to || !data.map.from || !data.type) {
+    return false
+  }
+
+  return true
+})
+</script>

--- a/frontend/pages/custom/index.vue
+++ b/frontend/pages/custom/index.vue
@@ -26,9 +26,7 @@
           </div>
         </div>
         <div class="is-hidden-mobile">
-          <span class="subtitle">
-            This page allow you to add custom GUIDs to the system and link them to the client GUIDs.
-          </span>
+          <span class="subtitle">User defined custom GUIDs.</span>
         </div>
       </div>
 
@@ -37,9 +35,9 @@
                  icon="fas fa-spinner fa-spin" message="Loading data. Please wait..."/>
       </div>
 
-      <div class="column is-12" v-if="!isLoading && data">
-        <div class="columns is-multiline" v-if="data?.guids?.length >0">
-          <div class="column is-3-tablet" v-for="(guid, index) in data.guids" :key="guid.name">
+      <div class="column is-12" v-if="!isLoading && guids">
+        <div class="columns is-multiline" v-if="guids?.length >0">
+          <div class="column is-3-tablet" v-for="(guid, index) in guids" :key="guid.name">
             <div class="card">
               <header class="card-header">
                 <p class="card-header-title is-text-overflow pr-1">
@@ -58,7 +56,8 @@
           </div>
         </div>
         <div v-else>
-          <Message message_class="has-background-warning-90 has-text-dark" title="Information" icon="fas fa-check">
+          <Message message_class="has-background-warning-90 has-text-dark" title="Information"
+                   icon="fas fa-exclamation">
             There are no custom GUIDs configured. You can add new GUIDs by clicking on the <i class="fa fa-add"></i>
             button.
           </Message>
@@ -81,14 +80,14 @@
           </div>
         </div>
         <div class="is-hidden-mobile">
-          <span class="subtitle">This section contains the client <> WatchState GUID links.</span>
+          <span class="subtitle">Client <--> WatchState GUID links.</span>
         </div>
       </div>
 
       <div class="column is-12">
-        <div class="column is-12" v-if="!isLoading && data && data?.links?.length > 0">
+        <div class="column is-12" v-if="!isLoading && links?.length > 0">
           <div class="columns is-multiline">
-            <div class="column is-6-tablet" v-for="(link,index) in data.links" :key="link.id">
+            <div class="column is-6-tablet" v-for="(link, index) in links" :key="link.id">
               <div class="card">
                 <header class="card-header">
                   <template v-if="link.replace?.from">
@@ -152,21 +151,56 @@
           </div>
         </div>
         <div v-else>
-          <Message message_class="has-background-warning-90 has-text-dark" title="Information" icon="fas fa-xmark">
-            There are no client links configured. You can add new links by clicking on the <i class="fa fa-add"></i>
+          <Message message_class="has-background-warning-90 has-text-dark" title="Information"
+                   icon="fas fa-exclamation">
+            There are no client GUID links configured. You can add new links by clicking on the <i
+              class="fa fa-add"></i>
             button.
           </Message>
         </div>
       </div>
-      <!--      <div class="column is-12">-->
-      <!--        <Message message_class="has-background-info-90 has-text-dark" :toggle="show_page_tips"-->
-      <!--                 @toggle="show_page_tips = !show_page_tips" :use-toggle="true" title="Tips" icon="fas fa-info-circle">-->
-      <!--          <ul>-->
-      <!--            <li>-->
-      <!--            </li>-->
-      <!--          </ul>-->
-      <!--        </Message>-->
-      <!--      </div>-->
+      <div class="column is-12">
+        <Message message_class="has-background-info-90 has-text-dark" :toggle="show_page_tips"
+                 @toggle="show_page_tips = !show_page_tips" :use-toggle="true" title="Tips" icon="fas fa-info-circle">
+          <ul>
+            <li>Using this feature allows you to extend <code>WatchState</code> to support more less known or regional
+              specific metadata databases. We cannot add support directly to all databases, so this feature instead
+              allow you to manually do it yourself.
+            </li>
+            <li>
+              Adding Custom guid without a client/s links is useless as the parsing engine will not know what to do with
+              it. So, make sure to add a client GUID link referencing the custom GUID.
+            </li>
+            <li>The guid names are unique. Therefore, you cannot reuse existing ones.</li>
+            <li>You cannot add link from the same client GUID twice. For example you cannot add <code>jellyfin:foobar ->
+              WatchState:guid_foobar</code> and another for <code>jellyfin:foobar -> guid_imdb</code>.
+            </li>
+            <li>Editing the <code>guid.yaml</code> file directly is unsupported and might lead to unexpected behavior.
+              Please use the WebUI to manage the GUIDs. as we expose the entire functionality via the WebUI. with
+              safeguards to prevent you from doing something that might break the system.
+            </li>
+            <li>If you added or removed Custom GUID, you should run
+              <NuxtLink :to="makeConsoleCommand('system:index --force-reindex',false)">
+                <span class="icon"><i class="fas fa-terminal"></i>&nbsp;</span>
+                <span>system:index --force-reindex</span>
+              </NuxtLink>
+              command to rebuild the database indexes. While not required, it is recommended to ensure the database is
+              up to date. and the indexing is correct and for speedy database operations.
+            </li>
+            <li>The links are global for each client, not the backend itself. So, For example, if you have NN jellyfin
+              backends and you add new GUID link for jellyfin, it will be applied to all jellyfin backends. The backends
+              themselves don't need to report it, however the support will be available for all backends.
+            </li>
+            <li>For more information please read the content in the <code>FAQ.md</code> page, or directly via
+              <NuxtLink target="_blank"
+                        to="https://github.com/arabcoders/watchstate/blob/master/FAQ.md#advanced-how-to-extend-the-guid-parser-to-support-more-guids-or-custom-ones">
+                <span class="icon"><i class="fas fa-external-link-alt"></i>&nbsp;</span>
+                <span>this link</span>
+              </NuxtLink>
+            </li>
+          </ul>
+        </Message>
+      </div>
     </div>
   </div>
 </template>
@@ -174,20 +208,27 @@
 <script setup>
 import 'assets/css/bulma-switch.css'
 import request from '~/utils/request'
-import {notification, parse_api_response} from '~/utils/index'
+import {makeConsoleCommand, notification, parse_api_response} from '~/utils/index'
 import {useStorage} from '@vueuse/core'
 import Message from '~/components/Message'
 
 useHead({title: 'Custom Guids'})
 
-const data = ref({})
+const guids = ref([])
+const links = ref([])
 const show_page_tips = useStorage('show_page_tips', true)
 const isLoading = ref(false)
 
 const loadContent = async () => {
+  isLoading.value = true
   try {
-    isLoading.value = true
-    data.value = await parse_api_response(await request(`/system/guids/custom`))
+    const response = await parse_api_response(await request(`/system/guids/custom`))
+    for (const i of Object.keys(response.guids)) {
+      guids.value.push(response.guids[i])
+    }
+    for (const i of Object.keys(response.links)) {
+      links.value.push(response.links[i])
+    }
   } catch (e) {
     isLoading.value = false
     return notification('error', 'Error', e.message)
@@ -199,21 +240,45 @@ const loadContent = async () => {
 onMounted(async () => await loadContent())
 
 const deleteGUID = async (index, guid) => {
-  if (!confirm(`Are you sure you want to delete the GUID: '${guid.name}'?`)) {
+  if (!confirm(`Delete '${guid.name}'? links using this GUID will be deleted as well.`)) {
     return
   }
 
   try {
     const response = await request(`/system/guids/custom/${guid.id}`, {method: 'DELETE'})
-    const result = await parse_api_response(response)
-    if (response.ok) {
-      data.value.guids.splice(index, 1)
-      notification('success', 'Success', result.message)
-    } else {
+    if (!response.ok) {
+      const result = await parse_api_response(response)
       notification('error', 'Error', result.error.message)
+      return
     }
+
+    guids.value.splice(index, 1)
+    links.value = links.value.filter(link => link.map.to !== guid.name)
+
+    notification('success', 'Success', `The GUID '${guid.name}' has been deleted.`)
   } catch (e) {
     return notification('error', 'Error', e.message)
   }
 }
+
+const deleteLink = async (index, link) => {
+  if (!confirm(`Are you sure you want to delete the '${link.type}' - '${link.id}'?`)) {
+    return
+  }
+
+  try {
+    const response = await request(`/system/guids/custom/${link.type}/${link.id}`, {method: 'DELETE'})
+    if (!response.ok) {
+      const result = await parse_api_response(response)
+      notification('error', 'Error', result.error.message)
+      return
+    }
+
+    links.value.splice(index, 1)
+    notification('success', 'Success', `The link '${link.type}' - '${link.id}' has been deleted.`)
+  } catch (e) {
+    return notification('error', 'Error', e.message)
+  }
+}
+
 </script>

--- a/frontend/pages/custom/index.vue
+++ b/frontend/pages/custom/index.vue
@@ -1,0 +1,208 @@
+<template>
+  <div>
+    <div class="columns is-multiline">
+      <div class="column is-12 is-clearfix is-unselectable">
+        <span id="env_page_title" class="title is-4">
+          <span class="icon"><i class="fas fa-map"></i></span>
+          Custom GUIDs Mapper
+        </span>
+        <div class="is-pulled-right">
+          <div class="field is-grouped">
+            <p class="control">
+              <NuxtLink class="button is-primary" v-tooltip.bottom="'Add New GUID'" to="/custom/add">
+                <span class="icon">
+                  <i class="fas fa-add"></i>
+                </span>
+              </NuxtLink>
+            </p>
+            <p class="control">
+              <button class="button is-info" @click="loadContent" :disabled="isLoading"
+                      :class="{'is-loading':isLoading}">
+                <span class="icon">
+                  <i class="fas fa-sync"></i>
+                </span>
+              </button>
+            </p>
+          </div>
+        </div>
+        <div class="is-hidden-mobile">
+          <span class="subtitle">
+            This page allow you to add custom GUIDs to the system, this is useful when you want to map a GUID from a
+            backend to a different GUID in WatchState. Or add new GUID identifiers to the system.
+          </span>
+        </div>
+      </div>
+
+      <div class="column is-12" v-if="!data">
+        <Message v-if="isLoading" message_class="has-background-info-90 has-text-dark" title="Loading"
+                 icon="fas fa-spinner fa-spin" message="Loading data. Please wait..."/>
+        <Message v-else message_class="has-background-success-90 has-text-dark" title="Information" icon="fas fa-check">
+          There are no custom GUIDs configured. You can add new GUIDs by clicking on the <i class="fa fa-add"></i>
+          button.
+        </Message>
+      </div>
+
+      <div class="column is-12" v-if="!isLoading &&data && data.guids">
+        <h1 class="is-unselectable title is-4">Custom GUIDs</h1>
+        <h2 class="is-unselectable subtitle">
+          This section contains the custom GUIDs that are currently configured in the system.
+        </h2>
+        <div class="columns is-multiline">
+          <div class="column is-3-tablet" v-for="(guid, index) in data.guids" :key="guid.name">
+            <div class="card">
+              <header class="card-header">
+                <p class="card-header-title is-text-overflow pr-1">
+                  {{ guid.name }}
+                </p>
+                <span class="card-header-icon">
+                  <NuxtLink @click="deleteGUID(index, guid)" class="has-text-danger" v-tooltip="'Delete GUID.'">
+                    <span class="icon"><i class="fas fa-trash"></i></span>
+                  </NuxtLink>
+                </span>
+              </header>
+              <div class="card-content">
+                {{ guid.description }}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="column is-12 is-clearfix is-unselectable" v-if="hasClientsData">
+        <span class="title is-4">
+          <span class="icon"><i class="fas fa-exchange-alt"></i></span>
+          Clients GUID Mapping
+        </span>
+
+        <div class="is-pulled-right">
+          <div class="field is-grouped">
+            <p class="control">
+              <button class="button is-primary" v-tooltip.bottom="'Add new Link'">
+                <span class="icon"><i class="fas fa-add"></i></span>
+              </button>
+            </p>
+          </div>
+        </div>
+        <div class="is-hidden-mobile">
+          <span class="subtitle">This section contains the client to GUID mapping.</span>
+        </div>
+      </div>
+
+      <div class="column is-12" v-if="hasClientsData">
+        <div class="columns is-multiline">
+          <template v-if="data" v-for="client in supported" :key="client">
+            <div class="column is-6-tablet" v-if="client in data && data[client].length > 0"
+                 v-for="(link, index) in data[client]" :key="`${client}-${index}`">
+              <div class="card">
+                <header class="card-header">
+                  <template v-if="link.replace?.from">
+                    <p class="card-header-title is-text-overflow pr-1 is-unselectable is-clickable"
+                       @click="link.show = !link.show">
+                      <span class="icon"><i
+                          class="fas"
+                          :class="{ 'fa-arrow-down': false === (link.show ?? false), 'fa-arrow-up': true === (link.show ?? false) }"
+                      ></i>&nbsp;</span>
+                      {{ ucFirst(client) }} client link
+                    </p>
+                  </template>
+                  <template v-else>
+                    <p class="card-header-title is-text-overflow pr-1 is-unselectable">
+                      {{ ucFirst(client) }} client link
+                    </p>
+                  </template>
+                  <span class="card-header-icon">
+                    <NuxtLink @click="deleteLink(index, link)" class="has-text-danger" v-tooltip="'Delete Link.'">
+                      <span class="icon"><i class="fas fa-trash"></i></span>
+                    </NuxtLink>
+                  </span>
+                </header>
+
+                <div class="card-content">
+                  <div class="columns is-mobile is-multiline">
+                    <div class="column is-3 has-text-left">
+                      <span class="icon"><i class="fas fa-arrow-right"></i>&nbsp;</span>
+                      From
+                    </div>
+                    <div class="column is-9 has-text-right">
+                      {{ link.map.from }}
+                    </div>
+                    <div class="column is-3 has-text-left">
+                      <span class="icon"><i class="fas fa-arrow-left"></i>&nbsp;</span>
+                      To
+                    </div>
+                    <div class="column is-9 has-text-right">
+                      {{ link.map.to }}
+                    </div>
+                    <template v-if="link.replace?.from && ('show' in link && link.show)">
+                      <div class="column is-3 has-text-left">
+                        <span class="icon"><i class="fas fa-xmark"></i>&nbsp;</span>
+                        Replace
+                      </div>
+                      <div class="column is-9 has-text-right">
+                        {{ link.replace.from }}
+                      </div>
+                      <div class="column is-3 has-text-left">
+                        <span class="icon"><i class="fas fa-check"></i>&nbsp;</span>
+                        To
+                      </div>
+                      <div class="column is-9 has-text-right">
+                        {{ link.replace.to }}
+                      </div>
+                    </template>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </template>
+        </div>
+      </div>
+
+      <div class="column is-12">
+        <Message message_class="has-background-info-90 has-text-dark" :toggle="show_page_tips"
+                 @toggle="show_page_tips = !show_page_tips" :use-toggle="true" title="Tips" icon="fas fa-info-circle">
+          <ul>
+            <li>
+              Clients means the internal implementations of the backends in WatchState, for example, Plex, Emby,
+              Jellyfin, etc.
+            </li>
+          </ul>
+        </Message>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import 'assets/css/bulma-switch.css'
+import request from '~/utils/request'
+import {notification, parse_api_response} from '~/utils/index'
+import {useStorage} from '@vueuse/core'
+import Message from '~/components/Message'
+
+useHead({title: 'Custom Guid Mapper'})
+
+const data = ref({})
+const show_page_tips = useStorage('show_page_tips', true)
+const isLoading = ref(false)
+const supported = ref([]);
+
+const loadContent = async () => {
+  try {
+    isLoading.value = true
+    data.value = await parse_api_response(await request(`/system/guids/custom`))
+  } catch (e) {
+    isLoading.value = false
+    return notification('error', 'Error', e.message)
+  } finally {
+    isLoading.value = false
+  }
+}
+
+onMounted(async () => {
+  const supportedClients = await request('/system/supported')
+  supported.value = await supportedClients.json()
+  await loadContent()
+})
+
+const hasClientsData = computed(() => !isLoading.value && supported.value.length > 0 && Object.keys(data.value).length > 0 && supported.value.some(client => client in data.value))
+</script>

--- a/frontend/pages/custom/index.vue
+++ b/frontend/pages/custom/index.vue
@@ -4,7 +4,7 @@
       <div class="column is-12 is-clearfix is-unselectable">
         <span id="env_page_title" class="title is-4">
           <span class="icon"><i class="fas fa-map"></i></span>
-          Custom GUIDs Mapper
+          Custom GUIDs
         </span>
         <div class="is-pulled-right">
           <div class="field is-grouped">
@@ -27,27 +27,18 @@
         </div>
         <div class="is-hidden-mobile">
           <span class="subtitle">
-            This page allow you to add custom GUIDs to the system, this is useful when you want to map a GUID from a
-            backend to a different GUID in WatchState. Or add new GUID identifiers to the system.
+            This page allow you to add custom GUIDs to the system and link them to the client GUIDs.
           </span>
         </div>
       </div>
 
-      <div class="column is-12" v-if="!data">
-        <Message v-if="isLoading" message_class="has-background-info-90 has-text-dark" title="Loading"
+      <div class="column is-12" v-if="isLoading">
+        <Message message_class="has-background-info-90 has-text-dark" title="Loading"
                  icon="fas fa-spinner fa-spin" message="Loading data. Please wait..."/>
-        <Message v-else message_class="has-background-success-90 has-text-dark" title="Information" icon="fas fa-check">
-          There are no custom GUIDs configured. You can add new GUIDs by clicking on the <i class="fa fa-add"></i>
-          button.
-        </Message>
       </div>
 
-      <div class="column is-12" v-if="!isLoading &&data && data.guids">
-        <h1 class="is-unselectable title is-4">Custom GUIDs</h1>
-        <h2 class="is-unselectable subtitle">
-          This section contains the custom GUIDs that are currently configured in the system.
-        </h2>
-        <div class="columns is-multiline">
+      <div class="column is-12" v-if="!isLoading && data">
+        <div class="columns is-multiline" v-if="data?.guids?.length >0">
           <div class="column is-3-tablet" v-for="(guid, index) in data.guids" :key="guid.name">
             <div class="card">
               <header class="card-header">
@@ -66,33 +57,38 @@
             </div>
           </div>
         </div>
+        <div v-else>
+          <Message message_class="has-background-warning-90 has-text-dark" title="Information" icon="fas fa-check">
+            There are no custom GUIDs configured. You can add new GUIDs by clicking on the <i class="fa fa-add"></i>
+            button.
+          </Message>
+        </div>
       </div>
 
-      <div class="column is-12 is-clearfix is-unselectable" v-if="hasClientsData">
+      <div class="column is-12 is-clearfix is-unselectable" v-if="!isLoading">
         <span class="title is-4">
           <span class="icon"><i class="fas fa-exchange-alt"></i></span>
-          Clients GUID Mapping
+          Client GUID links
         </span>
 
         <div class="is-pulled-right">
           <div class="field is-grouped">
             <p class="control">
-              <button class="button is-primary" v-tooltip.bottom="'Add new Link'">
+              <NuxtLink class="button is-primary" v-tooltip.bottom="'Add new Link'" to="/custom/addlink">
                 <span class="icon"><i class="fas fa-add"></i></span>
-              </button>
+              </NuxtLink>
             </p>
           </div>
         </div>
         <div class="is-hidden-mobile">
-          <span class="subtitle">This section contains the client to GUID mapping.</span>
+          <span class="subtitle">This section contains the client <> WatchState GUID links.</span>
         </div>
       </div>
 
-      <div class="column is-12" v-if="hasClientsData">
-        <div class="columns is-multiline">
-          <template v-if="data" v-for="client in supported" :key="client">
-            <div class="column is-6-tablet" v-if="client in data && data[client].length > 0"
-                 v-for="(link, index) in data[client]" :key="`${client}-${index}`">
+      <div class="column is-12">
+        <div class="column is-12" v-if="!isLoading && data && data?.links?.length > 0">
+          <div class="columns is-multiline">
+            <div class="column is-6-tablet" v-for="(link,index) in data.links" :key="link.id">
               <div class="card">
                 <header class="card-header">
                   <template v-if="link.replace?.from">
@@ -102,12 +98,12 @@
                           class="fas"
                           :class="{ 'fa-arrow-down': false === (link.show ?? false), 'fa-arrow-up': true === (link.show ?? false) }"
                       ></i>&nbsp;</span>
-                      {{ ucFirst(client) }} client link
+                      {{ ucFirst(link.type) }} client link
                     </p>
                   </template>
                   <template v-else>
                     <p class="card-header-title is-text-overflow pr-1 is-unselectable">
-                      {{ ucFirst(client) }} client link
+                      {{ ucFirst(link.type) }} client link
                     </p>
                   </template>
                   <span class="card-header-icon">
@@ -119,18 +115,18 @@
 
                 <div class="card-content">
                   <div class="columns is-mobile is-multiline">
-                    <div class="column is-3 has-text-left">
+                    <div class="column is-5 has-text-left">
                       <span class="icon"><i class="fas fa-arrow-right"></i>&nbsp;</span>
-                      From
+                      From Client GUID
                     </div>
-                    <div class="column is-9 has-text-right">
+                    <div class="column is-7 has-text-right">
                       {{ link.map.from }}
                     </div>
-                    <div class="column is-3 has-text-left">
+                    <div class="column is-5 has-text-left">
                       <span class="icon"><i class="fas fa-arrow-left"></i>&nbsp;</span>
-                      To
+                      To WatchState GUID
                     </div>
-                    <div class="column is-9 has-text-right">
+                    <div class="column is-7 has-text-right">
                       {{ link.map.to }}
                     </div>
                     <template v-if="link.replace?.from && ('show' in link && link.show)">
@@ -143,7 +139,7 @@
                       </div>
                       <div class="column is-3 has-text-left">
                         <span class="icon"><i class="fas fa-check"></i>&nbsp;</span>
-                        To
+                        With
                       </div>
                       <div class="column is-9 has-text-right">
                         {{ link.replace.to }}
@@ -153,21 +149,24 @@
                 </div>
               </div>
             </div>
-          </template>
+          </div>
+        </div>
+        <div v-else>
+          <Message message_class="has-background-warning-90 has-text-dark" title="Information" icon="fas fa-xmark">
+            There are no client links configured. You can add new links by clicking on the <i class="fa fa-add"></i>
+            button.
+          </Message>
         </div>
       </div>
-
-      <div class="column is-12">
-        <Message message_class="has-background-info-90 has-text-dark" :toggle="show_page_tips"
-                 @toggle="show_page_tips = !show_page_tips" :use-toggle="true" title="Tips" icon="fas fa-info-circle">
-          <ul>
-            <li>
-              Clients means the internal implementations of the backends in WatchState, for example, Plex, Emby,
-              Jellyfin, etc.
-            </li>
-          </ul>
-        </Message>
-      </div>
+      <!--      <div class="column is-12">-->
+      <!--        <Message message_class="has-background-info-90 has-text-dark" :toggle="show_page_tips"-->
+      <!--                 @toggle="show_page_tips = !show_page_tips" :use-toggle="true" title="Tips" icon="fas fa-info-circle">-->
+      <!--          <ul>-->
+      <!--            <li>-->
+      <!--            </li>-->
+      <!--          </ul>-->
+      <!--        </Message>-->
+      <!--      </div>-->
     </div>
   </div>
 </template>
@@ -179,12 +178,11 @@ import {notification, parse_api_response} from '~/utils/index'
 import {useStorage} from '@vueuse/core'
 import Message from '~/components/Message'
 
-useHead({title: 'Custom Guid Mapper'})
+useHead({title: 'Custom Guids'})
 
 const data = ref({})
 const show_page_tips = useStorage('show_page_tips', true)
 const isLoading = ref(false)
-const supported = ref([]);
 
 const loadContent = async () => {
   try {
@@ -198,11 +196,24 @@ const loadContent = async () => {
   }
 }
 
-onMounted(async () => {
-  const supportedClients = await request('/system/supported')
-  supported.value = await supportedClients.json()
-  await loadContent()
-})
+onMounted(async () => await loadContent())
 
-const hasClientsData = computed(() => !isLoading.value && supported.value.length > 0 && Object.keys(data.value).length > 0 && supported.value.some(client => client in data.value))
+const deleteGUID = async (index, guid) => {
+  if (!confirm(`Are you sure you want to delete the GUID: '${guid.name}'?`)) {
+    return
+  }
+
+  try {
+    const response = await request(`/system/guids/custom/${guid.id}`, {method: 'DELETE'})
+    const result = await parse_api_response(response)
+    if (response.ok) {
+      data.value.guids.splice(index, 1)
+      notification('success', 'Success', result.message)
+    } else {
+      notification('error', 'Error', result.error.message)
+    }
+  } catch (e) {
+    return notification('error', 'Error', e.message)
+  }
+}
 </script>

--- a/frontend/pages/integrity.vue
+++ b/frontend/pages/integrity.vue
@@ -185,29 +185,44 @@
                       <div class="field is-grouped">
                         <div class="control is-expanded is-unselectable">
                           <span class="icon"><i class="fas fa-info"></i>&nbsp;</span>
-                          <span>Has metadata from</span>
+                          <span>Has metadata</span>
                         </div>
                         <div class="control">
                           <template v-for="backend in item.reported_by" :key="`${item.id}-rb-${backend}`">
-                            <NuxtLink :to="'/backend/'+backend" v-text="backend" class="tag is-primary ml-1"/>
+                            <NuxtLink :to="'/backend/'+backend" class="tag is-primary ml-1">
+                              <span class="icon"><i class="fas fa-check"/></span>
+                              <span v-text="backend"/>
+                            </NuxtLink>
                           </template>
                           <template v-for="backend in item.not_reported_by" :key="`${item.id}-rb-${backend}`">
-                            <NuxtLink :to="'/backend/'+backend" v-text="backend" class="tag is-danger ml-1"/>
+                            <NuxtLink :to="'/backend/'+backend" class="tag is-danger ml-1">
+                              <span class="icon"><i class="fas fa-xmark"/></span>
+                              <span v-text="backend"/>
+                            </NuxtLink>
                           </template>
                         </div>
                       </div>
                     </div>
+
                     <div class="column is-12" v-if="item?.integrity">
-                      <template v-for="record in item.integrity" :key="`integrity-${record.backend}`">
-                        <p>
-                          <span class="icon">
-                            <i class="fas"
-                               :class="{'fa-xmark':!record.status,'fa-check':record.status}"></i>&nbsp;
-                          </span>
-                          <span :class="{'has-text-danger':!record.status,'has-text-success':record.status}">
-                            {{ record.backend }}: {{ record.message }}</span>
-                        </p>
-                      </template>
+                      <div class="field is-grouped">
+                        <div class="control is-expanded is-unselectable">
+                          <span class="icon"><i class="fas fa-file"></i>&nbsp;</span>
+                          <span>File reference exists</span>
+                        </div>
+                        <div class="control">
+                          <NuxtLink
+                              v-for="record in item.integrity" :key="`${item.id}-int-${record.backend}`"
+                              :to="'/backend/'+record.backend" class="tag ml-1"
+                              :class="{ 'is-danger': !record.status, 'is-primary': record.status}"
+                              v-tooltip.bottom="!record.status ? record.backend + ': ' + record.message : ''">
+                            <span class="icon">
+                              <i class="fas" :class="{ 'fa-xmark': !record.status, 'fa-check': record.status}"/>
+                            </span>
+                            <span v-text="record.backend"/>
+                          </NuxtLink>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/frontend/web-types.json
+++ b/frontend/web-types.json
@@ -1,0 +1,63 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "framework": "vue",
+    "js-types-syntax": "typescript",
+    "description-markup": "markdown",
+    "framework-config": {
+        "enable-when": {
+            "file-extensions": [
+                "vue"
+            ]
+        }
+    },
+    "contributions": {
+        "html": {
+            "vue-directives": [
+                {
+                    "name": "tooltip",
+                    "description": "Create a tooltip for an element.",
+                    "doc-url": "",
+                    "attribute-value": {
+                        "type": "string",
+                        "required": true
+                    },
+                    "modifiers": [
+                        {
+                            "name": "top",
+                            "description": "Position the tooltip at the top of the element."
+                        },
+                        {
+                            "name": "bottom",
+                            "description": "Position the tooltip at the bottom of the element."
+                        },
+                        {
+                            "name": "left",
+                            "description": "Position the tooltip at the left of the element."
+                        },
+                        {
+                            "name": "right",
+                            "description": "Position the tooltip at the right of the element."
+                        }
+                    ]
+                },
+                {
+                    "name": "highlight",
+                    "description": "Highlight an element.",
+                    "doc-url": ""
+                },
+                {
+                    "name": "autoscroll",
+                    "description": "Automatically scroll to an element.",
+                    "doc-url": ""
+                }
+            ],
+            "vue-components": [
+                {
+                    "name": "VTooltip",
+                    "description": "Create more advanced tooltips.",
+                    "doc-url": "https://floating-vue.starpad.dev/guide/component#tooltip"
+                }
+            ]
+        }
+    }
+}

--- a/src/API/System/Guids.php
+++ b/src/API/System/Guids.php
@@ -13,9 +13,11 @@ use App\Libs\Container;
 use App\Libs\DataUtil;
 use App\Libs\Enums\Http\Status;
 use App\Libs\Guid;
+use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface as iResponse;
 use Psr\Http\Message\ServerRequestInterface as iRequest;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 final class Guids
 {
@@ -53,7 +55,102 @@ final class Guids
     {
         $params = DataUtil::fromRequest($request);
 
-        return api_response(Status::OK, $request->getParsedBody());
+        $requiredFields = [
+            'name',
+            'type',
+            'description',
+            'validator.pattern',
+            'validator.example',
+            'validator.tests.valid',
+            'validator.tests.invalid'
+        ];
+
+        foreach ($requiredFields as $field) {
+            if (!$params->get($field)) {
+                return api_error(r("Field '{field}' is required. And is missing from request.", [
+                    'field' => $field
+                ]), Status::BAD_REQUEST);
+            }
+        }
+
+        try {
+            $this->validateName($params->get('name'));
+        } catch (InvalidArgumentException $e) {
+            return api_error($e->getMessage(), Status::BAD_REQUEST);
+        }
+
+        $pattern = stripslashes($params->get('validator.pattern'));
+        try {
+            preg_match($pattern, '');
+        } catch (Throwable) {
+            return api_error(r("Invalid regex pattern: '{pattern}'.", ['pattern' => $pattern]), Status::BAD_REQUEST);
+        }
+
+        if (count($params->get('validator.tests.valid')) < 1) {
+            return api_error('At least one valid test is required.', Status::BAD_REQUEST);
+        }
+
+        foreach ($params->get('validator.tests.valid', []) as $index => $test) {
+            if (empty($test)) {
+                return api_error(r("Empty value {index} - '{test}' is not allowed.", [
+                    'index' => $index,
+                    'test' => $test
+                ]), Status::BAD_REQUEST);
+            }
+
+            if (1 === preg_match($pattern, (string)$test)) {
+                continue;
+            }
+
+            return api_error(
+                r("Correct value {index} - '{test}' did not match given pattern '{pattern}'.", [
+                    'index' => $index,
+                    'test' => $test,
+                    'pattern' => $pattern,
+                ]),
+                Status::BAD_REQUEST
+            );
+        }
+
+        if (count($params->get('validator.tests.invalid')) < 1) {
+            return api_error('At least one invalid test is required.', Status::BAD_REQUEST);
+        }
+
+        foreach ($params->get('validator.tests.invalid', []) as $index => $test) {
+            if (1 !== preg_match($pattern, (string)$test)) {
+                continue;
+            }
+
+            return api_error(r("Incorrect value {index} - '{test}' matched given pattern '{pattern}'.", [
+                'index' => $index,
+                'test' => $test,
+                'pattern' => $pattern
+            ]), Status::BAD_REQUEST);
+        }
+
+        $data = [
+            'name' => $params->get('name'),
+            'type' => $params->get('type'),
+            'description' => $params->get('description'),
+            'validator' => [
+                'pattern' => $params->get('validator.pattern'),
+                'example' => $params->get('validator.example'),
+                'tests' => [
+                    'valid' => $params->get('validator.tests.valid'),
+                    'invalid' => $params->get('validator.tests.invalid')
+                ]
+            ]
+        ];
+
+        $file = ConfigFile::open(Config::get('guid.file'), 'yaml', autoCreate: true, autoBackup: true);
+
+        if (!$file->has('guids') || !is_array($file->get('guids'))) {
+            $file->set('guids', []);
+        }
+
+        $file->set('guids.' . count($file->get('guids', [])), $data)->persist();
+
+        return api_response(Status::OK, $data);
     }
 
     #[Delete(self::URL . '/custom/{index:number}[/]', name: 'system.guids.custom.guid.remove')]
@@ -123,5 +220,20 @@ final class Guids
         }
 
         return $guids;
+    }
+
+    private function validateName(string $name): void
+    {
+        if (false === preg_match('/^[a-z0-9_]+$/i', $name)) {
+            throw new InvalidArgumentException('Name must be alphanumeric and underscores only.');
+        }
+
+        if (strtolower($name) !== $name) {
+            throw new InvalidArgumentException('Name must be lowercase.');
+        }
+
+        if (str_contains($name, ' ')) {
+            throw new InvalidArgumentException('Name must not contain spaces.');
+        }
     }
 }

--- a/src/API/System/Guids.php
+++ b/src/API/System/Guids.php
@@ -10,6 +10,7 @@ use App\Libs\Attributes\Route\Put;
 use App\Libs\Config;
 use App\Libs\ConfigFile;
 use App\Libs\Container;
+use App\Libs\DataUtil;
 use App\Libs\Enums\Http\Status;
 use App\Libs\Guid;
 use Psr\Http\Message\ResponseInterface as iResponse;
@@ -50,6 +51,8 @@ final class Guids
     #[Put(self::URL . '/custom[/]', name: 'system.guids.custom.guid.add')]
     public function custom_guid_add(iRequest $request): iResponse
     {
+        $params = DataUtil::fromRequest($request);
+
         return api_response(Status::OK, $request->getParsedBody());
     }
 

--- a/src/Backends/Plex/PlexGuid.php
+++ b/src/Backends/Plex/PlexGuid.php
@@ -174,10 +174,10 @@ final class PlexGuid implements iGuid
                 continue;
             }
 
-            if (null !== ($replace = ag($map, 'replace', null))) {
+            if (null !== ($replace = ag($map, 'options.replace', null))) {
                 if (false === is_array($replace)) {
                     $this->logger->warning(
-                        "Ignoring 'links.{key}'. replace value must be an object. '{given}' is given.",
+                        "Ignoring 'links.{key}'. options.replace value must be an object. '{given}' is given.",
                         [
                             'key' => $key,
                             'given' => get_debug_type($replace),
@@ -190,14 +190,17 @@ final class PlexGuid implements iGuid
                 $to = ag($replace, 'to', null);
 
                 if (empty($from) || false === is_string($from)) {
-                    $this->logger->warning("Ignoring 'links.{key}'. replace.from field is empty or not a string.", [
-                        'key' => $key,
-                    ]);
+                    $this->logger->warning(
+                        "Ignoring 'links.{key}'. options.replace.from field is empty or not a string.",
+                        [
+                            'key' => $key,
+                        ]
+                    );
                     continue;
                 }
 
                 if (false === is_string($to)) {
-                    $this->logger->warning("Ignoring 'links.{key}'. replacer.to field is not a string.", [
+                    $this->logger->warning("Ignoring 'links.{key}'. options.replace.to field is not a string.", [
                         'key' => $key,
                     ]);
                     continue;

--- a/src/Backends/Plex/PlexGuid.php
+++ b/src/Backends/Plex/PlexGuid.php
@@ -147,10 +147,10 @@ final class PlexGuid implements iGuid
             ]));
         }
 
-        $mapping = ag($yaml, 'plex', []);
+        $mapping = ag($yaml, 'links', []);
 
         if (false === is_array($mapping)) {
-            throw new InvalidArgumentException(r("The GUIDs file '{file}' plex sub key is not an array.", [
+            throw new InvalidArgumentException(r("The GUIDs file '{file}' links sub key is not an array.", [
                 'file' => $file,
             ]));
         }
@@ -159,19 +159,25 @@ final class PlexGuid implements iGuid
             return;
         }
 
+        $type = strtolower(PlexClient::CLIENT_NAME);
+
         foreach ($mapping as $key => $map) {
             if (false === is_array($map)) {
-                $this->logger->warning("Ignoring 'plex.{key}'. Value must be an object. '{given}' is given.", [
+                $this->logger->warning("Ignoring 'links.{key}'. Value must be an object. '{given}' is given.", [
                     'key' => $key,
                     'given' => get_debug_type($map),
                 ]);
                 continue;
             }
 
+            if ($type !== ag($map, 'type', 'not_set')) {
+                continue;
+            }
+
             if (null !== ($replace = ag($map, 'replace', null))) {
                 if (false === is_array($replace)) {
                     $this->logger->warning(
-                        "Ignoring 'plex.{key}'. replace value must be an object. '{given}' is given.",
+                        "Ignoring 'links.{key}'. replace value must be an object. '{given}' is given.",
                         [
                             'key' => $key,
                             'given' => get_debug_type($replace),
@@ -184,14 +190,14 @@ final class PlexGuid implements iGuid
                 $to = ag($replace, 'to', null);
 
                 if (empty($from) || false === is_string($from)) {
-                    $this->logger->warning("Ignoring 'plex.{key}'. replace.from field is empty or not a string.", [
+                    $this->logger->warning("Ignoring 'links.{key}'. replace.from field is empty or not a string.", [
                         'key' => $key,
                     ]);
                     continue;
                 }
 
                 if (false === is_string($to)) {
-                    $this->logger->warning("Ignoring 'plex.{key}'. replacer.to field is not a string.", [
+                    $this->logger->warning("Ignoring 'links.{key}'. replacer.to field is not a string.", [
                         'key' => $key,
                     ]);
                     continue;
@@ -202,7 +208,7 @@ final class PlexGuid implements iGuid
 
             if (null !== ($mapper = ag($map, 'map', null))) {
                 if (false === is_array($mapper)) {
-                    $this->logger->warning("Ignoring 'plex.{key}'. map value must be an object. '{given}' is given.", [
+                    $this->logger->warning("Ignoring 'links.{key}'. map value must be an object. '{given}' is given.", [
                         'key' => $key,
                         'given' => get_debug_type($mapper),
                     ]);
@@ -213,47 +219,51 @@ final class PlexGuid implements iGuid
                 $to = ag($mapper, 'to', null);
 
                 if (empty($from) || false === is_string($from)) {
-                    $this->logger->warning("Ignoring 'plex.{key}'. map.from field is empty or not a string.", [
+                    $this->logger->warning("Ignoring 'links.{key}'. map.from field is empty or not a string.", [
                         'key' => $key,
                     ]);
                     continue;
                 }
 
                 if (empty($to) || false === is_string($to)) {
-                    $this->logger->warning("Ignoring 'plex.{key}'. map.to field is empty or not a string.", [
+                    $this->logger->warning("Ignoring 'links.{key}'. map.to field is empty or not a string.", [
                         'key' => $key,
                     ]);
                     continue;
                 }
 
                 if (false === str_starts_with($to, 'guid_')) {
-                    $this->logger->warning("Ignoring 'plex.{key}'. map.to '{to}' field does not starts with 'guid_'.", [
-                        'key' => $key,
-                        'to' => $to,
-                    ]);
+                    $this->logger->warning(
+                        "Ignoring 'links.{key}'. map.to '{to}' field does not starts with 'guid_'.",
+                        [
+                            'key' => $key,
+                            'to' => $to,
+                        ]
+                    );
                     continue;
                 }
 
                 if (false === in_array($to, $supported)) {
-                    $this->logger->warning("Ignoring 'plex.{key}'. map.to field is not a supported GUID type.", [
+                    $this->logger->warning("Ignoring 'links.{key}'. map.to field is not a supported GUID type.", [
                         'key' => $key,
                         'to' => $to,
                     ]);
                     continue;
                 }
 
-                if (false === (bool)ag($map, 'legacy', true)) {
+                if (false === (bool)ag($map, 'options.legacy', true)) {
                     $this->guidMapper[$from] = $to;
                     continue;
                 }
 
                 if (true === in_array($from, $this->guidLegacy)) {
-                    $this->logger->warning("Ignoring 'plex.{key}'. map.from already exists.", [
+                    $this->logger->warning("Ignoring 'links.{key}'. map.from already exists.", [
                         'key' => $key,
                         'from' => $from,
                     ]);
                     continue;
                 }
+
                 $this->guidLegacy[] = $from;
                 $agentGuid = explode('://', after($from, 'agents.'));
                 $this->guidMapper[$agentGuid[0]] = $to;

--- a/src/Commands/System/IndexCommand.php
+++ b/src/Commands/System/IndexCommand.php
@@ -86,6 +86,10 @@ final class IndexCommand extends Command
             'force-reindex' => (bool)$input->getOption('force-reindex'),
         ]);
 
+        if ($input->getOption('force-reindex')) {
+            $output->writeln('<info>Indexes have been recreated successfully.</info>');
+        }
+
         return self::SUCCESS;
     }
 }

--- a/tests/Backends/Emby/EmbyGuidTest.php
+++ b/tests/Backends/Emby/EmbyGuidTest.php
@@ -179,12 +179,12 @@ class EmbyGuidTest extends TestCase
         try {
             $this->checkException(
                 closure: function () use ($tmpFile) {
-                    file_put_contents($tmpFile, Yaml::dump(['emby' => 'foo']));
+                    file_put_contents($tmpFile, Yaml::dump(['links' => 'foo']));
                     $this->getClass()->parseGUIDFile($tmpFile);
                 },
                 reason: "Should throw an exception when there are no GUIDs mapping.",
                 exception: InvalidArgumentException::class,
-                exceptionMessage: 'emby sub key is not an array'
+                exceptionMessage: 'links sub key is not an array'
             );
         } finally {
             if (file_exists($tmpFile)) {
@@ -201,11 +201,11 @@ class EmbyGuidTest extends TestCase
             $this->handler->clear();
 
 
-            file_put_contents($tmpFile, Yaml::dump(ag_set($yaml, 'emby.0', 'ff')));
+            file_put_contents($tmpFile, Yaml::dump(ag_set($yaml, 'links.0', 'ff')));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
                 $this->logged(Level::Warning, 'Value must be an object.', true),
-                'Assert replace key is an object.'
+                'Assert links.0 key is an object.'
             );
         } finally {
             if (file_exists($tmpFile)) {
@@ -217,15 +217,15 @@ class EmbyGuidTest extends TestCase
 
         $tmpFile = tempnam(sys_get_temp_dir(), 'guid');
         try {
-            $yaml = ag_set(['emby' => []], 'emby.0.map', 'foo');
+            $yaml = ag_set(['links' => [['type' => 'emby']]], 'links.0.map', 'foo');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
                 $this->logged(Level::Warning, 'map value must be an object.', true),
-                'Assert replace key is an object.'
+                'Assert map key is an object.'
             );
 
-            $yaml = ag_set($yaml, 'emby.0', ['map' => []]);
+            $yaml = ag_set($yaml, 'links.0.map', []);
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
@@ -233,7 +233,7 @@ class EmbyGuidTest extends TestCase
                 'Assert to field is a string.'
             );
 
-            $yaml = ag_set($yaml, 'emby.0.map.from', 'foo');
+            $yaml = ag_set($yaml, 'links.0.map.from', 'foo');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
@@ -241,7 +241,7 @@ class EmbyGuidTest extends TestCase
                 'Assert to field is a string.'
             );
 
-            $yaml = ag_set($yaml, 'emby.0.map.to', 'foobar');
+            $yaml = ag_set($yaml, 'links.0.map.to', 'foobar');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
@@ -249,7 +249,7 @@ class EmbyGuidTest extends TestCase
                 'Assert to field is a string.'
             );
 
-            $yaml = ag_set($yaml, 'emby.0.map.to', 'guid_foobar');
+            $yaml = ag_set($yaml, 'links.0.map.to', 'guid_foobar');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
@@ -257,7 +257,7 @@ class EmbyGuidTest extends TestCase
                 'Assert to field is a string.'
             );
 
-            $yaml = ag_set($yaml, 'emby.0.map', [
+            $yaml = ag_set($yaml, 'links.0.map', [
                 'from' => 'tsdb',
                 'to' => Guid::GUID_IMDB,
             ]);
@@ -274,16 +274,15 @@ class EmbyGuidTest extends TestCase
             );
             $this->handler->clear();
 
-            $yaml = ag_set($yaml, 'emby.0', [
-                'legacy' => false,
-                'map' => [
-                    'from' => 'imthedb',
-                    'to' => 'guid_imdb',
-                ]
+            $yaml = ag_set($yaml, 'links.0.map', [
+                'from' => 'imthedb',
+                'to' => 'guid_imdb',
             ]);
+
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $class = $this->getClass();
             $class->parseGUIDFile($tmpFile);
+
             $this->assertArrayHasKey(
                 'imthedb',
                 ag($class->getConfig(), 'guidMapper', []),

--- a/tests/Backends/Jellyfin/JellyfinGuidTest.php
+++ b/tests/Backends/Jellyfin/JellyfinGuidTest.php
@@ -179,12 +179,12 @@ class JellyfinGuidTest extends TestCase
         try {
             $this->checkException(
                 closure: function () use ($tmpFile) {
-                    file_put_contents($tmpFile, Yaml::dump(['jellyfin' => 'foo']));
+                    file_put_contents($tmpFile, Yaml::dump(['links' => 'foo']));
                     $this->getClass()->parseGUIDFile($tmpFile);
                 },
                 reason: "Should throw an exception when there are no GUIDs mapping.",
                 exception: InvalidArgumentException::class,
-                exceptionMessage: 'jellyfin sub key is not an array'
+                exceptionMessage: 'links sub key is not an array'
             );
         } finally {
             if (file_exists($tmpFile)) {
@@ -195,13 +195,13 @@ class JellyfinGuidTest extends TestCase
         $tmpFile = tempnam(sys_get_temp_dir(), 'guid');
         try {
             $this->handler->clear();
-            $yaml = ['jellyfin' => []];
+            $yaml = ['links' => []];
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->assertCount(0, $this->handler->getRecords(), "There should be no messages logged for empty list.");
             $this->handler->clear();
 
 
-            file_put_contents($tmpFile, Yaml::dump(ag_set($yaml, 'jellyfin.0', 'ff')));
+            file_put_contents($tmpFile, Yaml::dump(ag_set($yaml, 'links.0', 'ff')));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
                 $this->logged(Level::Warning, 'Value must be an object.', true),
@@ -217,15 +217,15 @@ class JellyfinGuidTest extends TestCase
 
         $tmpFile = tempnam(sys_get_temp_dir(), 'guid');
         try {
-            $yaml = ag_set(['jellyfin' => []], 'jellyfin.0.map', 'foo');
+            $yaml = ag_set(['links' => [0 => ['type' => 'jellyfin']]], 'links.0.map', 'foo');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
                 $this->logged(Level::Warning, 'map value must be an object.', true),
-                'Assert replace key is an object.'
+                'Assert map key is an object.'
             );
 
-            $yaml = ag_set($yaml, 'jellyfin.0', ['map' => []]);
+            $yaml = ag_set($yaml, 'links.0.map', []);
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
@@ -233,7 +233,7 @@ class JellyfinGuidTest extends TestCase
                 'Assert to field is a string.'
             );
 
-            $yaml = ag_set($yaml, 'jellyfin.0.map.from', 'foo');
+            $yaml = ag_set($yaml, 'links.0.map.from', 'foo');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
@@ -241,7 +241,7 @@ class JellyfinGuidTest extends TestCase
                 'Assert to field is a string.'
             );
 
-            $yaml = ag_set($yaml, 'jellyfin.0.map.to', 'foobar');
+            $yaml = ag_set($yaml, 'links.0.map.to', 'foobar');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
@@ -249,7 +249,7 @@ class JellyfinGuidTest extends TestCase
                 'Assert to field is a string.'
             );
 
-            $yaml = ag_set($yaml, 'jellyfin.0.map.to', 'guid_foobar');
+            $yaml = ag_set($yaml, 'links.0.map.to', 'guid_foobar');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
@@ -257,7 +257,7 @@ class JellyfinGuidTest extends TestCase
                 'Assert to field is a string.'
             );
 
-            $yaml = ag_set($yaml, 'jellyfin.0.map', [
+            $yaml = ag_set($yaml, 'links.0.map', [
                 'from' => 'tsdb',
                 'to' => Guid::GUID_IMDB,
             ]);
@@ -274,12 +274,9 @@ class JellyfinGuidTest extends TestCase
             );
             $this->handler->clear();
 
-            $yaml = ag_set($yaml, 'jellyfin.0', [
-                'legacy' => false,
-                'map' => [
-                    'from' => 'imthedb',
-                    'to' => 'guid_imdb',
-                ]
+            $yaml = ag_set($yaml, 'links.0.map', [
+                'from' => 'imthedb',
+                'to' => 'guid_imdb',
             ]);
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $class = $this->getClass();

--- a/tests/Backends/Plex/PlexGuidTest.php
+++ b/tests/Backends/Plex/PlexGuidTest.php
@@ -206,10 +206,10 @@ class PlexGuidTest extends TestCase
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
                 $this->logged(Level::Warning, 'Value must be an object.', true),
-                'Assert replace key is an object.'
+                'Assert link value is an object.'
             );
 
-            $yaml = ag_set($yaml, 'links.0.replace', 'foo');
+            $yaml = ag_set($yaml, 'links.0.options.replace', 'foo');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
@@ -217,23 +217,23 @@ class PlexGuidTest extends TestCase
                 'Assert replace key is an object.'
             );
 
-            $yaml = ag_set($yaml, 'links.0.replace', []);
+            $yaml = ag_set($yaml, 'links.0.options.replace', []);
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
-                $this->logged(Level::Warning, 'replace.from field is empty or not a string.', true),
+                $this->logged(Level::Warning, 'options.replace.from field is empty or not a string.', true),
                 'Assert to field is a string.'
             );
 
-            $yaml = ag_set($yaml, 'links.0.replace.from', 'foo');
+            $yaml = ag_set($yaml, 'links.0.options.replace.from', 'foo');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
-                $this->logged(Level::Warning, 'replacer.to field is not a string.', true),
+                $this->logged(Level::Warning, 'options.replace.to field is not a string.', true),
                 'Assert to field is a string.'
             );
 
-            $yaml = ag_set($yaml, 'links.0.replace.to', 'bar');
+            $yaml = ag_set($yaml, 'links.0.options.replace.to', 'bar');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertCount(0, $this->handler->getRecords(), "There should be no error messages logged.");
@@ -252,7 +252,7 @@ class PlexGuidTest extends TestCase
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
                 $this->logged(Level::Warning, 'map value must be an object.', true),
-                'Assert replace key is an object.'
+                'Assert map key is an object.'
             );
 
             $yaml = ag_set($yaml, 'links.0.map', []);

--- a/tests/Backends/Plex/PlexGuidTest.php
+++ b/tests/Backends/Plex/PlexGuidTest.php
@@ -108,7 +108,7 @@ class PlexGuidTest extends TestCase
         try {
             $this->checkException(
                 closure: function () use ($tmpFile) {
-                    file_put_contents($tmpFile, 'version: 2.0');
+                    file_put_contents($tmpFile, 'version: 99.0');
                     $this->getClass()->parseGUIDFile($tmpFile);
                 },
                 reason: "Failed to throw exception when the GUID file version is not supported.",
@@ -179,12 +179,12 @@ class PlexGuidTest extends TestCase
         try {
             $this->checkException(
                 closure: function () use ($tmpFile) {
-                    file_put_contents($tmpFile, Yaml::dump(['plex' => 'foo']));
+                    file_put_contents($tmpFile, Yaml::dump(['links' => 'foo']));
                     $this->getClass()->parseGUIDFile($tmpFile);
                 },
                 reason: "Should throw an exception when there are no GUIDs mapping.",
                 exception: InvalidArgumentException::class,
-                exceptionMessage: 'plex sub key is not an array'
+                exceptionMessage: 'links sub key is not an array'
             );
         } finally {
             if (file_exists($tmpFile)) {
@@ -195,21 +195,21 @@ class PlexGuidTest extends TestCase
         $tmpFile = tempnam(sys_get_temp_dir(), 'guid');
         try {
             $this->handler->clear();
-            $yaml = ['plex' => [[]]];
+            $yaml = ['links' => [['type' => 'plex']]];
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertCount(0, $this->handler->getRecords(), "There should be no messages logged for empty list.");
             $this->handler->clear();
 
 
-            file_put_contents($tmpFile, Yaml::dump(ag_set($yaml, 'plex.0', 'ff')));
+            file_put_contents($tmpFile, Yaml::dump(ag_set($yaml, 'links.0', 'ff')));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
                 $this->logged(Level::Warning, 'Value must be an object.', true),
                 'Assert replace key is an object.'
             );
 
-            $yaml = ag_set($yaml, 'plex.0.replace', 'foo');
+            $yaml = ag_set($yaml, 'links.0.replace', 'foo');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
@@ -217,7 +217,7 @@ class PlexGuidTest extends TestCase
                 'Assert replace key is an object.'
             );
 
-            $yaml = ag_set($yaml, 'plex.0', ['replace' => []]);
+            $yaml = ag_set($yaml, 'links.0.replace', []);
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
@@ -225,7 +225,7 @@ class PlexGuidTest extends TestCase
                 'Assert to field is a string.'
             );
 
-            $yaml = ag_set($yaml, 'plex.0.replace.from', 'foo');
+            $yaml = ag_set($yaml, 'links.0.replace.from', 'foo');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
@@ -233,7 +233,7 @@ class PlexGuidTest extends TestCase
                 'Assert to field is a string.'
             );
 
-            $yaml = ag_set($yaml, 'plex.0.replace.to', 'bar');
+            $yaml = ag_set($yaml, 'links.0.replace.to', 'bar');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertCount(0, $this->handler->getRecords(), "There should be no error messages logged.");
@@ -247,7 +247,7 @@ class PlexGuidTest extends TestCase
 
         $tmpFile = tempnam(sys_get_temp_dir(), 'guid');
         try {
-            $yaml = ag_set(['plex' => []], 'plex.0.map', 'foo');
+            $yaml = ag_set(['links' => [['type' => 'plex']]], 'links.0.map', 'foo');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
@@ -255,7 +255,7 @@ class PlexGuidTest extends TestCase
                 'Assert replace key is an object.'
             );
 
-            $yaml = ag_set($yaml, 'plex.0', ['map' => []]);
+            $yaml = ag_set($yaml, 'links.0.map', []);
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
@@ -263,7 +263,7 @@ class PlexGuidTest extends TestCase
                 'Assert to field is a string.'
             );
 
-            $yaml = ag_set($yaml, 'plex.0.map.from', 'foo');
+            $yaml = ag_set($yaml, 'links.0.map.from', 'foo');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
@@ -271,7 +271,7 @@ class PlexGuidTest extends TestCase
                 'Assert to field is a string.'
             );
 
-            $yaml = ag_set($yaml, 'plex.0.map.to', 'foobar');
+            $yaml = ag_set($yaml, 'links.0.map.to', 'foobar');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
@@ -279,7 +279,7 @@ class PlexGuidTest extends TestCase
                 'Assert to field is a string.'
             );
 
-            $yaml = ag_set($yaml, 'plex.0.map.to', 'guid_foobar');
+            $yaml = ag_set($yaml, 'links.0.map.to', 'guid_foobar');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
             $this->assertTrue(
@@ -287,7 +287,7 @@ class PlexGuidTest extends TestCase
                 'Assert to field is a string.'
             );
 
-            $yaml = ag_set($yaml, 'plex.0.map', [
+            $yaml = ag_set($yaml, 'links.0.map', [
                 'from' => 'com.plexapp.agents.imdb',
                 'to' => 'guid_imdb',
             ]);
@@ -298,7 +298,7 @@ class PlexGuidTest extends TestCase
                 'Assert to field is a string.'
             );
 
-            $yaml = ag_set($yaml, 'plex.0.map', [
+            $yaml = ag_set($yaml, 'links.0.map', [
                 'from' => 'com.plexapp.agents.ccdb',
                 'to' => 'guid_imdb',
             ]);
@@ -315,8 +315,11 @@ class PlexGuidTest extends TestCase
             );
             $this->handler->clear();
 
-            $yaml = ag_set($yaml, 'plex.0', [
-                'legacy' => false,
+            $yaml = ag_set($yaml, 'links.0', [
+                'type' => 'plex',
+                'options' => [
+                    'legacy' => false,
+                ],
                 'map' => [
                     'from' => 'com.plexapp.agents.imthedb',
                     'to' => 'guid_imdb',

--- a/tests/Libs/VttConverterTest.php
+++ b/tests/Libs/VttConverterTest.php
@@ -49,9 +49,7 @@ class VttConverterTest extends TestCase
 
                 VTT;
 
-                $data = VttConverter::parse($text);
-                dump($data);
-                return $data;
+                return VttConverter::parse($text);
             },
             reason: 'Invalid VTT file',
             exception: \InvalidArgumentException::class,


### PR DESCRIPTION
Using this feature allows you to extend WatchState to support more less known or regional specific metadata databases. We cannot add support directly to all databases, so this feature instead allow you to manually do it yourself.
 For more information read [this FAQ](/arabcoders/watchstate/blob/master/FAQ.md#advanced-how-to-extend-the-guid-parser-to-support-more-guids-or-custom-ones) entry