### PR TITLE
support backing up mutli-user watch state via state:backup

### DIFF
--- a/src/Backends/Jellyfin/Action/Import.php
+++ b/src/Backends/Jellyfin/Action/Import.php
@@ -947,7 +947,7 @@ class Import
 
         $end = microtime(true);
         $this->logger->info(
-            "Parsing '{client}: {backend}' library '{library.title} {segment.number}/{segment.of}' completed in '{time.duration}'.",
+            "Parsing '{client}: {backend}' library '{library.title} {segment.number}/{segment.of}' completed in '{time.duration}'s.",
             [
                 'client' => $context->clientName,
                 'backend' => $context->backendName,

--- a/src/Commands/State/BackupCommand.php
+++ b/src/Commands/State/BackupCommand.php
@@ -4,17 +4,22 @@ declare(strict_types=1);
 
 namespace App\Commands\State;
 
+use App\Backends\Common\Cache as BackendCache;
 use App\Command;
 use App\Libs\Attributes\Route\Cli;
 use App\Libs\Config;
+use App\Libs\ConfigFile;
+use App\Libs\Container;
+use App\Libs\Mappers\ExtendedImportInterface as iEImport;
 use App\Libs\Mappers\Import\DirectMapper;
 use App\Libs\Options;
 use App\Libs\Stream;
-use Psr\Http\Message\StreamInterface;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\Console\Input\InputInterface;
+use DirectoryIterator;
+use Psr\Http\Message\StreamInterface as iStream;
+use Psr\Log\LoggerInterface as iLogger;
+use Symfony\Component\Console\Input\InputInterface as iInput;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\OutputInterface as iOutput;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Throwable;
 
@@ -34,9 +39,9 @@ class BackupCommand extends Command
      * Constructs a new instance of the class.
      *
      * @param DirectMapper $mapper The direct mapper instance.
-     * @param LoggerInterface $logger The logger instance.
+     * @param iLogger $logger The logger instance.
      */
-    public function __construct(private DirectMapper $mapper, private LoggerInterface $logger)
+    public function __construct(private DirectMapper $mapper, private iLogger $logger)
     {
         set_time_limit(0);
         ini_set('memory_limit', '-1');
@@ -78,6 +83,7 @@ class BackupCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'Full path backup file. Will only be used if backup list is 1'
             )
+            ->addOption('only-main-user', 'M', InputOption::VALUE_NONE, 'Only backup main user data.')
             ->addOption('no-compress', 'N', InputOption::VALUE_NONE, 'Do not compress the backup file.')
             ->setHelp(
                 r(
@@ -138,31 +144,92 @@ class BackupCommand extends Command
     /**
      * Make sure the command is not running in parallel.
      *
-     * @param InputInterface $input The input interface instance.
-     * @param OutputInterface $output The output interface instance.
+     * @param iInput $input The input interface instance.
+     * @param iOutput $output The output interface instance.
      *
      * @return int The exit code of the command.
      */
-    protected function runCommand(InputInterface $input, OutputInterface $output): int
+    protected function runCommand(iInput $input, iOutput $output): int
     {
         return $this->single(fn(): int => $this->process($input), $output);
+    }
+
+    private function getBackends(iInput $input): array
+    {
+        $configs = [
+            'main' => [
+                'config' => ConfigFile::open(Config::get('backends_file'), 'yaml'),
+                'mapper' => $this->mapper,
+                'cache' => null,
+            ]
+        ];
+
+        if (true === $input->getOption('only-main-user')) {
+            return $configs;
+        }
+
+        $usersDir = Config::get('path') . '/users';
+
+        if (false === is_dir($usersDir)) {
+            return $configs;
+        }
+
+        if (!is_readable($usersDir)) {
+            $this->logger->error("SYSTEM: Unable to read '{dir}' directory.", ['dir' => $usersDir]);
+            return $configs;
+        }
+
+        $mainUserIds = array_map(fn($backend) => ag($backend, 'user'), ag($configs, 'main.config')->getAll());
+
+        foreach (new DirectoryIterator(Config::get('path') . '/users') as $dir) {
+            if ($dir->isDot() || false === $dir->isDir()) {
+                continue;
+            }
+
+            $config = perUserConfig($dir->getBasename());
+            $subUserIds = array_map(fn($backend) => ag($backend, 'user'), $config->getAll());
+
+            foreach ($mainUserIds as $mainId) {
+                if (false === in_array($mainId, $subUserIds)) {
+                    continue;
+                }
+
+                $this->logger->debug("SYSTEM: Skipping '{user}' backends as it's same as main user.", [
+                    'user' => $dir->getBasename(),
+                    'main' => $mainUserIds,
+                    'sub' => $subUserIds,
+                ]);
+                continue 2;
+            }
+
+            $userName = $dir->getBasename();
+            $perUserCache = perUserCacheAdapter($userName);
+
+            $configs[$userName] = [
+                'config' => $config,
+                'mapper' => $this->mapper->withDB(perUserDb($userName))
+                    ->withCache($perUserCache)
+                    ->withLogger($this->logger)
+                    ->withOptions(
+                        array_replace_recursive($this->mapper->getOptions(), [Options::ALT_NAME => $userName])
+                    )
+                    ->loadData(),
+                'cache' => $perUserCache,
+            ];
+        }
+
+        return $configs;
     }
 
     /**
      * Execute the command.
      *
-     * @param InputInterface $input The input interface.
+     * @param iInput $input The input interface.
      *
      * @return int The integer result.
      */
-    protected function process(InputInterface $input): int
+    protected function process(iInput $input): int
     {
-        $list = [];
-        $selected = $input->getOption('select-backend');
-        $isCustom = !empty($selected) && count($selected) > 0;
-        $supported = Config::get('supported', []);
-        $noCompression = $input->getOption('no-compress');
-
         $mapperOpts = [];
 
         if ($input->getOption('dry-run')) {
@@ -178,18 +245,45 @@ class BackupCommand extends Command
             $this->mapper->setOptions(options: $mapperOpts);
         }
 
-        foreach (Config::get('servers', []) as $backendName => $backend) {
+        $this->logger->notice("Using WatchState version - '{version}'.", ['version' => getAppVersion()]);
+        foreach ($this->getBackends($input) as $user => $opt) {
+            try {
+                $this->process_backup($input, $user, $opt);
+            } finally {
+                ag($opt, 'mapper')->reset();
+            }
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function process_backup(iInput $input, string $user, array $opt): void
+    {
+        $list = [];
+
+        $selected = $input->getOption('select-backend');
+        $isCustom = !empty($selected) && count($selected) > 0;
+        $supported = Config::get('supported', []);
+
+        $noCompression = $input->getOption('no-compress');
+
+        $config = ag($opt, 'config');
+        assert($config instanceof ConfigFile);
+
+        foreach ($config->getAll() as $backendName => $backend) {
             $type = strtolower(ag($backend, 'type', 'unknown'));
 
-            if ($isCustom && $input->getOption('exclude') === in_array($backendName, $selected, true)) {
-                $this->logger->info("SYSTEM: Ignoring '{backend}' as requested by [-s, --select-backend].", [
+            if ($isCustom && $input->getOption('exclude') === $this->in_array($selected, $backendName)) {
+                $this->logger->info("SYSTEM: Ignoring '{user}@{backend}' as requested by [-s, --select-backend].", [
+                    'user' => $user,
                     'backend' => $backendName
                 ]);
                 continue;
             }
 
             if (true !== (bool)ag($backend, 'import.enabled')) {
-                $this->logger->info("SYSTEM: Ignoring '{backend}' as the backend has import disabled.", [
+                $this->logger->info("SYSTEM: Ignoring '{user}@{backend}' as the backend has import disabled.", [
+                    'user' => $user,
                     'backend' => $backendName
                 ]);
                 continue;
@@ -197,8 +291,9 @@ class BackupCommand extends Command
 
             if (!isset($supported[$type])) {
                 $this->logger->error(
-                    "SYSTEM: Ignoring '{backend}' due to unexpected type '{type}'. Expecting '{types}'.",
+                    "SYSTEM: Ignoring '{user}@{backend}' due to unexpected type '{type}'. Expecting '{types}'.",
                     [
+                        'user' => $user,
                         'type' => $type,
                         'backend' => $backendName,
                         'types' => implode(', ', array_keys($supported)),
@@ -208,7 +303,8 @@ class BackupCommand extends Command
             }
 
             if (null === ($url = ag($backend, 'url')) || false === isValidURL($url)) {
-                $this->logger->error("SYSTEM: Ignoring '{backend}' due to invalid URL. '{url}'.", [
+                $this->logger->error("SYSTEM: Ignoring '{user}@{backend}' due to invalid URL. '{url}'.", [
+                    'user' => $user,
                     'url' => $url ?? 'None',
                     'backend' => $backendName,
                 ]);
@@ -223,12 +319,16 @@ class BackupCommand extends Command
             $this->logger->warning(
                 $isCustom ? '[-s, --select-backend] flag did not match any backend.' : 'No backends were found.'
             );
-            return self::FAILURE;
+            return;
         }
 
+        $mapper = ag($opt, 'mapper');
+        assert($mapper instanceof iEImport);
+
         if (true !== $input->getOption('no-enhance')) {
-            $this->logger->notice("SYSTEM: Preloading '{mapper}' data.", [
-                'mapper' => afterLast($this->mapper::class, '\\'),
+            $this->logger->notice("SYSTEM: Preloading '{user}@{mapper}' data.", [
+                'user' => $user,
+                'mapper' => afterLast($mapper::class, '\\'),
                 'memory' => [
                     'now' => getMemoryUsage(),
                     'peak' => getPeakMemoryUsage(),
@@ -238,7 +338,8 @@ class BackupCommand extends Command
             $start = microtime(true);
             $this->mapper->loadData();
 
-            $this->logger->notice("SYSTEM: Preloading '{mapper}' data completed in '{duration}s'.", [
+            $this->logger->notice("SYSTEM: Preloading '{user}@{mapper}' data completed in '{duration}s'.", [
+                'user' => $user,
                 'mapper' => afterLast($this->mapper::class, '\\'),
                 'duration' => round(microtime(true) - $start, 2),
                 'memory' => [
@@ -250,8 +351,6 @@ class BackupCommand extends Command
 
         /** @var array<array-key,ResponseInterface> $queue */
         $queue = [];
-
-        $this->logger->notice("Using WatchState version - '{version}'.", ['version' => getAppVersion()]);
 
         foreach ($list as $name => &$backend) {
             $opts = ag($backend, 'options', []);
@@ -269,9 +368,19 @@ class BackupCommand extends Command
             }
 
             $backend['options'] = $opts;
-            $backend['class'] = $this->getBackend($name, $backend);
 
-            $this->logger->notice('SYSTEM: Backing up [{backend}] play state.', [
+            $backendOpts = [];
+
+            if (null !== ag($opt, 'cache')) {
+                $backendOpts = [
+                    BackendCache::class => Container::get(BackendCache::class)->with(adapter: ag($opt, 'cache')),
+                ];
+            }
+
+            $backend['class'] = makeBackend($backend, $name, $backendOpts)->setLogger($this->logger);
+
+            $this->logger->notice("SYSTEM: Backing up '{user}@{backend}' play state.", [
+                'user' => $user,
                 'backend' => $name,
             ]);
 
@@ -297,7 +406,8 @@ class BackupCommand extends Command
                     touch($fileName);
                 }
 
-                $this->logger->notice("SYSTEM: '{backend}' is using '{file}' as backup target.", [
+                $this->logger->notice("SYSTEM: '{user}@{backend}' is using '{file}' as backup target.", [
+                    'user' => $user,
                     'file' => realpath($fileName),
                     'backend' => $name,
                 ]);
@@ -306,24 +416,19 @@ class BackupCommand extends Command
                 $backend['fp']->write('[');
             }
 
-            array_push(
-                $queue,
-                ...$backend['class']->backup(
-                $this->mapper,
-                $backend['fp'] ?? null,
-                [
-                    'no_enhance' => true === $input->getOption('no-enhance'),
-                    Options::DRY_RUN => (bool)$input->getOption('dry-run'),
-                ]
-            )
-            );
+            array_push($queue, ...$backend['class']->backup($mapper, $backend['fp'] ?? null, [
+                'no_enhance' => true === $input->getOption('no-enhance'),
+                Options::DRY_RUN => (bool)$input->getOption('dry-run'),
+            ]));
         }
 
         unset($backend);
 
         $start = microtime(true);
-        $this->logger->notice("SYSTEM: Waiting on '{total}' requests.", [
+        $this->logger->notice("SYSTEM: Waiting on '{total}' requests for '{user}: {backends}' backends.", [
+            'user' => $user,
             'total' => number_format(count($queue)),
+            'backends' => implode(', ', array_keys($list)),
             'memory' => [
                 'now' => getMemoryUsage(),
                 'peak' => getPeakMemoryUsage(),
@@ -349,7 +454,7 @@ class BackupCommand extends Command
                 continue;
             }
 
-            assert($backend['fp'] instanceof StreamInterface);
+            assert($backend['fp'] instanceof iStream);
 
             if (false === $input->getOption('dry-run')) {
                 $backend['fp']->seek(-1, SEEK_END);
@@ -357,7 +462,10 @@ class BackupCommand extends Command
 
                 if (false === $noCompression) {
                     $file = $backend['fp']->getMetadata('uri');
-                    $this->logger->notice("SYSTEM: Compressing '{file}'.", ['file' => $file]);
+                    $this->logger->notice("SYSTEM: Compressing '{user}@{file}'.", [
+                        'user' => $user,
+                        'file' => $file
+                    ]);
                     $status = compress_files($file, [$file], ['affix' => 'zip']);
                     if (true === $status) {
                         unlink($file);
@@ -368,14 +476,19 @@ class BackupCommand extends Command
             }
         }
 
-        $this->logger->notice("SYSTEM: Backup operation finished in '{duration}s'.", [
+        $this->logger->notice("SYSTEM: Backup operation for '{user}: {backends}' backends finished in '{duration}s'.", [
+            'user' => $user,
+            'backends' => implode(', ', array_keys($list)),
             'duration' => round(microtime(true) - $start, 2),
             'memory' => [
                 'now' => getMemoryUsage(),
                 'peak' => getPeakMemoryUsage(),
             ],
         ]);
+    }
 
-        return self::SUCCESS;
+    private function in_array(array $haystack, string $needle): bool
+    {
+        return array_any($haystack, fn($item) => str_starts_with($item, $needle));
     }
 }


### PR DESCRIPTION
This pull request includes several changes to improve the `BackupCommand` class and enhance the profiling mechanism. The most important changes include the addition of a new option to backup only the main user data, refactoring of the `BackupCommand` class to support multiple users, and improvements to the profiling data filtering.

### Enhancements to `BackupCommand`:

* Added a new option `--only-main-user` to backup only the main user data.
* Refactored the `BackupCommand` class to support multiple users by introducing the `getBackends` method and updating the `process` method accordingly. [[1]](diffhunk://#diff-fdef717d960aeee9aba47b6c1f89623b3df1831aed17e8d690239196e5139d38L141-L165) [[2]](diffhunk://#diff-fdef717d960aeee9aba47b6c1f89623b3df1831aed17e8d690239196e5139d38L181-R296)
* Updated the `process` method to include user-specific information in log messages and backup operations. [[1]](diffhunk://#diff-fdef717d960aeee9aba47b6c1f89623b3df1831aed17e8d690239196e5139d38L211-R307) [[2]](diffhunk://#diff-fdef717d960aeee9aba47b6c1f89623b3df1831aed17e8d690239196e5139d38L226-R331) [[3]](diffhunk://#diff-fdef717d960aeee9aba47b6c1f89623b3df1831aed17e8d690239196e5139d38L241-R342) [[4]](diffhunk://#diff-fdef717d960aeee9aba47b6c1f89623b3df1831aed17e8d690239196e5139d38L254-L255) [[5]](diffhunk://#diff-fdef717d960aeee9aba47b6c1f89623b3df1831aed17e8d690239196e5139d38L272-R383) [[6]](diffhunk://#diff-fdef717d960aeee9aba47b6c1f89623b3df1831aed17e8d690239196e5139d38L300-R410) [[7]](diffhunk://#diff-fdef717d960aeee9aba47b6c1f89623b3df1831aed17e8d690239196e5139d38L309-R431) [[8]](diffhunk://#diff-fdef717d960aeee9aba47b6c1f89623b3df1831aed17e8d690239196e5139d38L352-R468) [[9]](diffhunk://#diff-fdef717d960aeee9aba47b6c1f89623b3df1831aed17e8d690239196e5139d38L371-R492)

### Profiling improvements:

* Enhanced the profiling callback to filter sensitive data before queuing the `ProcessProfileEvent`.
* Removed unnecessary imports from `ProcessProfileEvent` and simplified the data handling. [[1]](diffhunk://#diff-858f41ae10a84569e87dcfaf5b5cc5d2622f47d57d861053115340c4cfd77c75L11-L13) [[2]](diffhunk://#diff-858f41ae10a84569e87dcfaf5b5cc5d2622f47d57d861053115340c4cfd77c75L54-R52)

### Minor improvements:

* Updated log message format in `Import.php` to include the duration unit.
* Standardized the use of interface aliases in `BackupCommand.php`. [[1]](diffhunk://#diff-fdef717d960aeee9aba47b6c1f89623b3df1831aed17e8d690239196e5139d38R7-R22) [[2]](diffhunk://#diff-fdef717d960aeee9aba47b6c1f89623b3df1831aed17e8d690239196e5139d38L37-R44) [[3]](diffhunk://#diff-fdef717d960aeee9aba47b6c1f89623b3df1831aed17e8d690239196e5139d38L141-L165)

These changes improve the flexibility and security of the backup process and enhance the clarity of log messages.

### TLDR

`state:backup` now work with mutli-user config, no support for backing up via the WebUI or API yet.