### PR TITLE
more github action changes.

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -47,26 +47,32 @@ jobs:
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@github.com"
 
-          # Save the generated changelog file to a temporary directory outside the repo
-          mkdir -p ../changelog_temp
-          python .github/scripts/generate_changelog.py --repo_path . --changelog_path ../changelog_temp/CHANGELOG-${BRANCH_NAME}.json --branch_name $BRANCH_NAME
+          # Define a temporary directory for the gh-pages worktree
+          WORKTREE_DIR=gh-pages-worktree
 
-          # Now, checkout the gh-pages branch:
-          if git show-ref --quiet refs/heads/gh-pages; then
-            git checkout gh-pages
+          # Add (or update) a worktree for the gh-pages branch.
+          # If the branch exists, check it out; if not, create it.
+          if git show-ref --verify --quiet refs/heads/gh-pages; then
+            git worktree add $WORKTREE_DIR gh-pages
           else
-            git checkout --orphan gh-pages
-            # Remove all tracked files if any
-            git rm -rf .
+            git worktree add -B gh-pages $WORKTREE_DIR
           fi
 
-          # Clean the working directory (removing untracked files)
-          git clean -fdx
+          python .github/scripts/generate_changelog.py --repo_path . --changelog_path ./CHANGELOG-${BRANCH_NAME}.json --branch_name $BRANCH_NAME
 
-          # Copy back the changelog file from the temporary location
-          cp ../changelog_temp/CHANGELOG-${BRANCH_NAME}.json .
+          # Copy the updated changelog file into the worktree directory.
+          cp CHANGELOG-${BRANCH_NAME}.json $WORKTREE_DIR/
 
-          # Stage, commit, and push only the changelog file
+          # Change into the worktree directory.
+          cd $WORKTREE_DIR
+
+          # Stage and commit only the updated changelog file.
           git add CHANGELOG-${BRANCH_NAME}.json
-          git commit -m "Update Changelog for $TAG_NAME" || echo "No changes to commit"
-          git push origin gh-pages --force
+          git commit -m "Update Changelog for ${TAG_NAME}" || echo "No changes to commit"
+
+          # Push the changes to the gh-pages branch.
+          git push origin gh-pages
+
+          # (Optional) Clean up the worktree directory.
+          cd ..
+          rm -rf $WORKTREE_DIR


### PR DESCRIPTION
This pull request includes significant changes to the `jobs:` section in the `.github/workflows/changelog.yml` file. The changes focus on improving the process of updating the changelog by using a Git worktree for the `gh-pages` branch, which simplifies the workflow and avoids the need for a temporary directory outside the repository.

Improvements to changelog update process:

* Defined a temporary directory for the `gh-pages` worktree to streamline the process.
* Added or updated a worktree for the `gh-pages` branch, checking out the branch if it exists or creating it if it does not.
* Simplified the changelog generation by removing the need for a temporary directory and directly copying the changelog file into the worktree directory.
* Changed into the worktree directory to stage and commit only the updated changelog file, ensuring a clean commit process.
* Included an optional step to clean up the worktree directory after pushing the changes to the `gh-pages` branch.