### PR TITLE
fixed bug that prevents run_task from actually running

### DIFF
--- a/src/Commands/System/TasksCommand.php
+++ b/src/Commands/System/TasksCommand.php
@@ -211,6 +211,7 @@ final class TasksCommand extends Command
                     );
                     return $event;
                 }
+                break;
             }
             case self::CNAME:
             {
@@ -218,6 +219,7 @@ final class TasksCommand extends Command
                     $event->addLog(r('No command name was specified.'));
                     return $event;
                 }
+                break;
             }
         }
 


### PR DESCRIPTION
This pull request includes a small but important change to the `runEvent` function in the `TasksCommand` class. The change ensures that the function properly breaks out of the switch cases after handling specific conditions.

* [`src/Commands/System/TasksCommand.php`](diffhunk://#diff-faa328ad12336bcb07aecfb7bf34219760237b3bc8f320b04fc438513aa637dfR214-R222): Added `break` statements to the `runEvent` function to prevent fall-through in the switch cases.