### PR TITLE
Re-worked how we generate sub-users

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -239,41 +239,54 @@ The schema is simple, it's a list of users in the following format:
 version: "1.5"
 map:
     # 1st user...
-    -   my_plex_server:
+    -   my_plex_server: # your main user backend name
             name: "mike_jones"
             options: { } # optional key.
-        my_jellyfin_server:
+        my_jellyfin_server: # your main user backend name
             name: "jones_mike"
-        my_emby_server:
+        my_emby_server: # your main user backend name
             name: "mikeJones"
             replace_with: "mike_jones" # optional action, to replace the username with the new one.
     # 2nd user...
-    -   my_emby_server:
+    -   my_emby_server: # your main user backend name
             name: "jiji_jones"
             options: { } # optional key.
-        my_plex_server:
+        my_plex_server: # your main user backend name
             name: "jones_jiji"
-        my_jellyfin_server:
-            name: "jijiJones"
+        my_jellyfin_server: # your main user backend name
+            name: "jiji.jones"
             replace_with: "jiji_jones" # optional action, to replace the username with the new one.
     #.... more users
 ```
 
-> [!IMPORTANT]
-> As we enforce specific naming convention for backend names and usernames they must follow the following format
-> `^[a-z_0-9]+$` which means, lowercase letters, numbers and `_` are allowed. No spaces, uppercase letters or special
-> characters are allowed. you can use the `replace_with` key to replace the username with the new one. if it's not
-> complying with the naming convention, or you want to force specific display name.
+If you create a map for a user, it SHOULD include all the backends you want to sync the user data with. while th matcher
+might automatically detect the other backends even if not included in the map, it best to manually set them in group to
+prevent any issues that might arise. Each list item is a user, and each user has a list of backends. Each backend
 
 > [!NOTE]
 > the backend names `my_plex_server`, `my_jellyfin_server`, `my_emby_server` are the names you have chosen for
-> your> backends.
+> your backends.
 >
-> The `name` field is whatever the backend is reporting the username as.
+> The `name` field must match the name after normalization, so if you have a backend with the name `Mike Jones` as
+> username, the `name:` in the `mapper.yaml` file should be `mike_jones` as the `backend:create` command will normalize
+> the name before passing it to the mapper which the mapper will convert it to `mike_jones`.
+
+## Important
+
+We enforce strict naming convention for backend names and usernames, So they must follow the following format
+`^[a-z_0-9]+$` which means, lowercase letters, numbers and `_` are allowed. No spaces, uppercase letters or special
+characters or name entirely made of digits are allowed. If the username is not complying with the naming convention, we
+forcibly normalize it to make it comply with the naming convention.
+
+If you want another name, you can use `replace_with` key to replace the username with the new one. However, the name
+also must comply with the naming convention.
 
 This yaml file helps map your users usernames in the different backends, so the tool can sync the correct user data. If
 you added or updated mapping, you should delete `users` directory and generate new data. by running the `backend:create`
 command as described in the previous section.
+
+You can run the `backend:create` command with `-v --dry-run` to see what it will do and if you need to create a mapping
+file or not.
 
 ----
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # Old Updates
 
+### 2025-02-11
+
+We recently have added support to generate accesstoken for external `Plex` users, i.e. `not home users`. so the
+`backends:create` command now supports generating the needed config files for external users. Beware the support for
+this is still in early stages, and might not work as expected. report any issues you might face.
+
+### 2025-02-05
+
+We have added initial support to browse the WebUI as sub user, it's still in early stages, only few Endpoints support
+it.
+We have also added support to webhooks to allow sub users, you simply have to add new hooks using `user@backend`. Please
+take look at [this FAQ](FAQ.md#how-to-add-webhooks) to learn how to use it for sub users.
+
 ### 2025-02-02
 
 We are happy to announce that we have merged in direct support for multi-user in `state:import` and `state:export`

--- a/README.md
+++ b/README.md
@@ -9,9 +9,27 @@ out of the box, this tool support `Jellyfin`, `Plex` and `Emby` media servers.
 
 ## Updates
 
+## 2025-04-06
+
+We have recently re-worked how the `backend:create` command works, and we no longer generate random name for invalid
+backends names or usernames. We do a normalization step to make sure the name is valid. This should help with the
+confusion of having random names. This means if you re-run the `backend:create` you most likely will get a different
+name then before. So, we suggest to re-run the command with `--re-create` flag. This flag will delete the current
+sub-users, and regenerate updated config files.
+
+We have also added new guard for the command, so if you already generated your sub-users, re-running the command will
+show you a warning message and exit without doing anything. to run the command again either you need to use
+`--re-create`or `--run` flag. The `--run` flag will run the command without deleting the current sub-users.
+
+We have also updated `mapper.yaml` file format to v1.5, please take moment to read the
+related the [FAQ](FAQ.md#whats-the-schema-for-the-mapperyaml-file)
+about it. The new format has added support for renaming the usernames, and the new spec is more versatile which should
+help us if we need to update something or add new features in the future.
+
 ### 2025-03-13
 
-We have recently added support for plex webhooks via tautulli which you can use if you don't have PlexPass. This should help
+We have recently added support for plex webhooks via tautulli which you can use if you don't have PlexPass. This should
+help
 close the gap with other media servers.
 
 ### 2025-02-19
@@ -26,19 +44,6 @@ with seconds as value, the minimum value is `180` seconds. `0` seconds means it'
 
 We are still not keen on this feature, and it might be removed in future releases if we aren't able to deal with the
 issues we are facing.
-
-### 2025-02-11
-
-We recently have added support to generate accesstoken for external `Plex` users, i.e. `not home users`. so the
-`backends:create` command now supports generating the needed config files for external users. Beware the support for
-this is still in early stages, and might not work as expected. report any issues you might face.
-
-### 2025-02-05
-
-We have added initial support to browse the WebUI as sub user, it's still in early stages, only few Endpoints support
-it.
-We have also added support to webhooks to allow sub users, you simply have to add new hooks using `user@backend`. Please
-take look at [this FAQ](FAQ.md#how-to-add-webhooks) to learn how to use it for sub users.
 
 --- 
 Refer to [NEWS](NEWS.md) for old updates.

--- a/frontend/pages/backends/index.vue
+++ b/frontend/pages/backends/index.vue
@@ -10,7 +10,7 @@
           <div class="field is-grouped">
             <p class="control" v-if="backends && backends.length>0">
               <button class="button is-purple" v-tooltip.bottom="'Create sub users backends.'"
-                      @click="navigateTo(makeConsoleCommand('backend:create -v', true))"
+                      @click="navigateTo(makeConsoleCommand('backend:create -B -v', true))"
                       :disabled="'main' !== api_user">
                 <span class="icon"><i class="fas fa-users"></i></span>
               </button>

--- a/src/Commands/System/TasksCommand.php
+++ b/src/Commands/System/TasksCommand.php
@@ -255,8 +255,7 @@ final class TasksCommand extends Command
                     $this->needToSave = true;
                 }
             };
-
-
+            
             if (self::CNAME === $eventName) {
                 $event->addLog(r("Task: Run '{name}'.", ['name' => $eventName]));
                 $exitCode = $this->run_command(


### PR DESCRIPTION
We have recently re-worked how the `backend:create` command works, and we no longer generate random name for invalid
backends names or usernames. We do a normalization step to make sure the name is valid. This should help with the
confusion of having random names. This means if you re-run the `backend:create` you most likely will get a different
name then before. So, we suggest to re-run the command with `--re-create` flag. This flag will delete the current
sub-users, and regenerate updated config files.

We have also added new guard for the command, so if you already generated your sub-users, re-running the command will
show you a warning message and exit without doing anything. to run the command again either you need to use
`--re-create`or `--run` flag. The `--run` flag will run the command without deleting the current sub-users.

We have also updated `mapper.yaml` file format to v1.5, please take moment to read the related the [FAQ](FAQ.md#whats-the-schema-for-the-mapperyaml-file) about it. The new format has added support for renaming the usernames, and the new spec is more versatile which should
help us if we need to update something or add new features in the future.

---------------

# auto generated changelog below 

This pull request includes several updates and improvements across different files, focusing on enhancing user management, updating documentation, and fixing minor issues. The most important changes are summarized below:

### Documentation Updates:
* [`FAQ.md`](diffhunk://#diff-c7bd425fd98aad1f9fef20099637bcbdcfadeb566ba1f83bb40ce484f195b8cfL242-R290): Improved the user mapping schema explanation, added comments for backend names, and enforced naming conventions.
* [`NEWS.md`](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaR3-R15): Added entries for new features, including support for external Plex users and browsing the WebUI as a sub-user.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R12-R32): Updated the `backend:create` command description and added details about the new `mapper.yaml` file format. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R12-R32) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-L42)

### Code Enhancements:
* [`frontend/pages/backends/index.vue`](diffhunk://#diff-02a17593909b4fe3132ce1c9223050c64312d90fb58477120a28952f21ab1f6fL13-R13): Modified the command for creating sub-user backends to include the `-B` flag.

These changes collectively improve the functionality, usability, and maintainability of the project.