### PR TITLE
Fix makedate call when the added_at is null

### DIFF
--- a/src/Commands/State/ExportCommand.php
+++ b/src/Commands/State/ExportCommand.php
@@ -389,7 +389,7 @@ class ExportCommand extends Command
                                                     'id' => $entity->id,
                                                     'title' => $entity->getName(),
                                                 ],
-                                                'added_at' => makeDate($addedDate),
+                                                'added_at' => $addedDate,
                                                 'data' => $input->getOption('trace') ? $entity->getAll() : [],
                                             ]
                                         );


### PR DESCRIPTION
This pull request includes an important change to the `src/Commands/State/ExportCommand.php` file to simplify the code by removing an unnecessary function call.

Codebase simplification:

* [`src/Commands/State/ExportCommand.php`](diffhunk://#diff-99f113b21111224bc177743a42dbd246a27de0162f4f970427465fc7fc7cb5abL392-R392): Replaced the `makeDate` function call with the `addedDate` variable directly in the `process` method.