### PR TITLE
Improvements to logging & import content summary/genres

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -194,6 +194,12 @@ return (function () {
             'level' => env('WS_LOGGER_SYSLOG_LEVEL', Level::Error),
             'name' => ag($config, 'name'),
         ],
+        'remote' => [
+            'type' => 'remote',
+            'enabled' => (bool)env('WS_LOGGER_REMOTE_ENABLE', false),
+            'level' => env('WS_LOGGER_REMOTE_LEVEL', Level::Error),
+            'url' => env('WS_LOGGER_REMOTE_URL', null),
+        ],
     ];
 
     $config['supported'] = [

--- a/config/env.spec.php
+++ b/config/env.spec.php
@@ -203,6 +203,32 @@ return (function () {
                 return $value;
             },
         ],
+        [
+            'key' => 'WS_LOGGER_REMOTE_ENABLE',
+            'description' => 'Enable logging to remote logger.',
+            'type' => 'bool',
+        ],
+        [
+            'key' => 'WS_LOGGER_REMOTE_LEVEL',
+            'description' => 'Set the log level for the remote logger. Default: ERROR.',
+            'type' => 'string',
+        ],
+        [
+            'key' => 'WS_LOGGER_REMOTE_URL',
+            'description' => 'The URL to the remote logger.',
+            'type' => 'string',
+            'validate' => function (mixed $value): string {
+                if (!is_numeric($value) && empty($value)) {
+                    throw new ValidationException('Invalid remote logger URL. Empty value.');
+                }
+
+                if (false === isValidURL($value)) {
+                    throw new ValidationException('Invalid remote logger URL. Must be a valid URL.');
+                }
+                return $value;
+            },
+            'mask' => true,
+        ],
     ];
 
     $validateCronExpression = function (string $value): string {

--- a/frontend/assets/css/style.css
+++ b/frontend/assets/css/style.css
@@ -199,6 +199,10 @@ html {
     cursor: help;
 }
 
+.is-pointer-click {
+    cursor: pointer;
+}
+
 .is-text-contents {
     display: contents;
 }
@@ -240,17 +244,3 @@ html {
     color: #e3c981;
 }
 
-.is-terminal {
-    background-color: #1f2229 !important;
-    color: #e3c981;
-    padding: 0.50rem;
-    line-height: 1.7;
-}
-
-.is-terminal > span:nth-child(even), .is-terminal > code > span:nth-child(even) {
-    color: #ffc9d4;
-}
-
-.is-terminal > span:nth-child(odd), .is-terminal > code > span:nth-child(odd) {
-    color: #e3c981;
-}

--- a/frontend/assets/css/style.css
+++ b/frontend/assets/css/style.css
@@ -199,10 +199,6 @@ html {
     cursor: help;
 }
 
-.is-pointer-click {
-    cursor: pointer;
-}
-
 .is-text-contents {
     display: contents;
 }

--- a/frontend/components/Markdown.vue
+++ b/frontend/components/Markdown.vue
@@ -19,8 +19,6 @@ const content = ref('')
 const api_url = useStorage('api_url', '')
 
 onMounted(async () => {
-  disableOpacity()
-
   const response = await fetch(`${api_url.value}${props.file}?_=${Date.now()}`)
   const text = await response.text()
 
@@ -53,6 +51,5 @@ onMounted(async () => {
   content.value = marked.parse(text)
 });
 
-onUnmounted(() => enableOpacity())
 
 </script>

--- a/frontend/components/Overlay.vue
+++ b/frontend/components/Overlay.vue
@@ -34,6 +34,14 @@ const eventHandler = e => {
   closeOverLay()
 }
 
-onMounted(() => window.addEventListener('keydown', eventHandler))
-onUnmounted(() => window.removeEventListener('keydown', eventHandler))
+onMounted(() => {
+  disableOpacity()
+  window.addEventListener('keydown', eventHandler)
+})
+
+onUnmounted(() => {
+  enableOpacity()
+  window.removeEventListener('keydown', eventHandler)
+})
+
 </script>

--- a/frontend/pages/history/[id]/index.vue
+++ b/frontend/pages/history/[id]/index.vue
@@ -4,43 +4,44 @@
       <div class="column is-12 is-clearfix">
         <span class="title is-4">
           <span class="is-unselectable">
-            <span class="icon"><i class="fas fa-history"/>&nbsp;</span>
+            <span class="icon"><i class="fas fa-history" />&nbsp;</span>
             <NuxtLink to="/history">History</NuxtLink>
-            : </span>{{ headerTitle }}
+            :
+          </span>{{ headerTitle }}
         </span>
         <div class="is-pulled-right" v-if="data?.via">
           <div class="field is-grouped">
             <p class="control">
               <button @click="api_show_photos = !api_show_photos" class="button is-purple"
-                      v-tooltip.bottom="`${api_show_photos ? 'Hide' : 'Show'} fanart`">
-                <span class="icon"><i class="fas fa-image"/></span>
+                v-tooltip.bottom="`${api_show_photos ? 'Hide' : 'Show'} fanart`">
+                <span class="icon"><i class="fas fa-image" /></span>
               </button>
             </p>
-            <p class="control" v-if="data?.files?.length>0">
+            <p class="control" v-if="data?.files?.length > 0">
               <button @click="navigateTo(`/play/${data.id}`)" class="button has-text-white has-background-danger-50"
-                      v-tooltip.bottom="`${data.content_exists ? 'Play media' : 'Media is inaccessible'}`"
-                      :disabled="!data.content_exists">
-                <span class="icon"><i class="fas fa-play"/></span>
+                v-tooltip.bottom="`${data.content_exists ? 'Play media' : 'Media is inaccessible'}`"
+                :disabled="!data.content_exists">
+                <span class="icon"><i class="fas fa-play" /></span>
               </button>
             </p>
             <p class="control">
               <button class="button" @click="toggleWatched"
-                      :class="{ 'is-success': !data.watched, 'is-danger': data.watched }"
-                      v-tooltip.bottom="'Toggle watch state'">
+                :class="{ 'is-success': !data.watched, 'is-danger': data.watched }"
+                v-tooltip.bottom="'Toggle watch state'">
                 <span class="icon">
-                  <i class="fas" :class="{'fa-eye-slash':data.watched,'fa-eye':!data.watched}"/>
+                  <i class="fas" :class="{ 'fa-eye-slash': data.watched, 'fa-eye': !data.watched }" />
                 </span>
               </button>
             </p>
             <p class="control">
               <button class="button is-danger" @click="deleteItem(data)" v-tooltip.bottom="'Delete the record'"
-                      :disabled="isDeleting || isLoading" :class="{'is-loading':isDeleting}">
-                <span class="icon"><i class="fas fa-trash"/></span>
+                :disabled="isDeleting || isLoading" :class="{ 'is-loading': isDeleting }">
+                <span class="icon"><i class="fas fa-trash" /></span>
               </button>
             </p>
             <p class="control">
-              <button class="button is-info" @click="loadContent(id)" :class="{'is-loading':isLoading}">
-                <span class="icon"><i class="fas fa-sync"/></span>
+              <button class="button is-info" @click="loadContent(id)" :class="{ 'is-loading': isLoading }">
+                <span class="icon"><i class="fas fa-sync" /></span>
               </button>
             </p>
           </div>
@@ -48,39 +49,47 @@
         <div class="subtitle is-5" v-if="data?.via && (data?.content_title || data?.content_overview)">
           <template v-if="data?.content_title">
             <span class="is-unselectable icon">
-              <i class="fas fa-tv" :class="{ 'fa-tv': 'episode' === data.type, 'fa-film': 'movie' === data.type }"/>
+              <i class="fas fa-tv" :class="{ 'fa-tv': 'episode' === data.type, 'fa-film': 'movie' === data.type }" />
             </span>
             {{ data?.content_title }}
           </template>
-          <div v-if="data?.content_overview" class="is-hidden-mobile is-pointer-click"
-               @click="expandOverview = !expandOverview" :class="{'is-text-overflow': !expandOverview }">
+          <div v-if="data?.content_overview" class="is-hidden-mobile is-clickable"
+            @click="expandOverview = !expandOverview" :class="{ 'is-text-overflow': !expandOverview }">
             <span class="is-unselectable icon" v-if="!data?.content_title">
-              <i class="fas fa-tv" :class="{ 'fa-tv': 'episode' === data.type, 'fa-film': 'movie' === data.type }"/>
+              <i class="fas fa-tv" :class="{ 'fa-tv': 'episode' === data.type, 'fa-film': 'movie' === data.type }" />
             </span>
             {{ expandOverview ? data.content_overview : data.content_overview }}
+          </div>
+          <div v-if="data?.content_genres && data.content_genres.length > 0" class="is-hidden-mobile is-clickable"
+            :class="{ 'is-text-overflow': !expandGenres }" @click="expandGenres = !expandGenres">
+            <span class="tag is-info is-clickable mr-1" v-for="(genre, id) in data.content_genres"
+              :key="`head-genre-${id}`">
+              <span class="icon"><i class="fas fa-tag" /></span>
+              <span class="is-capitalized" v-text="genre" />
+            </span>
           </div>
         </div>
       </div>
 
       <div class="column is-12" v-if="!data?.via && isLoading">
-        <Message message_class="has-background-info-90 has-text-dark" title="Loading"
-                 icon="fas fa-spinner fa-spin" message="Loading data. Please wait..."/>
+        <Message message_class="has-background-info-90 has-text-dark" title="Loading" icon="fas fa-spinner fa-spin"
+          message="Loading data. Please wait..." />
       </div>
 
-      <div class="column is-12" v-if="data?.not_reported_by && data.not_reported_by.length>0">
+      <div class="column is-12" v-if="data?.not_reported_by && data.not_reported_by.length > 0">
         <Message message_class="has-background-warning-80 has-text-dark" icon="fas fa-exclamation-triangle"
-                 :toggle="show_history_page_warning" title="Warning" :use-toggle="true"
-                 @toggle="show_history_page_warning=!show_history_page_warning">
+          :toggle="show_history_page_warning" title="Warning" :use-toggle="true"
+          @toggle="show_history_page_warning = !show_history_page_warning">
           <p>
-            <span class="icon"><i class="fas fa-exclamation"/></span>
+            <span class="icon"><i class="fas fa-exclamation" /></span>
             There are no metadata regarding this <strong>{{ data.type }}</strong> from (
             <span class="tag mr-1 has-text-dark" v-for="backend in data.not_reported_by" :key="`nr-${backend}`">
-              <NuxtLink :to="`/backend/${backend}`" v-text="backend"/>
+              <NuxtLink :to="`/backend/${backend}`" v-text="backend" />
             </span>).
           </p>
           <h5 class="has-text-dark">
             <span class="icon-text">
-              <span class="icon"><i class="fas fa-question-circle"/></span>
+              <span class="icon"><i class="fas fa-question-circle" /></span>
               <span>Possible reasons</span>
             </span>
           </h5>
@@ -98,21 +107,21 @@
       </div>
     </div>
 
-    <div class="columns is-multiline" :style="styleInfo" :class="{'bg-fanart': styleInfo}">
+    <div class="columns is-multiline" :style="styleInfo" :class="{ 'bg-fanart': styleInfo }">
       <div class="column is-12" v-if="data?.via">
         <div class="card" :class="{ 'is-success': parseInt(data.watched), 'transparent-bg': styleInfo }">
           <header class="card-header">
             <div class="card-header-title is-clickable is-unselectable" @click="data._toggle = !data._toggle">
               <span class="icon">
-                <i class="fas" :class="{'fa-arrow-up': data?._toggle, 'fa-arrow-down': !data?._toggle}"/>
+                <i class="fas" :class="{ 'fa-arrow-up': data?._toggle, 'fa-arrow-down': !data?._toggle }" />
               </span>
               <span>Latest local metadata via</span>
             </div>
             <div class="card-header-icon">
               <span class="icon-text">
-                <span class="icon"><i class="fas fa-server"/></span>
+                <span class="icon"><i class="fas fa-server" /></span>
                 <span>
-                  <NuxtLink :to="`/backend/${data.via}`" v-text="data.via"/>
+                  <NuxtLink :to="`/backend/${data.via}`" v-text="data.via" />
                 </span>
               </span>
             </div>
@@ -121,17 +130,17 @@
             <div class="columns is-multiline is-mobile">
               <div class="column is-6">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-passport"/></span>
+                  <span class="icon"><i class="fas fa-passport" /></span>
                   <span>
                     <span class="is-hidden-mobile">ID:&nbsp;</span>
-                    <NuxtLink :to="`/history/${data.id}`" v-text="data.id"/>
+                    <NuxtLink :to="`/history/${data.id}`" v-text="data.id" />
                   </span>
                 </span>
               </div>
 
               <div class="column is-6 has-text-right">
                 <span class="icon-text" v-if="parseInt(data.progress)">
-                  <span class="icon"><i class="fas fa-bars-progress"/></span>
+                  <span class="icon"><i class="fas fa-bars-progress" /></span>
                   <span><span class="is-hidden-mobile">Progress:</span> {{ formatDuration(data.progress) }}</span>
                 </span>
                 <span v-else>-</span>
@@ -140,8 +149,8 @@
               <div class="column is-6 has-text-left">
                 <span class="icon-text">
                   <span class="icon">
-                    <i class="fas fa-eye-slash" v-if="!data.watched"/>
-                    <i class="fas fa-eye" v-else/>
+                    <i class="fas fa-eye-slash" v-if="!data.watched" />
+                    <i class="fas fa-eye" v-else />
                   </span>
                   <span>
                     <span class="is-hidden-mobile">Status:</span>
@@ -151,7 +160,7 @@
               </div>
               <div class="column is-6 has-text-right">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-envelope"/></span>
+                  <span class="icon"><i class="fas fa-envelope" /></span>
                   <span>
                     <span class="is-hidden-mobile">Event:</span>
                     {{ ag(data.extra, `${data.via}.event`, 'Unknown') }}
@@ -160,11 +169,11 @@
               </div>
               <div class="column is-6 has-text-left">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-calendar"/></span>
+                  <span class="icon"><i class="fas fa-calendar" /></span>
                   <span>
                     <span class="is-hidden-mobile">Updated:&nbsp;</span>
                     <span class="has-tooltip"
-                          v-tooltip="`Backend updated this record at: ${moment.unix(data.updated).format(TOOLTIP_DATE_FORMAT)}`">
+                      v-tooltip="`Backend updated this record at: ${moment.unix(data.updated).format(TOOLTIP_DATE_FORMAT)}`">
                       {{ moment.unix(data.updated).fromNow() }}
                     </span>
                   </span>
@@ -173,64 +182,64 @@
 
               <div class="column is-6 has-text-right">
                 <span class="icon-text">
-                  <span class="icon" v-if="'episode' === data.type"><i class="fas fa-tv"/></span>
-                  <span class="icon" v-else><i class="fas fa-film"/></span>
+                  <span class="icon" v-if="'episode' === data.type"><i class="fas fa-tv" /></span>
+                  <span class="icon" v-else><i class="fas fa-film" /></span>
                   <span>
                     <span class="is-hidden-mobile">Type:&nbsp;</span>
-                    <NuxtLink :to="makeSearchLink('type',data.type)" v-text="ucFirst(data.type)"/>
+                    <NuxtLink :to="makeSearchLink('type', data.type)" v-text="ucFirst(data.type)" />
                   </span>
                 </span>
               </div>
 
               <div class="column is-6 has-text-left" v-if="'episode' === data.type">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-tv"/></span>
+                  <span class="icon"><i class="fas fa-tv" /></span>
                   <span><span class="is-hidden-mobile">Season:&nbsp;</span>
-                    <NuxtLink :to="makeSearchLink('season',data.season)" v-text="data.season"/>
+                    <NuxtLink :to="makeSearchLink('season', data.season)" v-text="data.season" />
                   </span>
                 </span>
               </div>
 
               <div class="column is-6 has-text-right" v-if="'episode' === data.type">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-tv"/></span>
+                  <span class="icon"><i class="fas fa-tv" /></span>
                   <span><span class="is-hidden-mobile">Episode:&nbsp;</span>
-                    <NuxtLink :to="makeSearchLink('episode',data.episode)" v-text="data.episode"/>
+                    <NuxtLink :to="makeSearchLink('episode', data.episode)" v-text="data.episode" />
                   </span>
                 </span>
               </div>
 
-              <div class="column is-12" v-if="data.guids && Object.keys(data.guids).length>0">
+              <div class="column is-12" v-if="data.guids && Object.keys(data.guids).length > 0">
                 <span class="icon-text is-clickable" v-tooltip="'Globally unique identifier for this item'">
-                  <span class="icon"><i class="fas fa-link"/></span>
+                  <span class="icon"><i class="fas fa-link" /></span>
                   <span>GUIDs:&nbsp;</span>
                 </span>
-                <span class="tag mr-1" v-for="(guid,source) in data.guids">
-                  <NuxtLink target="_blank" :to="makeGUIDLink( data.type, source.split('guid_')[1], guid, data)">
+                <span class="tag mr-1" v-for="(guid, source) in data.guids">
+                  <NuxtLink target="_blank" :to="makeGUIDLink(data.type, source.split('guid_')[1], guid, data)">
                     {{ source.split('guid_')[1] }}://{{ guid }}
                   </NuxtLink>
                 </span>
               </div>
 
-              <div class="column is-12" v-if="data.rguids && Object.keys(data.rguids).length>0">
+              <div class="column is-12" v-if="data.rguids && Object.keys(data.rguids).length > 0">
                 <span class="icon-text is-clickable" v-tooltip="'Relative Globally unique identifier for this episode'">
-                  <span class="icon"><i class="fas fa-link"/></span>
+                  <span class="icon"><i class="fas fa-link" /></span>
                   <span>rGUIDs:&nbsp;</span>
                 </span>
-                <span class="tag mr-1" v-for="(guid,source) in data.rguids">
+                <span class="tag mr-1" v-for="(guid, source) in data.rguids">
                   <NuxtLink :to="makeSearchLink('rguid', `${source.split('guid_')[1]}://${guid}`)">
                     {{ source.split('guid_')[1] }}://{{ guid }}
                   </NuxtLink>
                 </span>
               </div>
 
-              <div class="column is-12" v-if="data.parent && Object.keys(data.parent).length>0">
+              <div class="column is-12" v-if="data.parent && Object.keys(data.parent).length > 0">
                 <span class="icon-text is-clickable" v-tooltip="'Globally unique identifier for the series'">
-                  <span class="icon"><i class="fas fa-link"/></span>
+                  <span class="icon"><i class="fas fa-link" /></span>
                   <span>Series GUIDs:&nbsp;</span>
                 </span>
-                <span class="tag mr-1" v-for="(guid,source) in data.parent">
-                  <NuxtLink target="_blank" :to="makeGUIDLink( 'series', source.split('guid_')[1], guid, data)">
+                <span class="tag mr-1" v-for="(guid, source) in data.parent">
+                  <NuxtLink target="_blank" :to="makeGUIDLink('series', source.split('guid_')[1], guid, data)">
                     {{ source.split('guid_')[1] }}://{{ guid }}
                   </NuxtLink>
                 </span>
@@ -238,27 +247,27 @@
 
               <div class="column is-12" v-if="data?.content_title">
                 <div class="is-text-overflow">
-                  <span class="icon"><i class="fas fa-heading"/></span>
+                  <span class="icon"><i class="fas fa-heading" /></span>
                   <span class="is-hidden-mobile">Subtitle:&nbsp;</span>
-                  <NuxtLink :to="makeSearchLink('subtitle', data.content_title)" v-text="data.content_title"/>
+                  <NuxtLink :to="makeSearchLink('subtitle', data.content_title)" v-text="data.content_title" />
                 </div>
               </div>
 
               <div class="column is-12" v-if="data?.content_path">
                 <div class="is-text-overflow">
-                  <span class="icon"><i class="fas fa-file"/></span>
+                  <span class="icon"><i class="fas fa-file" /></span>
                   <span class="is-hidden-mobile">File:&nbsp;</span>
-                  <NuxtLink :to="makeSearchLink('path', data.content_path)" v-text="data.content_path"/>
+                  <NuxtLink :to="makeSearchLink('path', data.content_path)" v-text="data.content_path" />
                 </div>
               </div>
 
               <div class="column is-6 has-text-left" v-if="data.created_at">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-database"/></span>
+                  <span class="icon"><i class="fas fa-database" /></span>
                   <span>
                     <span class="is-hidden-mobile">Created:&nbsp;</span>
                     <span class="has-tooltip"
-                          v-tooltip="`DB record created at: ${moment.unix(data.created_at).format(TOOLTIP_DATE_FORMAT)}`">
+                      v-tooltip="`DB record created at: ${moment.unix(data.created_at).format(TOOLTIP_DATE_FORMAT)}`">
                       {{ moment.unix(data.created_at).fromNow() }}
                     </span>
                   </span>
@@ -267,36 +276,57 @@
 
               <div class="column is-6 has-text-right" v-if="data.updated_at">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-database"/></span>
+                  <span class="icon"><i class="fas fa-database" /></span>
                   <span>
                     <span class="is-hidden-mobile">Updated:&nbsp;</span>
                     <span class="has-tooltip"
-                          v-tooltip="`DB record updated at: ${moment.unix(data.updated_at).format(TOOLTIP_DATE_FORMAT)}`">
+                      v-tooltip="`DB record updated at: ${moment.unix(data.updated_at).format(TOOLTIP_DATE_FORMAT)}`">
                       {{ moment.unix(data.updated_at).fromNow() }}
                     </span>
                   </span>
                 </span>
               </div>
+
+              <div class="is-hidden-tablet column is-12" v-if="data?.content_genres && data?.content_genres.length > 0">
+                <div class="is-clickable" :class="{ 'is-text-overflow': !expandGenres }"
+                  @click="expandGenres = !expandGenres">
+                  <span class="icon"><i class="fas fa-tag" /></span>
+                  <span class="is-hidden-mobile">Genres:&nbsp;</span>
+                  <span class="tag is-info mr-1 is-capitalized" v-for="genre in data.content_genres"
+                    :key="`latest-${genre}`" v-text="genre" />
+                </div>
+              </div>
+
+              <div class="is-hidden-tablet column is-12" v-if="data?.content_overview">
+                <span class="icon"><i class="fas fa-comment" /></span>
+                <span>Content Summary</span>
+                <br>
+                <div class="is-clickable" :class="{ 'is-text-overflow': !expandOverview }"
+                  @click="expandOverview = !expandOverview">
+                  {{ data.content_overview }}
+                </div>
+              </div>
+
             </div>
           </div>
         </div>
       </div>
 
-      <div class="column is-12" v-if="data?.via && Object.keys(data.metadata).length>0">
+      <div class="column is-12" v-if="data?.via && Object.keys(data.metadata).length > 0">
         <div class="card" v-for="(item, key) in data.metadata" :key="key"
-             :class="{ 'is-success': parseInt(item.watched), 'transparent-bg': styleInfo}">
+          :class="{ 'is-success': parseInt(item.watched), 'transparent-bg': styleInfo }">
           <header class="card-header">
             <div class="card-header-title is-clickable is-unselectable" @click="item._toggle = !item._toggle">
               <span class="icon">
-                <i class="fas" :class="{'fa-arrow-up': item?._toggle, 'fa-arrow-down': !item?._toggle}"/>
+                <i class="fas" :class="{ 'fa-arrow-up': item?._toggle, 'fa-arrow-down': !item?._toggle }" />
               </span>
               Metadata via
             </div>
             <div class="card-header-icon">
               <span class="icon-text">
-                <span class="icon"><i class="fas fa-server"/></span>
+                <span class="icon"><i class="fas fa-server" /></span>
                 <span>
-                  <NuxtLink :to="`/backend/${key}`" v-text="key"/>
+                  <NuxtLink :to="`/backend/${key}`" v-text="key" />
                 </span>
               </span>
             </div>
@@ -306,18 +336,18 @@
 
               <div class="column is-6">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-passport"/></span>
+                  <span class="icon"><i class="fas fa-passport" /></span>
                   <span>
                     <span class="is-hidden-mobile">ID:&nbsp;</span>
-                    <NuxtLink :to="item?.webUrl" target="_blank" v-text="item.id" v-if="item?.webUrl"/>
-                    <span v-else v-text="item.id"/>
+                    <NuxtLink :to="item?.webUrl" target="_blank" v-text="item.id" v-if="item?.webUrl" />
+                    <span v-else v-text="item.id" />
                   </span>
                 </span>
               </div>
 
               <div class="column is-6 has-text-right">
                 <span class="icon-text" v-if="parseInt(item?.progress)">
-                  <span class="icon"><i class="fas fa-bars-progress"/></span>
+                  <span class="icon"><i class="fas fa-bars-progress" /></span>
                   <span><span class="is-hidden-mobile">Progress:</span> {{ formatDuration(item.progress) }}</span>
                 </span>
                 <span v-else>-</span>
@@ -326,7 +356,7 @@
               <div class="column is-6">
                 <span class="icon-text">
                   <span class="icon">
-                    <i class="fas fa-eye-slash" :class="parseInt(item.watched) ?'fa-eye-slash' : 'fa-eye'"/>
+                    <i class="fas fa-eye-slash" :class="parseInt(item.watched) ? 'fa-eye-slash' : 'fa-eye'" />
                   </span>
                   <span>
                     <span class="is-hidden-mobile">Status:</span>
@@ -337,7 +367,7 @@
 
               <div class="column is-6 has-text-right">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-envelope"/></span>
+                  <span class="icon"><i class="fas fa-envelope" /></span>
                   <span>
                     <span class="is-hidden-mobile">Event:</span>
                     {{ ag(data.extra, `${key}.event`, 'Unknown') }}
@@ -347,11 +377,11 @@
 
               <div class="column is-6">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-calendar"/></span>
+                  <span class="icon"><i class="fas fa-calendar" /></span>
                   <span>
                     <span class="is-hidden-mobile">Updated:&nbsp;</span>
                     <span class="has-tooltip"
-                          v-tooltip="`Backend last activity: ${getMoment(ag(data.extra, `${key}.received_at`, data.updated)).format(TOOLTIP_DATE_FORMAT)}`">
+                      v-tooltip="`Backend last activity: ${getMoment(ag(data.extra, `${key}.received_at`, data.updated)).format(TOOLTIP_DATE_FORMAT)}`">
                       {{ getMoment(ag(data.extra, `${key}.received_at`, data.updated)).fromNow() }}
                     </span>
                   </span>
@@ -360,54 +390,54 @@
 
               <div class="column is-6 has-text-right">
                 <span class="icon-text">
-                  <span class="icon" v-if="'episode' === item.type"><i class="fas fa-tv"/></span>
-                  <span class="icon" v-else><i class="fas fa-film"/></span>
+                  <span class="icon" v-if="'episode' === item.type"><i class="fas fa-tv" /></span>
+                  <span class="icon" v-else><i class="fas fa-film" /></span>
                   <span>
                     <span class="is-hidden-mobile">Type:&nbsp;</span>
-                    <NuxtLink :to="makeSearchLink('type',item.type)" v-text="ucFirst(item.type)"/>
+                    <NuxtLink :to="makeSearchLink('type', item.type)" v-text="ucFirst(item.type)" />
                   </span>
                 </span>
               </div>
 
               <div class="column is-6" v-if="'episode' === item.type">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-tv"/></span>
+                  <span class="icon"><i class="fas fa-tv" /></span>
                   <span>
                     <span class="is-hidden-mobile">Season:&nbsp;</span>
-                    <NuxtLink :to="makeSearchLink('season',item.season)" v-text="item.season"/>
+                    <NuxtLink :to="makeSearchLink('season', item.season)" v-text="item.season" />
                   </span>
                 </span>
               </div>
 
               <div class="column is-6 has-text-right" v-if="'episode' === item.type">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-tv"/></span>
+                  <span class="icon"><i class="fas fa-tv" /></span>
                   <span>
                     <span class="is-hidden-mobile">Episode:&nbsp;</span>
-                    <NuxtLink :to="makeSearchLink('episode',item.episode)" v-text="item.episode"/>
+                    <NuxtLink :to="makeSearchLink('episode', item.episode)" v-text="item.episode" />
                   </span>
                 </span>
               </div>
 
-              <div class="column is-12" v-if="item.guids && Object.keys(item.guids).length>0">
+              <div class="column is-12" v-if="item.guids && Object.keys(item.guids).length > 0">
                 <span class="icon-text is-clickable" v-tooltip="'Globally unique identifier for this item'">
-                  <span class="icon"><i class="fas fa-link"/></span>
+                  <span class="icon"><i class="fas fa-link" /></span>
                   <span>GUIDs:&nbsp;</span>
                 </span>
-                <span class="tag mr-1" v-for="(guid,source) in item.guids">
-                  <NuxtLink target="_blank" :to="makeGUIDLink( item.type, source.split('guid_')[1], guid, item)">
+                <span class="tag mr-1" v-for="(guid, source) in item.guids">
+                  <NuxtLink target="_blank" :to="makeGUIDLink(item.type, source.split('guid_')[1], guid, item)">
                     {{ source.split('guid_')[1] }}://{{ guid }}
                   </NuxtLink>
                 </span>
               </div>
 
-              <div class="column is-12" v-if="item.parent && Object.keys(item.parent).length>0">
+              <div class="column is-12" v-if="item.parent && Object.keys(item.parent).length > 0">
                 <span class="is-clickable icon-text" v-tooltip="'Globally unique identifier for the series'">
-                  <span class="icon"><i class="fas fa-link"/></span>
+                  <span class="icon"><i class="fas fa-link" /></span>
                   <span>Series GUIDs:&nbsp;</span>
                 </span>
-                <span class="tag mr-1" v-for="(guid,source) in item.parent">
-                  <NuxtLink target="_blank" :to="makeGUIDLink( 'series', source.split('guid_')[1], guid, item)">
+                <span class="tag mr-1" v-for="(guid, source) in item.parent">
+                  <NuxtLink target="_blank" :to="makeGUIDLink('series', source.split('guid_')[1], guid, item)">
                     {{ source.split('guid_')[1] }}://{{ guid }}
                   </NuxtLink>
                 </span>
@@ -415,27 +445,37 @@
 
               <div class="column is-12" v-if="item?.extra?.title">
                 <div class="is-text-overflow">
-                  <span class="icon"><i class="fas fa-heading"/></span>
+                  <span class="icon"><i class="fas fa-heading" /></span>
                   <span class="is-hidden-mobile">Subtitle:&nbsp</span>
-                  <NuxtLink :to="makeSearchLink('subtitle', item.extra.title)" v-text="item.extra.title"/>
+                  <NuxtLink :to="makeSearchLink('subtitle', item.extra.title)" v-text="item.extra.title" />
+                </div>
+              </div>
+
+              <div class="column is-12" v-if="item?.extra?.genres && item.extra.genres.length > 0">
+                <div class="is-clickable" :class="{ 'is-text-overflow': !item?.expandGenres }"
+                  @click="item.expandGenres = !item?.expandGenres">
+                  <span class="icon"><i class="fas fa-tag" /></span>
+                  <span class="is-hidden-mobile">Genres:&nbsp;</span>
+                  <span class="tag is-info mr-1 is-capitalized" v-for="genre in item.extra.genres"
+                    :key="`${item.id}-${genre}`" v-text="genre" />
+                </div>
+              </div>
+
+              <div class="column is-12" v-if="item?.extra?.overview">
+                <span class="icon"><i class="fas fa-comment" /></span>
+                <span>Content Summary</span>
+                <br>
+                <div class="is-clickable" :class="{ 'is-text-overflow': !item?.expandOverview }"
+                  @click="item.expandOverview = !item?.expandOverview">
+                  {{ item.extra.overview }}
                 </div>
               </div>
 
               <div class="column is-12" v-if="item?.path">
                 <div class="is-text-overflow">
-                  <span class="icon"><i class="fas fa-file"/></span>
+                  <span class="icon"><i class="fas fa-file" /></span>
                   <span class="is-hidden-mobile">File:&nbsp;</span>
-                  <NuxtLink :to="makeSearchLink('path', item.path)" v-text="item.path"/>
-                </div>
-              </div>
-
-              <div class="column is-12" v-if="item?.extra?.overview">
-                <span class="icon"><i class="fas fa-comment"/></span>
-                <span>Content Summary</span>
-                <br>
-                <div class="is-pointer-click" :class="{'is-text-overflow': !item?.expandOverview }"
-                     @click="item.expandOverview = !item?.expandOverview">
-                  {{ item.extra.overview }}
+                  <NuxtLink :to="makeSearchLink('path', item.path)" v-text="item.path" />
                 </div>
               </div>
 
@@ -450,8 +490,8 @@
         <span class="title is-4 is-clickable" @click="showRawData = !showRawData">
           <span class="icon-text">
             <span class="icon">
-              <i v-if="showRawData" class="fas fa-arrow-up"/>
-              <i v-else class="fas fa-arrow-down"/>
+              <i v-if="showRawData" class="fas fa-arrow-up" />
+              <i v-else class="fas fa-arrow-down" />
             </span>
             <span>Show raw unfiltered data</span>
           </span>
@@ -459,22 +499,23 @@
         <p class="subtitle">Useful for debugging.</p>
         <div v-if="showRawData" class="mt-2" style="position: relative; max-height: 400px; overflow-y: auto;">
           <code class="is-terminal is-block is-pre-wrap p-4">{{
-              JSON.stringify(Object.keys(data)
-                  .filter(key => !['files', 'hardware', 'content_exists', '_toggle'].includes(key))
-                  .reduce((obj, key) => {
-                    obj[key] = data[key];
-                    return obj;
-                  }, {}), null, 2)
-            }}</code>
+            JSON.stringify(Object.keys(data)
+              .filter(key => !['files', 'hardware', 'content_exists', '_toggle'].includes(key))
+              .reduce((obj, key) => {
+                obj[key] = data[key];
+                return obj;
+              }, {}), null, 2)
+          }}</code>
           <button class="button m-4" v-tooltip="'Copy text'" @click="() => copyText(JSON.stringify(data, null, 2))"
-                  style="position: absolute; top:0; right:0;">
-            <span class="icon"><i class="fas fa-copy"/></span>
+            style="position: absolute; top:0; right:0;">
+            <span class="icon"><i class="fas fa-copy" /></span>
           </button>
         </div>
       </div>
+
       <div class="column is-12">
         <Message message_class="has-background-info-90 has-text-dark" :toggle="show_page_tips"
-                 @toggle="show_page_tips = !show_page_tips" :use-toggle="true" title="Tips" icon="fas fa-info-circle">
+          @toggle="show_page_tips = !show_page_tips" :use-toggle="true" title="Tips" icon="fas fa-info-circle">
           <ul>
             <li>
               To see if your media backends are reporting different metadata for the same file, click on the file link
@@ -486,7 +527,7 @@
             </li>
             <li>
               <code>rGUIDSs</code> are relative globally unique identifiers for episodes based on <code>series
-              GUID</code>. They are formatted as <code>GUID://seriesID/season_number/episode_number</code>. We use
+            GUID</code>. They are formatted as <code>GUID://seriesID/season_number/episode_number</code>. We use
               <code>rGUIDs</code>, to identify specific episode. This is more reliable than using episode specific
               <code>GUID</code>, as they are often misreported in the source data.
             </li>
@@ -522,12 +563,12 @@ import {
   ucFirst
 } from '~/utils/index'
 import moment from 'moment'
-import {useBreakpoints, useStorage} from '@vueuse/core'
+import { useBreakpoints, useStorage } from '@vueuse/core'
 import Message from '~/components/Message'
 
 const id = useRoute().params.id
 
-useHead({title: `History : ${id}`})
+useHead({ title: `History : ${id}` })
 
 const isLoading = ref(true)
 const showRawData = ref(false)
@@ -535,9 +576,10 @@ const show_page_tips = useStorage('show_page_tips', true)
 const api_show_photos = useStorage('api_show_photos', true)
 const show_history_page_warning = useStorage('show_history_page_warning', true)
 const isDeleting = ref(false)
-const breakpoints = useBreakpoints({mobile: 0, desktop: 640})
-const loadedImages = ref({poster: null, background: null})
+const breakpoints = useBreakpoints({ mobile: 0, desktop: 640 })
+const loadedImages = ref({ poster: null, background: null })
 const expandOverview = ref(false)
+const expandGenres = ref(false)
 
 const bgImage = ref()
 
@@ -577,7 +619,7 @@ const loadContent = async (id) => {
   if (200 !== response.status) {
     notification('Error', 'Error loading data', `${json.error.code}: ${json.error.message}`);
     if (404 === response.status) {
-      await navigateTo({name: 'history'})
+      await navigateTo({ name: 'history' })
     }
     return
   }
@@ -585,12 +627,19 @@ const loadContent = async (id) => {
   data.value = json
   data.value._toggle = true
 
-  useHead({title: `History : ${makeName(json) ?? id}`})
+  useHead({ title: `History : ${makeName(json) ?? id}` })
   await loadImage()
 }
 
 watch(breakpoints.active(), async () => await loadImage())
-watch(api_show_photos, async () => await loadImage())
+watch(api_show_photos, async v => {
+  if (!v) {
+    return enableOpacity()
+  }
+
+  disableOpacity()
+  await loadImage()
+})
 
 const loadImage = async (t = null) => {
   if (!api_show_photos.value) {
@@ -627,7 +676,7 @@ const deleteItem = async (item) => {
   isDeleting.value = true
 
   try {
-    const response = await request(`/history/${id}`, {method: 'DELETE'})
+    const response = await request(`/history/${id}`, { method: 'DELETE' })
 
     if (200 !== response.status) {
       const json = await response.json()
@@ -636,7 +685,7 @@ const deleteItem = async (item) => {
     }
 
     notification('success', 'Success!', `Deleted '${makeName(item)}'.`)
-    await navigateTo({name: 'history'})
+    await navigateTo({ name: 'history' })
   } catch (e) {
     notification('error', 'Error', e.message)
   } finally {
@@ -674,5 +723,16 @@ const toggleWatched = async () => {
 const getMoment = (time) => time.toString().length < 13 ? moment.unix(time) : moment(time)
 const headerTitle = computed(() => isLoading.value ? id : makeName(data.value))
 
-onMounted(async () => loadContent(id))
+onUnmounted(() => {
+  if (api_show_photos.value) {
+    enableOpacity()
+  }
+})
+
+onMounted(async () => {
+  if (api_show_photos.value) {
+    disableOpacity()
+  }
+  await loadContent(id)
+})
 </script>

--- a/frontend/pages/history/[id]/index.vue
+++ b/frontend/pages/history/[id]/index.vue
@@ -4,7 +4,7 @@
       <div class="column is-12 is-clearfix">
         <span class="title is-4">
           <span class="is-unselectable">
-            <span class="icon"><i class="fas fa-history"></i>&nbsp;</span>
+            <span class="icon"><i class="fas fa-history"/>&nbsp;</span>
             <NuxtLink to="/history">History</NuxtLink>
             : </span>{{ headerTitle }}
         </span>
@@ -35,21 +35,30 @@
             <p class="control">
               <button class="button is-danger" @click="deleteItem(data)" v-tooltip.bottom="'Delete the record'"
                       :disabled="isDeleting || isLoading" :class="{'is-loading':isDeleting}">
-                <span class="icon"><i class="fas fa-trash"></i></span>
+                <span class="icon"><i class="fas fa-trash"/></span>
               </button>
             </p>
             <p class="control">
               <button class="button is-info" @click="loadContent(id)" :class="{'is-loading':isLoading}">
-                <span class="icon"><i class="fas fa-sync"></i></span>
+                <span class="icon"><i class="fas fa-sync"/></span>
               </button>
             </p>
           </div>
         </div>
-        <div class="subtitle is-5" v-if="data?.via && data.content_title">
-          <span class="is-unselectable icon">
-            <i class="fas fa-tv" :class="{ 'fa-tv': 'episode' === data.type, 'fa-film': 'movie' === data.type }"></i>
-          </span>
-          {{ data?.content_title }}
+        <div class="subtitle is-5" v-if="data?.via && (data?.content_title || data?.content_overview)">
+          <template v-if="data?.content_title">
+            <span class="is-unselectable icon">
+              <i class="fas fa-tv" :class="{ 'fa-tv': 'episode' === data.type, 'fa-film': 'movie' === data.type }"/>
+            </span>
+            {{ data?.content_title }}
+          </template>
+          <div v-if="data?.content_overview" class="is-hidden-mobile is-pointer-click"
+               @click="expandOverview = !expandOverview" :class="{'is-text-overflow': !expandOverview }">
+            <span class="is-unselectable icon" v-if="!data?.content_title">
+              <i class="fas fa-tv" :class="{ 'fa-tv': 'episode' === data.type, 'fa-film': 'movie' === data.type }"/>
+            </span>
+            {{ expandOverview ? data.content_overview : data.content_overview }}
+          </div>
         </div>
       </div>
 
@@ -63,7 +72,7 @@
                  :toggle="show_history_page_warning" title="Warning" :use-toggle="true"
                  @toggle="show_history_page_warning=!show_history_page_warning">
           <p>
-            <span class="icon"><i class="fas fa-exclamation"></i></span>
+            <span class="icon"><i class="fas fa-exclamation"/></span>
             There are no metadata regarding this <strong>{{ data.type }}</strong> from (
             <span class="tag mr-1 has-text-dark" v-for="backend in data.not_reported_by" :key="`nr-${backend}`">
               <NuxtLink :to="`/backend/${backend}`" v-text="backend"/>
@@ -71,7 +80,7 @@
           </p>
           <h5 class="has-text-dark">
             <span class="icon-text">
-              <span class="icon"><i class="fas fa-question-circle"></i></span>
+              <span class="icon"><i class="fas fa-question-circle"/></span>
               <span>Possible reasons</span>
             </span>
           </h5>
@@ -95,13 +104,13 @@
           <header class="card-header">
             <div class="card-header-title is-clickable is-unselectable" @click="data._toggle = !data._toggle">
               <span class="icon">
-                <i class="fas" :class="{'fa-arrow-up': data?._toggle, 'fa-arrow-down': !data?._toggle}"></i>
+                <i class="fas" :class="{'fa-arrow-up': data?._toggle, 'fa-arrow-down': !data?._toggle}"/>
               </span>
               <span>Latest local metadata via</span>
             </div>
             <div class="card-header-icon">
               <span class="icon-text">
-                <span class="icon"><i class="fas fa-server"></i></span>
+                <span class="icon"><i class="fas fa-server"/></span>
                 <span>
                   <NuxtLink :to="`/backend/${data.via}`" v-text="data.via"/>
                 </span>
@@ -112,7 +121,7 @@
             <div class="columns is-multiline is-mobile">
               <div class="column is-6">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-passport"></i></span>
+                  <span class="icon"><i class="fas fa-passport"/></span>
                   <span>
                     <span class="is-hidden-mobile">ID:&nbsp;</span>
                     <NuxtLink :to="`/history/${data.id}`" v-text="data.id"/>
@@ -122,7 +131,7 @@
 
               <div class="column is-6 has-text-right">
                 <span class="icon-text" v-if="parseInt(data.progress)">
-                  <span class="icon"><i class="fas fa-bars-progress"></i></span>
+                  <span class="icon"><i class="fas fa-bars-progress"/></span>
                   <span><span class="is-hidden-mobile">Progress:</span> {{ formatDuration(data.progress) }}</span>
                 </span>
                 <span v-else>-</span>
@@ -131,8 +140,8 @@
               <div class="column is-6 has-text-left">
                 <span class="icon-text">
                   <span class="icon">
-                    <i class="fas fa-eye-slash" v-if="!data.watched"></i>
-                    <i class="fas fa-eye" v-else></i>
+                    <i class="fas fa-eye-slash" v-if="!data.watched"/>
+                    <i class="fas fa-eye" v-else/>
                   </span>
                   <span>
                     <span class="is-hidden-mobile">Status:</span>
@@ -142,7 +151,7 @@
               </div>
               <div class="column is-6 has-text-right">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-envelope"></i></span>
+                  <span class="icon"><i class="fas fa-envelope"/></span>
                   <span>
                     <span class="is-hidden-mobile">Event:</span>
                     {{ ag(data.extra, `${data.via}.event`, 'Unknown') }}
@@ -151,7 +160,7 @@
               </div>
               <div class="column is-6 has-text-left">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-calendar"></i></span>
+                  <span class="icon"><i class="fas fa-calendar"/></span>
                   <span>
                     <span class="is-hidden-mobile">Updated:&nbsp;</span>
                     <span class="has-tooltip"
@@ -164,8 +173,8 @@
 
               <div class="column is-6 has-text-right">
                 <span class="icon-text">
-                  <span class="icon" v-if="'episode' === data.type"><i class="fas fa-tv"></i></span>
-                  <span class="icon" v-else><i class="fas fa-film"></i></span>
+                  <span class="icon" v-if="'episode' === data.type"><i class="fas fa-tv"/></span>
+                  <span class="icon" v-else><i class="fas fa-film"/></span>
                   <span>
                     <span class="is-hidden-mobile">Type:&nbsp;</span>
                     <NuxtLink :to="makeSearchLink('type',data.type)" v-text="ucFirst(data.type)"/>
@@ -175,7 +184,7 @@
 
               <div class="column is-6 has-text-left" v-if="'episode' === data.type">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-tv"></i></span>
+                  <span class="icon"><i class="fas fa-tv"/></span>
                   <span><span class="is-hidden-mobile">Season:&nbsp;</span>
                     <NuxtLink :to="makeSearchLink('season',data.season)" v-text="data.season"/>
                   </span>
@@ -184,7 +193,7 @@
 
               <div class="column is-6 has-text-right" v-if="'episode' === data.type">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-tv"></i></span>
+                  <span class="icon"><i class="fas fa-tv"/></span>
                   <span><span class="is-hidden-mobile">Episode:&nbsp;</span>
                     <NuxtLink :to="makeSearchLink('episode',data.episode)" v-text="data.episode"/>
                   </span>
@@ -193,7 +202,7 @@
 
               <div class="column is-12" v-if="data.guids && Object.keys(data.guids).length>0">
                 <span class="icon-text is-clickable" v-tooltip="'Globally unique identifier for this item'">
-                  <span class="icon"><i class="fas fa-link"></i></span>
+                  <span class="icon"><i class="fas fa-link"/></span>
                   <span>GUIDs:&nbsp;</span>
                 </span>
                 <span class="tag mr-1" v-for="(guid,source) in data.guids">
@@ -205,7 +214,7 @@
 
               <div class="column is-12" v-if="data.rguids && Object.keys(data.rguids).length>0">
                 <span class="icon-text is-clickable" v-tooltip="'Relative Globally unique identifier for this episode'">
-                  <span class="icon"><i class="fas fa-link"></i></span>
+                  <span class="icon"><i class="fas fa-link"/></span>
                   <span>rGUIDs:&nbsp;</span>
                 </span>
                 <span class="tag mr-1" v-for="(guid,source) in data.rguids">
@@ -217,7 +226,7 @@
 
               <div class="column is-12" v-if="data.parent && Object.keys(data.parent).length>0">
                 <span class="icon-text is-clickable" v-tooltip="'Globally unique identifier for the series'">
-                  <span class="icon"><i class="fas fa-link"></i></span>
+                  <span class="icon"><i class="fas fa-link"/></span>
                   <span>Series GUIDs:&nbsp;</span>
                 </span>
                 <span class="tag mr-1" v-for="(guid,source) in data.parent">
@@ -229,7 +238,7 @@
 
               <div class="column is-12" v-if="data?.content_title">
                 <div class="is-text-overflow">
-                  <span class="icon"><i class="fas fa-heading"></i></span>
+                  <span class="icon"><i class="fas fa-heading"/></span>
                   <span class="is-hidden-mobile">Subtitle:&nbsp;</span>
                   <NuxtLink :to="makeSearchLink('subtitle', data.content_title)" v-text="data.content_title"/>
                 </div>
@@ -237,7 +246,7 @@
 
               <div class="column is-12" v-if="data?.content_path">
                 <div class="is-text-overflow">
-                  <span class="icon"><i class="fas fa-file"></i></span>
+                  <span class="icon"><i class="fas fa-file"/></span>
                   <span class="is-hidden-mobile">File:&nbsp;</span>
                   <NuxtLink :to="makeSearchLink('path', data.content_path)" v-text="data.content_path"/>
                 </div>
@@ -245,7 +254,7 @@
 
               <div class="column is-6 has-text-left" v-if="data.created_at">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-database"></i></span>
+                  <span class="icon"><i class="fas fa-database"/></span>
                   <span>
                     <span class="is-hidden-mobile">Created:&nbsp;</span>
                     <span class="has-tooltip"
@@ -258,7 +267,7 @@
 
               <div class="column is-6 has-text-right" v-if="data.updated_at">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-database"></i></span>
+                  <span class="icon"><i class="fas fa-database"/></span>
                   <span>
                     <span class="is-hidden-mobile">Updated:&nbsp;</span>
                     <span class="has-tooltip"
@@ -268,7 +277,6 @@
                   </span>
                 </span>
               </div>
-
             </div>
           </div>
         </div>
@@ -280,13 +288,13 @@
           <header class="card-header">
             <div class="card-header-title is-clickable is-unselectable" @click="item._toggle = !item._toggle">
               <span class="icon">
-                <i class="fas" :class="{'fa-arrow-up': item?._toggle, 'fa-arrow-down': !item?._toggle}"></i>
+                <i class="fas" :class="{'fa-arrow-up': item?._toggle, 'fa-arrow-down': !item?._toggle}"/>
               </span>
               Metadata via
             </div>
             <div class="card-header-icon">
               <span class="icon-text">
-                <span class="icon"><i class="fas fa-server"></i></span>
+                <span class="icon"><i class="fas fa-server"/></span>
                 <span>
                   <NuxtLink :to="`/backend/${key}`" v-text="key"/>
                 </span>
@@ -298,7 +306,7 @@
 
               <div class="column is-6">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-passport"></i></span>
+                  <span class="icon"><i class="fas fa-passport"/></span>
                   <span>
                     <span class="is-hidden-mobile">ID:&nbsp;</span>
                     <NuxtLink :to="item?.webUrl" target="_blank" v-text="item.id" v-if="item?.webUrl"/>
@@ -309,7 +317,7 @@
 
               <div class="column is-6 has-text-right">
                 <span class="icon-text" v-if="parseInt(item?.progress)">
-                  <span class="icon"><i class="fas fa-bars-progress"></i></span>
+                  <span class="icon"><i class="fas fa-bars-progress"/></span>
                   <span><span class="is-hidden-mobile">Progress:</span> {{ formatDuration(item.progress) }}</span>
                 </span>
                 <span v-else>-</span>
@@ -318,7 +326,7 @@
               <div class="column is-6">
                 <span class="icon-text">
                   <span class="icon">
-                    <i class="fas fa-eye-slash" :class="parseInt(item.watched) ?'fa-eye-slash' : 'fa-eye'"></i>
+                    <i class="fas fa-eye-slash" :class="parseInt(item.watched) ?'fa-eye-slash' : 'fa-eye'"/>
                   </span>
                   <span>
                     <span class="is-hidden-mobile">Status:</span>
@@ -329,7 +337,7 @@
 
               <div class="column is-6 has-text-right">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-envelope"></i></span>
+                  <span class="icon"><i class="fas fa-envelope"/></span>
                   <span>
                     <span class="is-hidden-mobile">Event:</span>
                     {{ ag(data.extra, `${key}.event`, 'Unknown') }}
@@ -339,7 +347,7 @@
 
               <div class="column is-6">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-calendar"></i></span>
+                  <span class="icon"><i class="fas fa-calendar"/></span>
                   <span>
                     <span class="is-hidden-mobile">Updated:&nbsp;</span>
                     <span class="has-tooltip"
@@ -352,8 +360,8 @@
 
               <div class="column is-6 has-text-right">
                 <span class="icon-text">
-                  <span class="icon" v-if="'episode' === item.type"><i class="fas fa-tv"></i></span>
-                  <span class="icon" v-else><i class="fas fa-film"></i></span>
+                  <span class="icon" v-if="'episode' === item.type"><i class="fas fa-tv"/></span>
+                  <span class="icon" v-else><i class="fas fa-film"/></span>
                   <span>
                     <span class="is-hidden-mobile">Type:&nbsp;</span>
                     <NuxtLink :to="makeSearchLink('type',item.type)" v-text="ucFirst(item.type)"/>
@@ -363,7 +371,7 @@
 
               <div class="column is-6" v-if="'episode' === item.type">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-tv"></i></span>
+                  <span class="icon"><i class="fas fa-tv"/></span>
                   <span>
                     <span class="is-hidden-mobile">Season:&nbsp;</span>
                     <NuxtLink :to="makeSearchLink('season',item.season)" v-text="item.season"/>
@@ -373,7 +381,7 @@
 
               <div class="column is-6 has-text-right" v-if="'episode' === item.type">
                 <span class="icon-text">
-                  <span class="icon"><i class="fas fa-tv"></i></span>
+                  <span class="icon"><i class="fas fa-tv"/></span>
                   <span>
                     <span class="is-hidden-mobile">Episode:&nbsp;</span>
                     <NuxtLink :to="makeSearchLink('episode',item.episode)" v-text="item.episode"/>
@@ -383,7 +391,7 @@
 
               <div class="column is-12" v-if="item.guids && Object.keys(item.guids).length>0">
                 <span class="icon-text is-clickable" v-tooltip="'Globally unique identifier for this item'">
-                  <span class="icon"><i class="fas fa-link"></i></span>
+                  <span class="icon"><i class="fas fa-link"/></span>
                   <span>GUIDs:&nbsp;</span>
                 </span>
                 <span class="tag mr-1" v-for="(guid,source) in item.guids">
@@ -395,7 +403,7 @@
 
               <div class="column is-12" v-if="item.parent && Object.keys(item.parent).length>0">
                 <span class="is-clickable icon-text" v-tooltip="'Globally unique identifier for the series'">
-                  <span class="icon"><i class="fas fa-link"></i></span>
+                  <span class="icon"><i class="fas fa-link"/></span>
                   <span>Series GUIDs:&nbsp;</span>
                 </span>
                 <span class="tag mr-1" v-for="(guid,source) in item.parent">
@@ -407,7 +415,7 @@
 
               <div class="column is-12" v-if="item?.extra?.title">
                 <div class="is-text-overflow">
-                  <span class="icon"><i class="fas fa-heading"></i></span>
+                  <span class="icon"><i class="fas fa-heading"/></span>
                   <span class="is-hidden-mobile">Subtitle:&nbsp</span>
                   <NuxtLink :to="makeSearchLink('subtitle', item.extra.title)" v-text="item.extra.title"/>
                 </div>
@@ -415,9 +423,19 @@
 
               <div class="column is-12" v-if="item?.path">
                 <div class="is-text-overflow">
-                  <span class="icon"><i class="fas fa-file"></i></span>
+                  <span class="icon"><i class="fas fa-file"/></span>
                   <span class="is-hidden-mobile">File:&nbsp;</span>
                   <NuxtLink :to="makeSearchLink('path', item.path)" v-text="item.path"/>
+                </div>
+              </div>
+
+              <div class="column is-12" v-if="item?.extra?.overview">
+                <span class="icon"><i class="fas fa-comment"/></span>
+                <span>Content Summary</span>
+                <br>
+                <div class="is-pointer-click" :class="{'is-text-overflow': !item?.expandOverview }"
+                     @click="item.expandOverview = !item?.expandOverview">
+                  {{ item.extra.overview }}
                 </div>
               </div>
 
@@ -432,8 +450,8 @@
         <span class="title is-4 is-clickable" @click="showRawData = !showRawData">
           <span class="icon-text">
             <span class="icon">
-              <i v-if="showRawData" class="fas fa-arrow-up"></i>
-              <i v-else class="fas fa-arrow-down"></i>
+              <i v-if="showRawData" class="fas fa-arrow-up"/>
+              <i v-else class="fas fa-arrow-down"/>
             </span>
             <span>Show raw unfiltered data</span>
           </span>
@@ -450,7 +468,7 @@
             }}</code>
           <button class="button m-4" v-tooltip="'Copy text'" @click="() => copyText(JSON.stringify(data, null, 2))"
                   style="position: absolute; top:0; right:0;">
-            <span class="icon"><i class="fas fa-copy"></i></span>
+            <span class="icon"><i class="fas fa-copy"/></span>
           </button>
         </div>
       </div>
@@ -519,6 +537,7 @@ const show_history_page_warning = useStorage('show_history_page_warning', true)
 const isDeleting = ref(false)
 const breakpoints = useBreakpoints({mobile: 0, desktop: 640})
 const loadedImages = ref({poster: null, background: null})
+const expandOverview = ref(false)
 
 const bgImage = ref()
 

--- a/src/API/System/Explode.php
+++ b/src/API/System/Explode.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\API\System;
+
+use App\Libs\Attributes\Route\Get;
+use App\Libs\Exceptions\RuntimeException;
+use Psr\Http\Message\ResponseInterface as iResponse;
+
+final readonly class Explode
+{
+    public const string URL = '%{api.prefix}/system/explode';
+
+    #[Get(self::URL . '[/]', name: 'system.explode')]
+    public function __invoke(): iResponse
+    {
+        throw new RuntimeException('Throwing an exception to test exception handling.');
+    }
+}

--- a/src/Backends/Jellyfin/JellyfinActionTrait.php
+++ b/src/Backends/Jellyfin/JellyfinActionTrait.php
@@ -169,6 +169,14 @@ trait JellyfinActionTrait
             $metadataExtra[iState::COLUMN_META_DATA_EXTRA_DATE] = makeDate($PremieredAt)->format('Y-m-d');
         }
 
+        if (null !== ($IsFavorite = ag($item, 'UserData.IsFavorite'))) {
+            $metadataExtra[iState::COLUMN_META_DATA_EXTRA_FAVORITE] = (int)$IsFavorite;
+        }
+
+        if (null !== ($overView = ag($item, 'Overview'))) {
+            $metadataExtra[iState::COLUMN_META_DATA_EXTRA_OVERVIEW] = $overView;
+        }
+
         if (true === $isPlayed) {
             $metadata[iState::COLUMN_META_DATA_PLAYED_AT] = (string)makeDate($date)->getTimestamp();
             $metadata[iState::COLUMN_META_DATA_PROGRESS] = "0";

--- a/src/Backends/Jellyfin/JellyfinActionTrait.php
+++ b/src/Backends/Jellyfin/JellyfinActionTrait.php
@@ -126,6 +126,8 @@ trait JellyfinActionTrait
         $metadata = &$builder[iState::COLUMN_META_DATA][$context->backendName];
         $metadataExtra = &$metadata[iState::COLUMN_META_DATA_EXTRA];
 
+        $metadataExtra[iState::COLUMN_META_DATA_EXTRA_GENRES] = array_map(fn ($v) => strtolower($v), ag($item, 'Genres', []));
+
         // -- jellyfin/emby API does not provide library ID.
         if (null !== ($library = $opts[iState::COLUMN_META_LIBRARY] ?? null)) {
             $metadata[iState::COLUMN_META_LIBRARY] = (string)$library;
@@ -152,7 +154,15 @@ trait JellyfinActionTrait
                     guid: $guid,
                     id: $parentId
                 );
+
                 $metadata[iState::COLUMN_PARENT] = $builder[iState::COLUMN_PARENT];
+
+                if (count($metadataExtra[iState::COLUMN_META_DATA_EXTRA_GENRES]) < 1) {
+                    $metadataExtra[iState::COLUMN_META_DATA_EXTRA_GENRES] = array_map(
+                        fn ($v) => strtolower($v),
+                        ag($this->getItemDetails(context: $context, id: $parentId), 'Genres', [])
+                    );
+                }
             }
         }
 
@@ -267,18 +277,14 @@ trait JellyfinActionTrait
             return [];
         }
 
-        $context->cache->set(
-            $cacheKey,
-            Guid::fromArray(
-                payload: $guid->get(guids: $providersId, context: $logContext),
-                context: [
-                    'backend' => $context->backendName,
-                    ...$logContext,
-                ]
-            )->getAll()
-        );
+        $data = Guid::fromArray(
+            payload: $guid->get(guids: $providersId, context: $logContext),
+            context: ['backend' => $context->backendName, ...$logContext]
+        )->getAll();
 
-        return $context->cache->get($cacheKey);
+        $context->cache->set($cacheKey, $data);
+
+        return $data;
     }
 
     /**

--- a/src/Backends/Jellyfin/JellyfinClient.php
+++ b/src/Backends/Jellyfin/JellyfinClient.php
@@ -88,8 +88,10 @@ class JellyfinClient implements iClient
         'CustomRating',
         'DateCreated',
         'DateLastMediaAdded',
-        'Overview'
+        'Overview',
+        'Genres',
     ];
+
     /**
      * @var array<string> Map the Jellyfin types to our own types.
      */
@@ -245,7 +247,7 @@ class JellyfinClient implements iClient
 
         if (false === $response->isSuccessful()) {
             throw new HttpException(
-                ag($response->extra, 'message', fn() => $response->error->format()),
+                ag($response->extra, 'message', fn () => $response->error->format()),
                 ag($response->extra, 'http_code', 400),
             );
         }
@@ -786,7 +788,7 @@ class JellyfinClient implements iClient
     private function throwError(Response $response, string $className = RuntimeException::class, int $code = 0): void
     {
         throw new $className(
-            message: ag($response->extra, 'message', fn() => $response->error->format()),
+            message: ag($response->extra, 'message', fn () => $response->error->format()),
             code: $code,
             previous: $response->error->previous
         );

--- a/src/Backends/Jellyfin/JellyfinClient.php
+++ b/src/Backends/Jellyfin/JellyfinClient.php
@@ -84,6 +84,11 @@ class JellyfinClient implements iClient
         'ProductionYear',
         'Path',
         'UserDataLastPlayedDate',
+        'AirTime',
+        'CustomRating',
+        'DateCreated',
+        'DateLastMediaAdded',
+        'Overview'
     ];
     /**
      * @var array<string> Map the Jellyfin types to our own types.

--- a/src/Backends/Plex/PlexActionTrait.php
+++ b/src/Backends/Plex/PlexActionTrait.php
@@ -179,6 +179,10 @@ trait PlexActionTrait
             $metadataExtra[iState::COLUMN_META_DATA_EXTRA_DATE] = makeDate($PremieredAt)->format('Y-m-d');
         }
 
+        if (null !== ($summary = ag($item, 'summary'))) {
+            $metadataExtra[iState::COLUMN_META_DATA_EXTRA_OVERVIEW] = (string)$summary;
+        }
+
         if (true === $isPlayed) {
             $metadata[iState::COLUMN_META_DATA_PLAYED_AT] = (string)$date;
             $metadata[iState::COLUMN_META_DATA_PROGRESS] = "0";

--- a/src/Backends/Plex/PlexActionTrait.php
+++ b/src/Backends/Plex/PlexActionTrait.php
@@ -135,6 +135,15 @@ trait PlexActionTrait
         $metadata = &$builder[iState::COLUMN_META_DATA][$context->backendName];
         $metadataExtra = &$metadata[iState::COLUMN_META_DATA_EXTRA];
 
+        $metadataExtra[iState::COLUMN_META_DATA_EXTRA_GENRES] = [];
+
+        if (count(ag($item, 'Genre', [])) > 0) {
+            $metadataExtra[iState::COLUMN_META_DATA_EXTRA_GENRES] = array_map(
+                fn ($item) => strtolower((string)ag($item, 'tag', '??')),
+                ag($item, 'Genre', [])
+            );
+        }
+
         if (null !== ($library = ag($item, 'librarySectionID', $opts[iState::COLUMN_META_LIBRARY] ?? null))) {
             $metadata[iState::COLUMN_META_LIBRARY] = (string)$library;
         }
@@ -158,7 +167,15 @@ trait PlexActionTrait
                     guid: $guid,
                     id: $parentId
                 );
+
                 $metadata[iState::COLUMN_PARENT] = $builder[iState::COLUMN_PARENT];
+
+                if (count($metadataExtra[iState::COLUMN_META_DATA_EXTRA_GENRES]) < 1) {
+                    $metadataExtra[iState::COLUMN_META_DATA_EXTRA_GENRES] = array_map(
+                        fn ($i) => strtolower((string)ag($i, 'tag', '??')),
+                        ag($this->getItemDetails(context: $context, id: $parentId), 'MediaContainer.Metadata.0.Genre', [])
+                    );
+                }
             }
         }
 
@@ -366,9 +383,9 @@ trait PlexActionTrait
     protected function isSupportedType(string $type): bool
     {
         return true === in_array(
-                PlexClient::TYPE_MAPPER[$type] ?? PlexClient::TYPE_MAPPER[strtolower($type)] ?? $type,
-                iState::TYPES_LIST,
-                true
-            );
+            PlexClient::TYPE_MAPPER[$type] ?? PlexClient::TYPE_MAPPER[strtolower($type)] ?? $type,
+            iState::TYPES_LIST,
+            true
+        );
     }
 }

--- a/src/Commands/Database/ListCommand.php
+++ b/src/Commands/Database/ListCommand.php
@@ -79,6 +79,7 @@ final class ListCommand extends Command
             ->addOption('subtitle', null, InputOption::VALUE_REQUIRED, 'Limit results to this specified content title.')
             ->addOption('path', null, InputOption::VALUE_REQUIRED, 'Show results that contains this file path.')
             ->addOption('season', null, InputOption::VALUE_REQUIRED, 'Select season number.')
+            ->addOption('genre', null, InputOption::VALUE_REQUIRED, 'Filter on genre.')
             ->addOption('episode', null, InputOption::VALUE_REQUIRED, 'Select episode number.')
             ->addOption('year', null, InputOption::VALUE_REQUIRED, 'Select year.')
             ->addOption('id', null, InputOption::VALUE_REQUIRED, 'Select db record number.')
@@ -221,6 +222,10 @@ final class ListCommand extends Command
 
         if (null !== $input->getOption('season')) {
             $params['season'] = $input->getOption('season');
+        }
+
+        if (null !== $input->getOption('genre')) {
+            $params['genres'] = strtolower($input->getOption('genre'));
         }
 
         if (null !== $input->getOption('episode')) {

--- a/src/Libs/Entity/StateInterface.php
+++ b/src/Libs/Entity/StateInterface.php
@@ -45,6 +45,8 @@ interface StateInterface extends LoggerAwareInterface
     public const string COLUMN_META_DATA_RATING = 'rating';
     public const string COLUMN_META_DATA_EXTRA = 'extra';
     public const string COLUMN_META_DATA_EXTRA_TITLE = 'title';
+    public const string COLUMN_META_DATA_EXTRA_OVERVIEW = 'overview';
+    public const string COLUMN_META_DATA_EXTRA_FAVORITE = 'favorite';
     public const string COLUMN_META_DATA_EXTRA_DATE = 'date';
     public const string COLUMN_EXTRA = 'extra';
     public const string COLUMN_EXTRA_EVENT = 'event';

--- a/src/Libs/Entity/StateInterface.php
+++ b/src/Libs/Entity/StateInterface.php
@@ -47,6 +47,7 @@ interface StateInterface extends LoggerAwareInterface
     public const string COLUMN_META_DATA_EXTRA_TITLE = 'title';
     public const string COLUMN_META_DATA_EXTRA_OVERVIEW = 'overview';
     public const string COLUMN_META_DATA_EXTRA_FAVORITE = 'favorite';
+    public const string COLUMN_META_DATA_EXTRA_GENRES = 'genres';
     public const string COLUMN_META_DATA_EXTRA_DATE = 'date';
     public const string COLUMN_EXTRA = 'extra';
     public const string COLUMN_EXTRA_EVENT = 'event';

--- a/src/Libs/Extends/RemoteHandler.php
+++ b/src/Libs/Extends/RemoteHandler.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Libs\Extends;
+
+use App\Libs\Enums\Http\Method;
+use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Level;
+use Monolog\LogRecord;
+use Symfony\Contracts\HttpClient\HttpClientInterface as iHttp;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Throwable;
+
+final class RemoteHandler extends AbstractProcessingHandler
+{
+    /**
+     * @var array<ResponseInterface>
+     */
+    private array $requests = [];
+
+    public function __construct(
+        private readonly iHttp $client,
+        private readonly string $url,
+        $level = Level::Debug,
+        bool $bubble = true
+    ) {
+        $this->bubble = $bubble;
+
+        parent::__construct($level, $bubble);
+    }
+
+    public function __destruct()
+    {
+        if (count($this->requests) > 0) {
+            foreach ($this->requests as $request) {
+                try {
+                    $request->getStatusCode();
+                } catch (Throwable $e) {
+                    syslog(LOG_DEBUG, self::class . ': ' . $e->getMessage());
+                }
+            }
+        }
+
+        parent::__destruct();
+    }
+
+    protected function write(LogRecord $record): void
+    {
+        $server = $_SERVER ?? [];
+
+        foreach ($server as $key => $value) {
+            if (is_string($key) && str_starts_with(strtoupper($key), 'WS_')) {
+                $server[$key] = '***';
+            }
+        }
+
+        try {
+            $this->requests[] = $this->client->request(Method::POST->value, $this->url, [
+                'timeout' => 6,
+                'json' => [
+                    'id' => generateUUID(),
+                    'message' => $record->message,
+                    'trace' => ag($record->context, 'trace', []),
+                    'structured' => ag($record->context, 'structured', []),
+                    'server' => ag($_SERVER ?? [], ['HTTP_HOST', 'SERVER_NAME'], 'watchstate.cli'),
+                    'context' => $server,
+                    'raw' => $record->toArray(),
+                ]
+            ]);
+        } catch (Throwable $e) {
+            syslog(LOG_ERR, sprintf('%s: %s. (%s:%d)', $e::class, $e->getMessage(), $e->getFile(), $e->getLine()));
+        }
+    }
+}

--- a/src/Libs/Initializer.php
+++ b/src/Libs/Initializer.php
@@ -11,6 +11,7 @@ use App\Libs\Exceptions\Backends\RuntimeException;
 use App\Libs\Exceptions\HttpException;
 use App\Libs\Extends\ConsoleHandler;
 use App\Libs\Extends\ConsoleOutput;
+use App\Libs\Extends\RemoteHandler;
 use App\Libs\Extends\RouterStrategy;
 use Closure;
 use ErrorException;
@@ -29,6 +30,7 @@ use Psr\Log\LoggerInterface as iLogger;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Console\CommandLoader\ContainerCommandLoader;
 use Symfony\Component\Yaml\Yaml;
+use Symfony\Contracts\HttpClient\HttpClientInterface as iHttp;
 use Throwable;
 
 /**
@@ -542,6 +544,20 @@ final class Initializer
                             )
                         )
                     );
+                    break;
+                case 'remote':
+                    if (null !== ($remoteUrl = ag($context, 'url'))) {
+                        $logger->pushHandler(
+                            $wrap->withHandler(
+                                new RemoteHandler(
+                                    Container::get(iHttp::class),
+                                    $remoteUrl,
+                                    ag($context, 'level', Level::Warning),
+                                    (bool)ag($context, 'bubble', true),
+                                )
+                            )
+                        );
+                    }
                     break;
                 case 'console':
                     $logger->pushHandler($wrap->withHandler(new ConsoleHandler($this->cliOutput)));

--- a/src/Libs/Traits/APITraits.php
+++ b/src/Libs/Traits/APITraits.php
@@ -228,6 +228,10 @@ trait APITraits
 
         $item['content_title'] = $entity->getMeta(iState::COLUMN_EXTRA . '.' . iState::COLUMN_TITLE, null);
         $item['content_path'] = ag($entity->getMetadata($entity->via), iState::COLUMN_META_PATH);
+        $item['content_overview'] = ag(
+            $entity->getMetadata($entity->via),
+            iState::COLUMN_EXTRA . '.' . iState::COLUMN_META_DATA_EXTRA_OVERVIEW
+        );
 
         $item['rguids'] = [];
         $item['reported_by'] = [];

--- a/src/Libs/Traits/APITraits.php
+++ b/src/Libs/Traits/APITraits.php
@@ -233,6 +233,11 @@ trait APITraits
             iState::COLUMN_EXTRA . '.' . iState::COLUMN_META_DATA_EXTRA_OVERVIEW
         );
 
+        $item['content_genres'] = ag(
+            $entity->getMetadata($entity->via),
+            iState::COLUMN_EXTRA . '.' . iState::COLUMN_META_DATA_EXTRA_GENRES
+        );
+
         $item['rguids'] = [];
         $item['reported_by'] = [];
 


### PR DESCRIPTION
This PR does the following

- [x] Reduce logging bloat for metadata only imports, by reducing it's level to `INFO` instead of `NOTICE`
- [x] Improve some logging messages to be more concise.
- [x] Import and display the content summary in history page.
- [x] Import content genre.
- [x] Add remote logging target handler, to let the user forward log to external entity.
- [x] Make genres searchable via WebUI/CLI
- [x] import jellyfin/Emby `IsFavorite` flag, similarly to plex `userRating`, we are not doing anything with it yet, but it could be useful, in the future if we want to make in-house recommendation prompts to AI.