### PR TITLE
Add the ability to send backends requests in sequential instead of the default parallel mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,24 @@
-# Old Updates
+# NEWS
+
+This page contains old news about the project.
+
+### 2025-03-13
+
+We have recently added support for plex webhooks via tautulli which you can use if you don't have PlexPass. This should
+help close the gap with other media servers.
+
+### 2025-02-19
+
+We have introduced new experimental feature to allow syncing watch progress for played items. This feature is still in
+early stages, and might not work as expected. and there are probably still many bugs that we need to fix. Please report
+any issues you might face.
+
+The feature is disabled by default, to enable it you need to run add this environment variable `WS_PROGRESS_THRESHOLD`
+with seconds as value, the minimum value is `180` seconds. `0` seconds means it's disabled. We think reasonable value is
+`86400` or more this number is about 1day.
+
+We are still not keen on this feature, and it might be removed in future releases if we aren't able to deal with the
+issues we are facing.
 
 ### 2025-02-11
 

--- a/README.md
+++ b/README.md
@@ -9,23 +9,34 @@ out of the box, this tool support `Jellyfin`, `Plex` and `Emby` media servers.
 
 # Updates
 
+### 2025-05-05
+
+We’ve added a new feature that lets you send requests **sequentially** to the backends instead of using the default
+**parallel** mode. This can be especially helpful if you have very large libraries, slow disks, or simply want to avoid
+overloading the backends with too many concurrent requests. You can enable by enabling `WS_HTTP_SYNC_REQUESTS`
+environment variable. This mode only applies to `import`, `export`, and `backup` tasks at the moment.
+
+Additionally, two command-line flags let you override the mode on the fly `--sync-requests` and `--async-requests`.
+
+We’ll be evaluating this feature for a trial period. If it proves effective (and the slowdown is acceptable), we may
+make **sequential** mode the default in a future release.
+
+> [!NOTE]
+> Because we cache many HTTP requests, comparing timings between sequential and parallel runs of `import` can be
+> misleading. To get an accurate benchmark of `--sync-requests`, either start with a fresh setup (new installation) or
+> purge your Redis instance before testing.
+
 ### 2025-04-06
 
-We have recently re-worked how the `backend:create` command works, and we no longer generate random name for invalid backends names or usernames. We do a normalization step to make sure the name is valid. This should help with the confusion of having random names. This means if you re-run the `backend:create` you most likely will get a different name than before. So, we suggest to re-run the command with `--re-create` flag. This flag will delete the current sub-users, and regenerate updated config files.
+We have recently re-worked how the `backend:create` command works, and we no longer generate random name for invalid
+backends names or usernames. We do a normalization step to make sure the name is valid. This should help with the
+confusion of having random names. This means if you re-run the `backend:create` you most likely will get a different
+name than before. So, we suggest to re-run the command with `--re-create` flag. This flag will delete the current
+sub-users, and regenerate updated config files.
 
-We have also added new guard for the command, so if you already generated your sub-users, re-running the command will show you a warning message and exit without doing anything. to run the command again either you need to use `--re-create`or `--run` flag. The `--run` flag will run the command without deleting the current sub-users.
-
-### 2025-03-13
-
-We have recently added support for plex webhooks via tautulli which you can use if you don't have PlexPass. This should help close the gap with other media servers.
-
-### 2025-02-19
-
-We have introduced new experimental feature to allow syncing watch progress for played items. This feature is still in early stages, and might not work as expected. and there are probably still many bugs that we need to fix. Please report any issues you might face.
-
-The feature is disabled by default, to enable it you need to run add this environment variable `WS_PROGRESS_THRESHOLD` with seconds as value, the minimum value is `180` seconds. `0` seconds means it's disabled. We think reasonable value is `86400` or more this number is about 1day.
-
-We are still not keen on this feature, and it might be removed in future releases if we aren't able to deal with the issues we are facing.
+We have also added new guard for the command, so if you already generated your sub-users, re-running the command will
+show you a warning message and exit without doing anything. to run the command again either you need to use
+`--re-create`or `--run` flag. The `--run` flag will run the command without deleting the current sub-users.
 
 --- 
 Refer to [NEWS](NEWS.md) for old updates.
@@ -42,11 +53,13 @@ Refer to [NEWS](NEWS.md) for old updates.
 * Sync your watch progress/play state via webhooks or scheduled tasks.
 * Check if your media backends have stale references to old files.
 
-If you like my work, you might also like my other project [YTPTube](https://github.com/arabcoders/ytptube), which is simple and to the point yt-dlp frontend to help download content from all supported sites by yt-dlp.
+If you like my work, you might also like my other project [YTPTube](https://github.com/arabcoders/ytptube), which is
+simple and to the point yt-dlp frontend to help download content from all supported sites by yt-dlp.
 
 # Install
 
-First, start by creating a directory to store the data, to follow along with this setup, create directory called `data` at your working directory. Then proceed to use your preferred method to install the tool.
+First, start by creating a directory to store the data, to follow along with this setup, create directory called `data`
+at your working directory. Then proceed to use your preferred method to install the tool.
 
 ### Via compose file.
 
@@ -79,26 +92,34 @@ $ docker run -d --rm --user "${UID:-1000}:${GID:-1000}" --name watchstate --rest
 ```
 
 > [!IMPORTANT]
-> It's really important to match the `user:`, `--user` to the owner of the `data` directory, the container is rootless, as such it will crash if it's unable to write to the data directory. 
-> 
-> It's really not recommended to run containers as root, but if you fail to run the container you can try setting the `user: "0:0"` or `--user '0:0'` if that works it means you have permissions issues. refer to [FAQ](FAQ.md) to troubleshoot the problem.
+> It's really important to match the `user:`, `--user` to the owner of the `data` directory, the container is rootless,
+> as such it will crash if it's unable to write to the data directory.
+>
+> It's really not recommended to run containers as root, but if you fail to run the container you can try setting the
+`user: "0:0"` or `--user '0:0'` if that works it means you have permissions issues. refer to [FAQ](FAQ.md) to
+> troubleshoot the problem.
 
 ### Unraid users
 
-For `Unraid` users You can install the `Community Applications` plugin, and search for  **watchstate** it comes preconfigured. Otherwise, to manually install it, you need to add value to the `Extra Parameters` section in advanced tab/view. add the following value `--user 99:100`.
- 
-This has to happen before you start the container, otherwise it will have the old user id, and 
- you then have to run the following command from terminal `chown -R 99:100 /mnt/user/appdata/watchstate`.
+For `Unraid` users You can install the `Community Applications` plugin, and search for  **watchstate** it comes
+preconfigured. Otherwise, to manually install it, you need to add value to the `Extra Parameters` section in advanced
+tab/view. add the following value `--user 99:100`.
+
+This has to happen before you start the container, otherwise it will have the old user id, and
+you then have to run the following command from terminal `chown -R 99:100 /mnt/user/appdata/watchstate`.
 
 ### Podman instead of docker
 
-To use this container with `podman` set `compose.yaml` `user` to `0:0`. it will appear to be working as root inside the container, but it will be mapped to the user in which the command was run under.
+To use this container with `podman` set `compose.yaml` `user` to `0:0`. it will appear to be working as root inside the
+container, but it will be mapped to the user in which the command was run under.
 
 # Management
 
 After starting the container, you can access the WebUI by visiting `http://localhost:8080` in your browser.
 
-At the start you won't see anything as the `WebUI` is decoupled from the WatchState and need to be configured to be able to access the API. In the top right corner, you will see a cogwheel icon, click on it and then Configure the connection settings.
+At the start you won't see anything as the `WebUI` is decoupled from the WatchState and need to be configured to be able
+to access the API. In the top right corner, you will see a cogwheel icon, click on it and then Configure the connection
+settings.
 
 ![Connection settings](screenshots/api_settings.png)
 
@@ -117,31 +138,40 @@ From the host machine, you can run the following command
 $ docker exec watchstate console system:apikey
 ```
 
-Insert the `API key` into the `API Token` field and make sure to set the `API URL` or click the `current page URL` link. If everything is ok, the reset of the navbar will show up.
+Insert the `API key` into the `API Token` field and make sure to set the `API URL` or click the `current page URL` link.
+If everything is ok, the reset of the navbar will show up.
 
-To add your backends, please click on the help button in the top right corner, and choose which method you want [one-way](guides/one-way-sync.md) or [two-way](guides/two-way-sync.md) sync. and follow the instructions.
+To add your backends, please click on the help button in the top right corner, and choose which method you
+want [one-way](guides/one-way-sync.md) or [two-way](guides/two-way-sync.md) sync. and follow the instructions.
 
-### Supported import method
+### Supported import methods
 
 Currently, the tool supports three methods to import data from backends.
 
-- **Scheduled Tasks**. 
-  - `A scheduled job that pull data from backends on a schedule.`
-- **On demand**. 
-  - `Pull data from backends on demand. By running the import task manually.`
-- **Webhooks**. 
-  - `Receive events from backends and update the database accordingly.`
+- **Scheduled Tasks**.
+    - `A scheduled job that pull data from backends on a schedule.`
+- **On demand**.
+    - `Pull data from backends on demand. By running the import task manually.`
+- **Webhooks**.
+    - `Receive events from backends and update the database accordingly.`
 
 > [!NOTE]
-> Even if all your backends support webhooks, you should keep import task enabled. This help keep healthy relationship and pick up any missed events. For more information please check the FAQ related to webhooks limitations.
+> Even if all your backends support webhooks, you should keep import task enabled. This help keep healthy relationship
+> and pick up any missed events. For more information please check the [webhook guide](/guides/webhooks.md) to
+> understand
+> webhooks limitations.
 
 # FAQ
 
-Take look at this [frequently asked questions](FAQ.md) page, or the [guides](guides/) for more in-depth guides on how to setup things.
+Take look at this [frequently asked questions](FAQ.md) page, or the [guides](/guides/) for more in-depth guides on how
+to
+configure things.
 
 # Social channels
 
-If you have short or quick questions, or just want to chat with other users, feel free to join this [discord server](https://discord.gg/haUXHJyj6Y), keep in mind it's solo project, as such it might take me a bit of time to reply to questions, I operate in `UTC+3` timezone.
+If you have short or quick questions, or just want to chat with other users, feel free to join
+this [discord server](https://discord.gg/haUXHJyj6Y), keep in mind it's solo project, as such it might take me a bit of
+time to reply to questions, I operate in `UTC+3` timezone.
 
 # Donate
 

--- a/config/config.php
+++ b/config/config.php
@@ -137,6 +137,7 @@ return (function () {
 
     $config['http'] = [
         'default' => [
+            'maxRetries' => (int)env('WS_HTTP_MAX_RETRIES', 3),
             'options' => [
                 'headers' => [
                     'User-Agent' => ag($config, 'name') . '/' . getAppVersion(),

--- a/config/config.php
+++ b/config/config.php
@@ -138,6 +138,7 @@ return (function () {
     $config['http'] = [
         'default' => [
             'maxRetries' => (int)env('WS_HTTP_MAX_RETRIES', 3),
+            'sync_requests' => (bool)env('WS_HTTP_SYNC_REQUESTS', false),
             'options' => [
                 'headers' => [
                     'User-Agent' => ag($config, 'name') . '/' . getAppVersion(),

--- a/config/env.spec.php
+++ b/config/env.spec.php
@@ -229,6 +229,11 @@ return (function () {
             },
             'mask' => true,
         ],
+        [
+            'key' => 'WS_HTTP_SYNC_REQUESTS',
+            'description' => 'Whether to send backend requests in parallel or sequentially.',
+            'type' => 'bool',
+        ],
     ];
 
     $validateCronExpression = function (string $value): string {

--- a/config/servers.spec.php
+++ b/config/servers.spec.php
@@ -104,7 +104,7 @@ return [
         'key' => 'options.LIBRARY_SEGMENT',
         'type' => 'int',
         'visible' => true,
-        'description' => 'How many items to per request.',
+        'description' => 'How many items to get per request when syncing.',
         'validate' => function ($value) {
             $limit = 300;
             if ((int)$value < $limit) {

--- a/config/services.php
+++ b/config/services.php
@@ -44,7 +44,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 return (function (): array {
     return [
         iLogger::class => [
-            'class' => fn () => new Logger(name: 'logger', processors: [new LogMessageProcessor()])
+            'class' => fn() => new Logger(name: 'logger', processors: [new LogMessageProcessor()])
         ],
 
         HttpClientInterface::class => [
@@ -63,6 +63,7 @@ return (function (): array {
                 iLogger::class,
             ],
         ],
+        
         RetryableHttpClient::class => [
             'class' => function (HttpClientInterface $client, iLogger $logger): RetryableHttpClient {
                 return new RetryableHttpClient(
@@ -76,6 +77,7 @@ return (function (): array {
                 iLogger::class,
             ],
         ],
+
         LogSuppressor::class => [
             'class' => function (): LogSuppressor {
                 $suppress = [];
@@ -90,11 +92,11 @@ return (function (): array {
         ],
 
         StateInterface::class => [
-            'class' => fn () => new StateEntity([])
+            'class' => fn() => new StateEntity([])
         ],
 
         QueueRequests::class => [
-            'class' => fn () => new QueueRequests()
+            'class' => fn() => new QueueRequests()
         ],
 
         Redis::class => [
@@ -189,16 +191,16 @@ return (function (): array {
         ],
 
         UriInterface::class => [
-            'class' => fn () => new Uri(''),
+            'class' => fn() => new Uri(''),
             'shared' => false,
         ],
 
         InputInterface::class => [
-            'class' => fn (): InputInterface => new ArgvInput()
+            'class' => fn(): InputInterface => new ArgvInput()
         ],
 
         OutputInterface::class => [
-            'class' => fn (): OutputInterface => new ConsoleOutput()
+            'class' => fn(): OutputInterface => new ConsoleOutput()
         ],
 
         PDO::class => [
@@ -226,7 +228,7 @@ return (function (): array {
         ],
 
         DBLayer::class => [
-            'class' => fn (PDO $pdo): DBLayer => new DBLayer($pdo),
+            'class' => fn(PDO $pdo): DBLayer => new DBLayer($pdo),
             'args' => [
                 PDO::class,
             ],
@@ -290,16 +292,16 @@ return (function (): array {
         ],
 
         iImport::class => [
-            'class' => fn (iImport $mapper): iImport => $mapper,
+            'class' => fn(iImport $mapper): iImport => $mapper,
             'args' => [MemoryMapper::class],
         ],
 
         EventDispatcherInterface::class => [
-            'class' => fn (): EventDispatcher => new EventDispatcher(),
+            'class' => fn(): EventDispatcher => new EventDispatcher(),
         ],
 
         UserContext::class => [
-            'class' => fn (iCache $cache, iImport $mapper, iDB $db): UserContext => new UserContext(
+            'class' => fn(iCache $cache, iImport $mapper, iDB $db): UserContext => new UserContext(
                 name: 'main',
                 config: new ConfigFile(
                     file: Config::get('backends_file'),

--- a/frontend/components/Markdown.vue
+++ b/frontend/components/Markdown.vue
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 .markdown-alert {
   padding: 0 1em;
   margin-bottom: 16px;

--- a/frontend/pages/tasks.vue
+++ b/frontend/pages/tasks.vue
@@ -10,13 +10,13 @@
           <div class="field is-grouped">
             <p class="control">
               <button class="button" @click="showTaskRunner = !showTaskRunner" v-tooltip="'Task Runner Status'"
-                :class="{ 'is-primary': taskRunner.status, 'is-danger': !taskRunner.status }">
-                <span class="icon"><i class="fas fa-microchip" /></span>
+                      :class="{ 'is-primary': taskRunner.status, 'is-danger': !taskRunner.status }">
+                <span class="icon"><i class="fas fa-microchip"/></span>
               </button>
             </p>
             <p class="control">
               <button class="button is-info" @click="loadContent()" :disabled="isLoading"
-                :class="{ 'is-loading': isLoading }">
+                      :class="{ 'is-loading': isLoading }">
                 <span class="icon"><i class="fas fa-sync"></i></span>
               </button>
             </p>
@@ -30,12 +30,12 @@
       </div>
 
       <div class="column is-12" v-if="showTaskRunner || false === taskRunner?.status">
-        <TaskRunnerStatus :status="taskRunner" @taskrunner_update="e => taskRunner = e" />
+        <TaskRunnerStatus :status="taskRunner" @taskrunner_update="e => taskRunner = e"/>
       </div>
 
       <div id="queued_tasks" class="column is-12" v-if="queued.length > 0">
         <Message message_class="has-background-success-90 has-text-dark" title="Queued Tasks"
-          icon="fas fa-circle-notch fa-spin">
+                 icon="fas fa-circle-notch fa-spin">
           <p>
             The following tasks
             <template v-for="(task, index) in queued" :key="`queued-${index}`">
@@ -51,7 +51,7 @@
 
       <div class="column is-12" v-if="isLoading">
         <Message message_class="has-background-info-90 has-text-dark" title="Loading" icon="fas fa-spinner fa-spin"
-          message="Loading data. Please wait..." />
+                 message="Loading data. Please wait..."/>
       </div>
 
       <div v-for="task in tasks" :key="task.name" class="column is-6-tablet is-12-mobile">
@@ -62,7 +62,7 @@
             </div>
             <span class="card-header-icon" v-tooltip="'Enable/Disable Task.'" v-if="task.allow_disable">
               <input :id="task.name" type="checkbox" class="switch is-success" :checked="task.enabled"
-                @change="toggleTask(task)">
+                     @change="toggleTask(task)">
               <label :for="task.name"></label>
             </span>
           </header>
@@ -73,28 +73,22 @@
               </div>
               <div class="column is-12 has-text-left">
                 <strong class="is-hidden-mobile">Runs: </strong>
-                <NuxtLink class="has-tooltip" target="_blank"
-                  :to="`https://crontab.guru/#${task.timer.replace(/ /g, '_')}`">
+                <NuxtLink class="is-underlined" target="_blank"
+                          :to="`https://crontab.guru/#${task.timer.replace(/ /g, '_')}`">
                   {{ cronstrue.toString(task.timer) }}
                 </NuxtLink>
               </div>
               <div class="column is-6 has-text-left">
                 <strong class="is-hidden-mobile">Timer:&nbsp;</strong>
-                <span v-if="!task.allow_disabled" class="is-unselectable">
-                  {{ task.timer }}
-                </span>
-                <NuxtLink v-else class="has-tooltip"
-                  :to='makeEnvLink(`WS_CRON_${task.name.toUpperCase()}_AT`, task.timer)'>
+                <NuxtLink class="has-tooltip" :to='makeEnvLink(`WS_CRON_${task.name.toUpperCase()}_AT`, task.timer)'
+                          v-tooltip="'Edit cron timer.'">
                   {{ task.timer }}
                 </NuxtLink>
               </div>
               <div class="column is-6 has-text-right" v-if="task.args">
                 <strong class="is-hidden-mobile">Args:&nbsp;</strong>
-                <span v-if="!task.allow_disabled" class="is-unselectable">
-                  {{ task.args }}
-                </span>
-                <NuxtLink v-else class="has-tooltip"
-                  :to='makeEnvLink(`WS_CRON_${task.name.toUpperCase()}_ARGS`, task.args)'>
+                <NuxtLink class="has-tooltip" :to='makeEnvLink(`WS_CRON_${task.name.toUpperCase()}_ARGS`, task.args)'
+                          v-tooltip="'Edit task arguments.'">
                   {{ task.args }}
                 </NuxtLink>
               </div>
@@ -102,7 +96,7 @@
                 <strong class="is-hidden-mobile">Prev Run:&nbsp;</strong>
                 <template v-if="task.enabled">
                   <span class="has-tooltip"
-                    v-tooltip="`Last run was at: ${moment(task.prev_run).format(TOOLTIP_DATE_FORMAT)}`">
+                        v-tooltip="`Last run was at: ${moment(task.prev_run).format(TOOLTIP_DATE_FORMAT)}`">
                     {{ task.prev_run ? moment(task.prev_run).fromNow() : '???' }}
                   </span>
                 </template>
@@ -114,7 +108,7 @@
                 <strong class="is-hidden-mobile">Next Run:&nbsp;</strong>
                 <template v-if="task.enabled">
                   <span class="has-tooltip"
-                    v-tooltip="`Next run will be at: ${moment(task.next_run).format(TOOLTIP_DATE_FORMAT)}`">
+                        v-tooltip="`Next run will be at: ${moment(task.next_run).format(TOOLTIP_DATE_FORMAT)}`">
                     {{ task.next_run ? moment(task.next_run).fromNow() : 'Never' }}
                   </span>
                 </template>
@@ -127,7 +121,7 @@
           <footer class="card-footer">
             <div class="card-footer-item">
               <button class="button is-info" @click="queueTask(task)"
-                :class="{ 'is-danger': task.queued, 'is-info': !task.queued }">
+                      :class="{ 'is-danger': task.queued, 'is-info': !task.queued }">
                 <span class="icon-text">
                   <span class="icon"><i class="fas fa-clock" :class="{ 'fa-spin': task.queued }"></i></span>
                   <span>
@@ -152,22 +146,17 @@
 
       <div class="column is-12">
         <Message message_class="has-background-info-90 has-text-dark" :toggle="show_page_tips"
-          @toggle="show_page_tips = !show_page_tips" :use-toggle="true" title="Tips" icon="fas fa-info-circle">
+                 @toggle="show_page_tips = !show_page_tips" :use-toggle="true" title="Tips" icon="fas fa-info-circle">
           <ul>
-            <li>For long running tasks like <code>Import</code> and <code>Export</code>, you should queue the task to
-              run
-              in background. As running them via web console will take longer if you have many backends and/or has large
-              libraries.
+            <li>For long running tasks like <strong>Import</strong> and <strong>Export</strong>, you should queue the
+              task to run in background. As running them via web console will take longer if you have many backends
+              and/or has large libraries.
             </li>
             <li>Use the switch next to the task to enable or disable the task from being run automatically.</li>
-            <li>To change when task is scheduled to run, please visit
-              <span class="icon"><i class="fas fa-cogs"></i>&nbsp;</span>
-              <NuxtLink to="/env" v-text="'Environment variables'" />
-              page. The <code>WS_CRON_(TASK)_*</code> variables are used to control scheduled tasks.
-            </li>
-            <li>Clicking on the <code>Runs</code> link will take you to external page that will show for you more
-              information about the cron timer syntax. While clicking on <code>Timer</code> or <code>Args</code>
-              link will take you to edit the related environment variable.
+            <li>Clicking on the <strong>Runs</strong> link will take you to external page that will show for you more
+              information about the cron timer syntax. While clicking on <strong>Timer</strong> or <strong>Args</strong>
+              link will take you to <span><i class="fas fa-cogs"></i></span> <strong>Env</strong> page to edit the
+              related environment variable.
             </li>
           </ul>
         </Message>
@@ -180,19 +169,19 @@
 import 'assets/css/bulma-switch.css'
 import moment from 'moment'
 import request from '~/utils/request'
-import { awaitElement, makeConsoleCommand, notification, parse_api_response, TOOLTIP_DATE_FORMAT } from '~/utils/index'
+import {awaitElement, makeConsoleCommand, notification, parse_api_response, TOOLTIP_DATE_FORMAT} from '~/utils/index'
 import cronstrue from 'cronstrue'
 import Message from '~/components/Message'
-import { useStorage } from '@vueuse/core'
+import {useStorage} from '@vueuse/core'
 import TaskRunnerStatus from '~/components/TaskRunnerStatus'
 
-useHead({ title: 'Tasks' })
+useHead({title: 'Tasks'})
 
 const tasks = ref([])
 const queued = ref([])
 const isLoading = ref(false)
 const show_page_tips = useStorage('show_page_tips', true)
-const taskRunner = ref({ status: true, message: '', restartable: false })
+const taskRunner = ref({status: true, message: '', restartable: false})
 const showTaskRunner = ref(false)
 
 const loadContent = async () => {
@@ -224,7 +213,7 @@ const toggleTask = async task => {
 
     const update = await request(`/system/env/${keyName}`, {
       method: 'POST',
-      body: JSON.stringify({ "value": !task.enabled })
+      body: JSON.stringify({"value": !task.enabled})
     })
 
     if (200 !== update.status) {
@@ -249,7 +238,7 @@ const queueTask = async task => {
   }
 
   try {
-    const response = await request(`/tasks/${task.name}/queue`, { method: is_queued ? 'DELETE' : 'POST' })
+    const response = await request(`/tasks/${task.name}/queue`, {method: is_queued ? 'DELETE' : 'POST'})
     if (response.ok) {
       notification('success', 'Success', `Task '${task.name}' has been ${is_queued ? 'cancelled' : 'queued'}.`)
       task.queued = !is_queued

--- a/src/API/Backend/Update.php
+++ b/src/API/Backend/Update.php
@@ -160,6 +160,13 @@ final class Update
             $userContext->config->set($key, $value);
         }
 
+        # -- sanity check.
+        if (true === (bool)$userContext->config->get("{$name}.import.enabled", false)) {
+            if ($userContext->config->has("{$name}.options." . Options::IMPORT_METADATA_ONLY)) {
+                $userContext->config->delete("{$name}.options." . Options::IMPORT_METADATA_ONLY);
+            }
+        }
+
         $userContext->config->persist();
 
         $backend = $this->getBackends(name: $name, userContext: $userContext);

--- a/src/API/History/Index.php
+++ b/src/API/History/Index.php
@@ -71,7 +71,7 @@ final class Index
 
         $data = DataUtil::fromArray($request->getQueryParams());
 
-        $es = fn (string $val) => $db->escapeIdentifier($val, true);
+        $es = fn(string $val) => $db->escapeIdentifier($val, true);
         $filters = [];
 
         $page = (int)$data->get('page', 1);
@@ -347,9 +347,9 @@ final class Index
             }
 
             if (null === ($matches['field'] ?? null) || false === in_array(
-                $matches['field'],
-                self::COLUMNS_SORTABLE
-            )) {
+                    $matches['field'],
+                    self::COLUMNS_SORTABLE
+                )) {
                 continue;
             }
 
@@ -426,7 +426,7 @@ final class Index
                 [
                     'key' => 'watched',
                     'description' => 'Search using watched status.',
-                    'type' => [ '0', '1'],
+                    'type' => ['0', '1'],
                 ],
                 [
                     'key' => 'via',
@@ -579,7 +579,7 @@ final class Index
                     'ffprobe' => $data,
                     'subtitles' => array_filter(
                         findSideCarFiles(new SplFileInfo($file)),
-                        fn ($sideCar) => isset(Subtitle::FORMATS[getExtension($sideCar)])
+                        fn($sideCar) => isset(Subtitle::FORMATS[getExtension($sideCar)])
                     )
                 ];
             }

--- a/src/API/History/Index.php
+++ b/src/API/History/Index.php
@@ -71,11 +71,12 @@ final class Index
 
         $data = DataUtil::fromArray($request->getQueryParams());
 
-        $es = fn(string $val) => $db->escapeIdentifier($val, true);
+        $es = fn (string $val) => $db->escapeIdentifier($val, true);
         $filters = [];
 
         $page = (int)$data->get('page', 1);
         $perpage = (int)$data->get('perpage', 12);
+        $customView = $data->get('view', null);
 
         $start = (($page <= 2) ? ((1 === $page) ? 0 : $perpage) : $perpage * ($page - 1));
         $start = (!$page) ? 0 : $start;
@@ -109,6 +110,12 @@ final class Index
             }
 
             $filters['rguid'] = $data->get('rguid');
+        }
+
+        if ($data->has(iState::COLUMN_WATCHED)) {
+            $where[] = $es(iState::COLUMN_WATCHED) . ' = :' . iState::COLUMN_WATCHED;
+            $params[iState::COLUMN_WATCHED] = (int)$data->get(iState::COLUMN_WATCHED);
+            $filters[iState::COLUMN_WATCHED] = $data->get(iState::COLUMN_WATCHED);
         }
 
         if ($data->get(iState::COLUMN_ID)) {
@@ -340,9 +347,9 @@ final class Index
             }
 
             if (null === ($matches['field'] ?? null) || false === in_array(
-                    $matches['field'],
-                    self::COLUMNS_SORTABLE
-                )) {
+                $matches['field'],
+                self::COLUMNS_SORTABLE
+            )) {
                 continue;
             }
 
@@ -415,6 +422,11 @@ final class Index
                     'key' => 'id',
                     'description' => 'Search using local history id.',
                     'type' => 'int',
+                ],
+                [
+                    'key' => 'watched',
+                    'description' => 'Search using watched status.',
+                    'type' => [ '0', '1'],
                 ],
                 [
                     'key' => 'via',
@@ -497,8 +509,19 @@ final class Index
             ],
         ];
 
+
         while ($row = $stmt->fetch()) {
-            $response['history'][] = $this->formatEntity($row, userContext: $userContext);
+            $entity = $this->formatEntity($row, userContext: $userContext);
+
+            if (null !== $customView) {
+                $customEntity = [];
+                foreach (explode(',', $customView) as $k) {
+                    $customEntity = ag_set($customEntity, $k, ag($entity, $k, null));
+                }
+                $entity = $customEntity;
+            }
+
+            $response['history'][] = $entity;
         }
 
         return api_response(Status::OK, $response);
@@ -556,7 +579,7 @@ final class Index
                     'ffprobe' => $data,
                     'subtitles' => array_filter(
                         findSideCarFiles(new SplFileInfo($file)),
-                        fn($sideCar) => isset(Subtitle::FORMATS[getExtension($sideCar)])
+                        fn ($sideCar) => isset(Subtitle::FORMATS[getExtension($sideCar)])
                     )
                 ];
             }

--- a/src/Backends/Common/Request.php
+++ b/src/Backends/Common/Request.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backends\Common;
+
+use App\Libs\Enums\Http\Method;
+use App\Libs\Uri;
+use Closure;
+
+final readonly class Request
+{
+    public readonly string $id;
+
+    /**
+     * Wrap client requests into object.
+     *
+     * @param Method $method The HTTP method to use.
+     * @param Uri|string $url The URL to send the request to.
+     * @param array $options The options to pass to the request.
+     * @param callable|null $success The callback to call on successful response.
+     * @param callable|null $error The callback to call on error response.
+     * @param array $extras An array that can contain anything. Should be rarely used.
+     */
+    public function __construct(
+        public Method $method,
+        public Uri|string $url,
+        public array $options = [],
+        public Closure|null $success = null,
+        public Closure|null $error = null,
+        public array $extras = [],
+    ) {
+        $this->id = generateUUID();
+    }
+
+    public function toRequest(): array
+    {
+        return [
+            'method' => $this->method->value,
+            'url' => (string)$this->url,
+            'options' => $this->options,
+        ];
+    }
+
+    public function __debugInfo()
+    {
+        return [
+            'id' => $this->id,
+            'method' => $this->method,
+            'url' => $this->url,
+            'options' => $this->options,
+            'success' => $this->success,
+            'error' => $this->error,
+        ];
+    }
+}

--- a/src/Backends/Common/Request.php
+++ b/src/Backends/Common/Request.php
@@ -10,7 +10,7 @@ use Closure;
 
 final readonly class Request
 {
-    public readonly string $id;
+    public string $id;
 
     /**
      * Wrap client requests into object.
@@ -18,8 +18,8 @@ final readonly class Request
      * @param Method $method The HTTP method to use.
      * @param Uri|string $url The URL to send the request to.
      * @param array $options The options to pass to the request.
-     * @param callable|null $success The callback to call on successful response.
-     * @param callable|null $error The callback to call on error response.
+     * @param Closure|null $success The callback to call on successful response.
+     * @param Closure|null $error The callback to call on error response.
      * @param array $extras An array that can contain anything. Should be rarely used.
      */
     public function __construct(

--- a/src/Backends/Jellyfin/Action/Import.php
+++ b/src/Backends/Jellyfin/Action/Import.php
@@ -10,9 +10,11 @@ use App\Backends\Common\GuidInterface as iGuid;
 use App\Backends\Common\Response;
 use App\Backends\Jellyfin\JellyfinActionTrait;
 use App\Backends\Jellyfin\JellyfinClient as JFC;
+use App\Libs\Config;
 use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Enums\Http\Method;
 use App\Libs\Enums\Http\Status;
+use App\Libs\Extends\RetryableHttpClient;
 use App\Libs\Guid;
 use App\Libs\Mappers\ImportInterface as iImport;
 use App\Libs\Message;
@@ -50,14 +52,21 @@ class Import
      */
     protected string $action = 'jellyfin.import';
 
+    protected RetryableHttpClient $http;
+
     /**
      * Constructor method for the class.
      *
      * @param iHttp $http The HTTP client instance.
      * @param iLogger $logger The logger instance.
      */
-    public function __construct(protected iHttp $http, protected iLogger $logger)
+    public function __construct(iHttp $http, protected iLogger $logger)
     {
+        $this->http = new RetryableHttpClient(
+            $http,
+            maxRetries: (int)Config::get('http.default.maxRetries', 3),
+            logger: $logger
+        );
     }
 
     /**
@@ -80,12 +89,12 @@ class Import
     ): Response {
         return $this->tryResponse(
             context: $context,
-            fn: fn() => $this->getLibraries(
+            fn: fn () => $this->getLibraries(
                 context: $context,
-                handle: fn(array $logContext = []) => fn(iResponse $response) => $this->handle(
+                handle: fn (array $logContext = []) => fn (iResponse $response) => $this->handle(
                     context: $context,
                     response: $response,
-                    callback: fn(array $item, array $logContext = []) => $this->process(
+                    callback: fn (array $item, array $logContext = []) => $this->process(
                         context: $context,
                         guid: $guid,
                         mapper: $mapper,
@@ -95,7 +104,7 @@ class Import
                     ),
                     logContext: $logContext
                 ),
-                error: fn(array $logContext = []) => fn(Throwable $e) => $this->logger->error(
+                error: fn (array $logContext = []) => fn (Throwable $e) => $this->logger->error(
                     message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' library '{library.title}' request. '{error.message}' at '{error.file}:{error.line}'.",
                     context: [
                         'action' => property_exists($this, 'action') ? $this->action : 'import',
@@ -279,7 +288,7 @@ class Import
         }
 
         if (null !== ($ignoreIds = ag($context->options, 'ignore', null))) {
-            $ignoreIds = array_map(fn($v) => trim($v), explode(',', (string)$ignoreIds));
+            $ignoreIds = array_map(fn ($v) => trim($v), explode(',', (string)$ignoreIds));
         }
 
         $limitLibraryId = ag($opts, Options::ONLY_LIBRARY_ID, null);
@@ -430,8 +439,8 @@ class Import
             } catch (iException $e) {
                 $this->logger->error(
                     ...lw(
-                    message: "{action}: Request for '{client}: {user}@{backend}' - '{library.title}' total items has failed. '{error.kind}' '{error.message}' at '{error.file}:{error.line}'.",
-                    context: [
+                        message: "{action}: Request for '{client}: {user}@{backend}' - '{library.title}' total items has failed. '{error.kind}' '{error.message}' at '{error.file}:{error.line}'.",
+                        context: [
                         'error' => [
                             'kind' => $e::class,
                             'line' => $e->getLine(),
@@ -447,8 +456,8 @@ class Import
                         ],
                         ...$logContext,
                     ],
-                    e: $e
-                ),
+                        e: $e
+                    ),
                 );
                 continue;
             } catch (Throwable $e) {
@@ -565,8 +574,8 @@ class Import
             } catch (Throwable $e) {
                 $this->logger->error(
                     ...lw(
-                    message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' '{library.title}' series external ids request. '{error.message}' at '{error.file}:{error.line}'.",
-                    context: [
+                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' '{library.title}' series external ids request. '{error.message}' at '{error.file}:{error.line}'.",
+                        context: [
                         'error' => [
                             'kind' => $e::class,
                             'line' => $e->getLine(),
@@ -582,8 +591,8 @@ class Import
                         ],
                         ...$logContext,
                     ],
-                    e: $e
-                ),
+                        e: $e
+                    ),
                 );
                 continue;
             }

--- a/src/Backends/Plex/Action/Import.php
+++ b/src/Backends/Plex/Action/Import.php
@@ -7,6 +7,7 @@ namespace App\Backends\Plex\Action;
 use App\Backends\Common\CommonTrait;
 use App\Backends\Common\Context;
 use App\Backends\Common\GuidInterface as iGuid;
+use App\Backends\Common\Request;
 use App\Backends\Common\Response;
 use App\Backends\Plex\PlexActionTrait;
 use App\Backends\Plex\PlexClient;
@@ -70,12 +71,12 @@ class Import
     ): Response {
         return $this->tryResponse(
             context: $context,
-            fn: fn () => $this->getLibraries(
+            fn: fn() => $this->getLibraries(
                 context: $context,
-                handle: fn (array $logContext = []) => fn (iResponse $response) => $this->handle(
+                handle: fn(array $logContext = []) => fn(iResponse $response) => $this->handle(
                     context: $context,
                     response: $response,
-                    callback: fn (array $item, array $logContext = []) => $this->process(
+                    callback: fn(array $item, array $logContext = []) => $this->process(
                         context: $context,
                         guid: $guid,
                         mapper: $mapper,
@@ -85,26 +86,15 @@ class Import
                     ),
                     logContext: $logContext
                 ),
-                error: fn (array $logContext = []) => fn (Throwable $e) => $this->logger->error(
+                error: fn(array $logContext = []) => fn(Throwable $e) => $this->logger->error(
                     message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' library '{library.title}' request. '{error.message}' at '{error.file}:{error.line}'.",
                     context: [
                         'action' => $this->action,
                         'backend' => $context->backendName,
                         'client' => $context->clientName,
                         'user' => $context->userContext->name,
-                        'error' => [
-                            'kind' => $e::class,
-                            'line' => $e->getLine(),
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
                         ...$logContext,
-                        'exception' => [
-                            'file' => $e->getFile(),
-                            'line' => $e->getLine(),
-                            'kind' => get_class($e),
-                            'message' => $e->getMessage(),
-                        ],
+                        ...exception_log($e)
                     ]
                 ),
                 opts: $opts,
@@ -195,22 +185,7 @@ class Import
             $this->logger->error(
                 ...lw(
                     message: "{action}: Request for '{client}: {user}@{backend}' libraries has failed. '{error.kind}' with message '{error.message}' at '{error.file}:{error.line}'.",
-                    context: [
-                        ...$rContext,
-                        'error' => [
-                            'line' => $e->getLine(),
-                            'kind' => $e::class,
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
-                        'exception' => [
-                            'file' => $e->getFile(),
-                            'line' => $e->getLine(),
-                            'kind' => $e::class,
-                            'message' => $e->getMessage(),
-                            'trace' => $e->getTrace(),
-                        ],
-                    ],
+                    context: [...$rContext, ...exception_log($e)],
                     e: $e
                 )
             );
@@ -220,21 +195,7 @@ class Import
             $this->logger->error(
                 ...lw(
                     message: "{action}: Request for '{client}: {user}@{backend}' libraries returned with invalid body. '{error.kind}' with message '{error.message}' at '{error.file}:{error.line}'.",
-                    context: [
-                        ...$rContext,
-                        'error' => [
-                            'line' => $e->getLine(),
-                            'kind' => $e::class,
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
-                        'exception' => [
-                            'file' => $e->getFile(),
-                            'line' => $e->getLine(),
-                            'message' => $e->getMessage(),
-                            'trace' => $e->getTrace(),
-                        ],
-                    ],
+                    context: [...$rContext, ...exception_log($e)],
                     e: $e
                 )
             );
@@ -244,22 +205,7 @@ class Import
             $this->logger->error(
                 ...lw(
                     message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request for libraries. {error.message} at '{error.file}:{error.line}'.",
-                    context: [
-                        ...$rContext,
-                        'error' => [
-                            'kind' => $e::class,
-                            'line' => $e->getLine(),
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
-                        'exception' => [
-                            'file' => $e->getFile(),
-                            'line' => $e->getLine(),
-                            'kind' => get_class($e),
-                            'message' => $e->getMessage(),
-                            'trace' => $e->getTrace(),
-                        ],
-                    ],
+                    context: [...$rContext, ...exception_log($e)],
                     e: $e
                 )
             );
@@ -268,7 +214,7 @@ class Import
         }
 
         if (null !== ($ignoreIds = ag($context->options, 'ignore', null))) {
-            $ignoreIds = array_map(fn ($v) => (int)trim($v), explode(',', (string)$ignoreIds));
+            $ignoreIds = array_map(fn($v) => (int)trim($v), explode(',', (string)$ignoreIds));
         }
 
         $limitLibraryId = ag($opts, Options::ONLY_LIBRARY_ID, null);
@@ -382,23 +328,7 @@ class Import
                 $this->logger->error(
                     ...lw(
                         message: "{action}: Request for '{client}: {user}@{backend}' - '{library.title}' items count has failed. '{error.kind}' with message '{error.message}' at '{error.file}:{error.line}'.",
-                        context: [
-                            ...$rContext,
-                            'error' => [
-                                'line' => $e->getLine(),
-                                'kind' => $e::class,
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
-                            'exception' => [
-                                'file' => $e->getFile(),
-                                'line' => $e->getLine(),
-                                'kind' => get_class($e),
-                                'message' => $e->getMessage(),
-                                'trace' => $e->getTrace(),
-                            ],
-                            ...$logContext,
-                        ],
+                        context: [...$rContext, ...exception_log($e), ...$logContext],
                         e: $e
                     )
                 );
@@ -407,23 +337,7 @@ class Import
                 $this->logger->error(
                     ...lw(
                         message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request for libraries. {error.message} at '{error.file}:{error.line}'.",
-                        context: [
-                            ...$rContext,
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
-                            'exception' => [
-                                'file' => $e->getFile(),
-                                'line' => $e->getLine(),
-                                'kind' => get_class($e),
-                                'message' => $e->getMessage(),
-                                'trace' => $e->getTrace(),
-                            ],
-                            ...$logContext,
-                        ],
+                        context: [...$rContext, ...exception_log($e), ...$logContext,],
                         e: $e
                     )
                 );
@@ -471,22 +385,7 @@ class Import
                 $this->logger->error(
                     ...lw(
                         message: "{action}: Request for '{client}: {user}@{backend}' - '{library.title}' total items has failed. '{error.kind}' '{error.message}' at '{error.file}:{error.line}'.",
-                        context: [
-                            ...$logContext,
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
-                            'exception' => [
-                                'file' => $e->getFile(),
-                                'line' => $e->getLine(),
-                                'kind' => get_class($e),
-                                'message' => $e->getMessage(),
-                                'trace' => $e->getTrace(),
-                            ],
-                        ],
+                        context: [...$logContext, ...exception_log($e)],
                         e: $e
                     )
                 );
@@ -495,22 +394,7 @@ class Import
                 $this->logger->error(
                     ...lw(
                         message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request for items count. {error.message} at '{error.file}:{error.line}'.",
-                        context: [
-                            ...$logContext,
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
-                            'exception' => [
-                                'file' => $e->getFile(),
-                                'line' => $e->getLine(),
-                                'kind' => get_class($e),
-                                'message' => $e->getMessage(),
-                                'trace' => $e->getTrace(),
-                            ],
-                        ],
+                        context: [...$logContext, ...exception_log($e)],
                         e: $e
                     )
                 );
@@ -586,64 +470,24 @@ class Import
                         context: $logContext,
                     );
 
-                    $requests[] = $this->http->request(
+                    $requests[] = new Request(
                         method: Method::GET,
-                        url: (string)$url,
+                        url: $url,
                         options: array_replace_recursive($context->backendHeaders, [
                             'headers' => [
                                 'X-Plex-Container-Size' => $segmentSize,
                                 'X-Plex-Container-Start' => $i < 1 ? 0 : ($segmentSize * $i),
-                            ],
-                            'user_data' => [
-                                'ok' => $handle($logContext),
-                                'error' => $error($logContext),
                             ]
-                        ])
+                        ]),
+                        success: $handle($logContext),
+                        error: $error($logContext),
+                        extras: ['logContext' => $logContext, iHttp::class => $this->http]
                     );
-                } catch (ExceptionInterface $e) {
-                    $this->logger->error(
-                        ...lw(
-                            message: "{action}: Request for '{client}: {user}@{backend}' - '{library.title} {segment.number}/{segment.of}' series external ids has failed. '{error.kind}' with message '{error.message}' at '{error.file}:{error.line}'.",
-                            context: [
-                                ...$logContext,
-                                'error' => [
-                                    'line' => $e->getLine(),
-                                    'kind' => $e::class,
-                                    'message' => $e->getMessage(),
-                                    'file' => after($e->getFile(), ROOT_PATH),
-                                ],
-                                'exception' => [
-                                    'file' => $e->getFile(),
-                                    'line' => $e->getLine(),
-                                    'kind' => get_class($e),
-                                    'message' => $e->getMessage(),
-                                    'trace' => $e->getTrace(),
-                                ],
-                            ],
-                            e: $e
-                        )
-                    );
-                    continue;
                 } catch (Throwable $e) {
                     $this->logger->error(
                         ...lw(
                             message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' '{library.title} {segment.number}/{segment.of}' series external ids request. {error.message} at '{error.file}:{error.line}'.",
-                            context: [
-                                ...$logContext,
-                                'error' => [
-                                    'kind' => $e::class,
-                                    'line' => $e->getLine(),
-                                    'message' => $e->getMessage(),
-                                    'file' => after($e->getFile(), ROOT_PATH),
-                                ],
-                                'exception' => [
-                                    'file' => $e->getFile(),
-                                    'line' => $e->getLine(),
-                                    'kind' => get_class($e),
-                                    'message' => $e->getMessage(),
-                                    'trace' => $e->getTrace(),
-                                ],
-                            ],
+                            context: [...$logContext, ...exception_log($e)],
                             e: $e
                         )
                     );
@@ -730,64 +574,24 @@ class Import
                         context: $logContext,
                     );
 
-                    $requests[] = $this->http->request(
+                    $requests[] = new Request(
                         method: Method::GET,
-                        url: (string)$url,
+                        url: $url,
                         options: array_replace_recursive($context->backendHeaders, [
                             'headers' => [
                                 'X-Plex-Container-Size' => $segmentSize,
                                 'X-Plex-Container-Start' => $i < 1 ? 0 : ($segmentSize * $i),
-                            ],
-                            'user_data' => [
-                                'ok' => $handle($logContext),
-                                'error' => $error($logContext),
                             ]
                         ]),
+                        success: $handle($logContext),
+                        error: $error($logContext),
+                        extras: ['logContext' => $logContext, iHttp::class => $this->http]
                     );
-                } catch (ExceptionInterface $e) {
-                    $this->logger->error(
-                        ...lw(
-                            message: "{action}: Request for '{client}: {user}@{backend}' - '{library.title} {segment.number}/{segment.of}' content list has failed. {error.kind}' with message '{error.message}' at '{error.file}:{error.line}'.",
-                            context: [
-                                ...$logContext,
-                                'error' => [
-                                    'line' => $e->getLine(),
-                                    'kind' => $e::class,
-                                    'message' => $e->getMessage(),
-                                    'file' => after($e->getFile(), ROOT_PATH),
-                                ],
-                                'exception' => [
-                                    'file' => $e->getFile(),
-                                    'line' => $e->getLine(),
-                                    'kind' => get_class($e),
-                                    'message' => $e->getMessage(),
-                                    'trace' => $e->getTrace(),
-                                ],
-                            ],
-                            e: $e
-                        )
-                    );
-                    continue;
                 } catch (Throwable $e) {
                     $this->logger->error(
                         ...lw(
                             message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' - '{library.title} {segment.number}/{segment.of}' content list request. {error.message} at '{error.file}:{error.line}'.",
-                            context: [
-                                ...$logContext,
-                                'error' => [
-                                    'kind' => $e::class,
-                                    'line' => $e->getLine(),
-                                    'message' => $e->getMessage(),
-                                    'file' => after($e->getFile(), ROOT_PATH),
-                                ],
-                                'exception' => [
-                                    'file' => $e->getFile(),
-                                    'line' => $e->getLine(),
-                                    'kind' => get_class($e),
-                                    'message' => $e->getMessage(),
-                                    'trace' => $e->getTrace(),
-                                ],
-                            ],
+                            context: [...$logContext, ...exception_log($e)],
                             e: $e
                         )
                     );
@@ -875,23 +679,7 @@ class Import
                     $this->logger->error(
                         ...lw(
                             message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' parsing '{library.title} {segment.number}/{segment.of}' item response. {error.message} at '{error.file}:{error.line}'.",
-                            context: [
-                                ...$logContext,
-                                'error' => [
-                                    'kind' => $e::class,
-                                    'line' => $e->getLine(),
-                                    'message' => $e->getMessage(),
-                                    'file' => after($e->getFile(), ROOT_PATH),
-                                ],
-                                'entity' => $entity,
-                                'exception' => [
-                                    'kind' => $e::class,
-                                    'line' => $e->getLine(),
-                                    'trace' => $e->getTrace(),
-                                    'message' => $e->getMessage(),
-                                    'file' => after($e->getFile(), ROOT_PATH),
-                                ],
-                            ],
+                            context: [...$logContext, ...exception_log($e), 'entity' => $entity],
                             e: $e
                         )
                     );
@@ -901,22 +689,7 @@ class Import
             $this->logger->error(
                 ...lw(
                     message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' parsing of '{library.title} {segment.number}/{segment.of}' response. {error.message} at '{error.file}:{error.line}'.",
-                    context: [
-                        ...$logContext,
-                        'error' => [
-                            'kind' => $e::class,
-                            'line' => $e->getLine(),
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
-                        'exception' => [
-                            'line' => $e->getLine(),
-                            'kind' => get_class($e),
-                            'message' => $e->getMessage(),
-                            'trace' => $e->getTrace(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
-                    ],
+                    context: [...$logContext, ...exception_log($e)],
                     e: $e
                 )
             );
@@ -1055,10 +828,7 @@ class Import
                         default => throw new InvalidArgumentException(
                             r(
                                 text: "{action}: Unexpected content type '{type}' was received from '{client}: {user}@{backend}'.",
-                                context: [
-                                    ...$logContext,
-                                    'type' => $type
-                                ]
+                                context: [...$logContext, 'type' => $type]
                             )
                         ),
                     },
@@ -1170,22 +940,7 @@ class Import
             $this->logger->error(
                 ...lw(
                     message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' - '{library.title}' - '{item.title}' item process. {error.message} at '{error.file}:{error.line}'.",
-                    context: [
-                        ...$logContext,
-                        'error' => [
-                            'kind' => $e::class,
-                            'line' => $e->getLine(),
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
-                        'exception' => [
-                            'file' => $e->getFile(),
-                            'line' => $e->getLine(),
-                            'kind' => get_class($e),
-                            'message' => $e->getMessage(),
-                            'trace' => $e->getTrace(),
-                        ],
-                    ],
+                    context: [...$logContext, ...exception_log($e)],
                     e: $e
                 )
             );

--- a/src/Libs/Utils.php
+++ b/src/Libs/Utils.php
@@ -1361,3 +1361,31 @@ if (!function_exists('getUserContext')) {
     }
 }
 
+
+if (!function_exists('exception_log')) {
+    /**
+     * Add standard way to access exception in log context.
+     *
+     * @param Throwable $e The exception.
+     *
+     * @return array{error: array,excpetion: array} The exception formatted in standard way.
+     */
+    function exception_log(Throwable $e): array
+    {
+        return [
+            'error' => [
+                'kind' => $e::class,
+                'line' => $e->getLine(),
+                'message' => $e->getMessage(),
+                'file' => after($e->getFile(), ROOT_PATH),
+            ],
+            'exception' => [
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+                'kind' => $e::class,
+                'message' => $e->getMessage(),
+                'trace' => $e->getTrace(),
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
- [x] [Added retry logic for emby/jellyfin backend it was missing.](https://github.com/arabcoders/watchstate/pull/656/commits/75073c8597b9d1cb32bdc9b2a67c92c99371dbb2)
- [x] [Added sanity check for import.enabled in PATCH request](https://github.com/arabcoders/watchstate/pull/656/commits/bcbe71a158391eeeacaa0ff41c6a3e95775d253e)
- [x] [Add the ability to filtered on watched status and the ability to customize the history item entity view.](https://github.com/arabcoders/watchstate/pull/656/commits/29dbf2f06f95405e6485fc0ed58fc8b90793660d) 
- [x] [Add the ability to send backends requests in sequential instead of the default parallel mode](https://github.com/arabcoders/watchstate/pull/656/commits/45e9e27b54fafde1fc95f8f783e1ebf441e714f3) 
- [x] [Re-enabled linking from task to env page](https://github.com/arabcoders/watchstate/pull/656/commits/d690436115d7bd96bf3588793be5de365008e6dc)

===

This pull request introduces several new features, enhancements, and fixes across the codebase, focusing on improving request handling, user configuration options, and documentation updates. Key changes include adding support for sequential HTTP requests, introducing a new `Request` class, and improving the `backend:create` command. Additionally, there are updates to documentation and configuration files to reflect these changes.

### New Features and Enhancements

* **Sequential HTTP Requests**:
  - Added support for sending backend requests sequentially using the `WS_HTTP_SYNC_REQUESTS` environment variable. This feature is configurable via CLI flags (`--sync-requests` and `--async-requests`) and is currently applied to `import`, `export`, and `backup` tasks. [[1]](diffhunk://#diff-f55db4bc294bbb90108ccfcbdd11881f4707473ad9384b382e2a6b653e118471R140-R141) [[2]](diffhunk://#diff-34567274073534cc05724332349c103a9dda68553a8dd3704af0d3b69d958079R232-R236)
  - Introduced a `RetryableHttpClient` class to handle retries for HTTP requests, integrated into the Jellyfin backend import logic. [[1]](diffhunk://#diff-a7bf72e66282b81a3685555cf2fa6fbb80ba61953539e8d6e80b603eb58e0709R67-R80) [[2]](diffhunk://#diff-0c68138108cb75a64fdf555ba9774ccbd03da077075e2d7309dce46fa4d3938cR56-R70)

* **New `Request` Class**:
  - Added a `Request` class to encapsulate HTTP requests with metadata, callbacks, and options, improving request handling and extensibility.

### Configuration and API Improvements

* **Sanity Check for Import Configuration**:
  - Added a check to ensure that the `import.enabled` option is consistent with other related settings in the backend configuration.

* **API Enhancements**:
  - Added support for filtering history by watched status (`watched`) and customizing the response view in the `History` API. [[1]](diffhunk://#diff-3c302e7175a796067966e594822d051696668024c5d8744850fb44e8da909d69R79) [[2]](diffhunk://#diff-3c302e7175a796067966e594822d051696668024c5d8744850fb44e8da909d69R115-R120) [[3]](diffhunk://#diff-3c302e7175a796067966e594822d051696668024c5d8744850fb44e8da909d69R512-R524)

### Documentation Updates

* **Feature Documentation**:
  - Updated `README.md` to document the new sequential request feature, including environment variables and CLI flags.
  - Added details about the `backend:create` command rework, including new flags and behavior.

* **Styling and Formatting**:
  - Removed scoped styles from `Markdown.vue` to allow global styling for markdown alerts.

* **Additional Updates**:
  - Updated `NEWS.md` with a summary of recent changes, including experimental features and new webhook support.


