### PR TITLE
Change GUID parsing from error level to info.

### DIFF
--- a/src/Backends/Jellyfin/JellyfinGuid.php
+++ b/src/Backends/Jellyfin/JellyfinGuid.php
@@ -24,6 +24,7 @@ class JellyfinGuid implements iGuid
         'tmdb' => Guid::GUID_TMDB,
         'tvdb' => Guid::GUID_TVDB,
         'tvmaze' => Guid::GUID_TVMAZE,
+        'tv maze' => Guid::GUID_TVMAZE, //-- why emby?
         'tvrage' => Guid::GUID_TVRAGE,
         'anidb' => Guid::GUID_ANIDB,
         'ytinforeader' => Guid::GUID_YOUTUBE,
@@ -267,18 +268,13 @@ class JellyfinGuid implements iGuid
                 $guid[$this->guidMapper[$key]] = $value;
             } catch (Throwable $e) {
                 if (true === $log) {
-                    $this->logger->error(
-                        message: "{class}: Unhandled exception was thrown during '{client}: {user}@{backend}' {title}parsing '{agent}' identifier. '{error.message}' at '{error.file}:{error.line}'.",
+                    $this->logger->info(
+                        message: "{class}: Ignoring '{user}@{backend}' invalid GUID '{agent}' for {item.type} '{item.id}: {item.title}'.",
                         context: [
                             'class' => afterLast(static::class, '\\'),
-                            'backend' => $this->context->backendName,
-                            'client' => $this->context->clientName,
                             'user' => $this->context->userContext->name,
+                            'backend' => $this->context->backendName,
                             'agent' => $value,
-                            'title' => ag_exists($context, 'item.title') ? r(
-                                    "'{item.id}: {item.title}'",
-                                    $context
-                                ) . ' ' : '',
                             ...$context,
                             ...exception_log($e),
                         ]

--- a/src/Backends/Plex/PlexGuid.php
+++ b/src/Backends/Plex/PlexGuid.php
@@ -418,16 +418,13 @@ final class PlexGuid implements iGuid
                 $guid[$this->guidMapper[$key]] = $value;
             } catch (Throwable $e) {
                 if (true === $log) {
-                    $this->logger->error(
-                        message: "PlexGuid: Unhandled exception was thrown during '{client}: {backend}' {title}parsing '{agent}' identifier. '{error.message}' at '{error.file}:{error.line}'.",
+                    $this->logger->info(
+                        message: "{class}: Ignoring '{user}@{backend}' invalid GUID '{agent}' for {item.type} '{item.id}: {item.title}'.",
                         context: [
+                            'class' => afterLast(self::class, '\\'),
+                            'user' => $this->context->userContext->name,
                             'backend' => $this->context->backendName,
-                            'client' => $this->context->clientName,
                             'agent' => $val,
-                            'title' => ag_exists($context, 'item.title') ? r(
-                                    "'{item.id}: {item.title}'",
-                                    $context
-                                ) . ' ' : '',
                             ...$context,
                             ...exception_log($e),
                         ]

--- a/tests/Backends/Jellyfin/JellyfinGuidTest.php
+++ b/tests/Backends/Jellyfin/JellyfinGuidTest.php
@@ -353,6 +353,12 @@ class JellyfinGuidTest extends TestCase
             'none' => '123456',
             'imdb' => ''
         ], $context), 'Assert that the GUID does not exist. for invalid GUIDs.');
+
+        $this->assertEquals(
+            [Guid::GUID_TVMAZE => '123456'],
+            $this->getClass()->parse(['tv maze' => '123456'], $context),
+            'Assert "tv maze" get converted to "tvmaze".'
+        );
     }
 
     public function test_get()


### PR DESCRIPTION
This pull request introduces several changes to improve logging consistency, enhance GUID parsing, and add test coverage for specific cases. The key updates include modifying log levels and messages for invalid GUIDs, adding support for a new GUID format, and expanding test cases to validate these changes.

### Logging improvements:
* Updated log level from `error` to `info` for invalid GUIDs in `JellyfinGuid` and `PlexGuid`, and revised log messages to provide clearer context about ignored GUIDs. (`src/Backends/Jellyfin/JellyfinGuid.php`: [[1]](diffhunk://#diff-23c27c6bcee9fa0289d757c4ad68a7f0639e18bcca5450647f02bd47a904b5c3L270-L281) `src/Backends/Plex/PlexGuid.php`: [[2]](diffhunk://#diff-900be8b464aae7858b33d7a8b48586337b98a659033a254fe6c1d10717837743L421-L430)

### GUID parsing enhancements:
* Added support for parsing "tv maze" as an alias for "tvmaze" in `JellyfinGuid`. (`src/Backends/Jellyfin/JellyfinGuid.php`: [src/Backends/Jellyfin/JellyfinGuid.phpR27](diffhunk://#diff-23c27c6bcee9fa0289d757c4ad68a7f0639e18bcca5450647f02bd47a904b5c3R27))

### Test coverage:
* Added a new test case in `JellyfinGuidTest` to ensure "tv maze" is correctly converted to "tvmaze" during GUID parsing. (`tests/Backends/Jellyfin/JellyfinGuidTest.php`: [tests/Backends/Jellyfin/JellyfinGuidTest.phpR356-R361](diffhunk://#diff-3d09cfa5b93a058ea86e54525bec403c0a51c6d4d25e5af791d4bbf440a76386R356-R361))