### PR TITLE
Fix logged exception when a generic event trigger metadata 404

### DIFF
--- a/guides/webhooks-v2.md
+++ b/guides/webhooks-v2.md
@@ -34,18 +34,8 @@ report them on the [GitHub issue tracker](https://github.com/arabcoders/watchsta
   setting.
 
 Eventually, we will be removing the old webhook system alongside the related settings. The new system is designed to be
-more user friendly and enforces good practices and defaults, as we noticed many users don't really understand the old
+more user-friendly and enforces good practices and defaults, as we noticed many users don't really understand the old
 system and how to set it up correctly.
-
-## Downsides of the new system
-
-The only downside of the new system is that the generic events are triggered to all users that match the backend, and
-due to us caching the metadata call result, it will be added to the all users databases, even if they don't have access
-to the item.
-
-This is something we can improve in the future by switching out of the cache per backend id to per user again, but for
-now, we will be keeping it as is. The boost from caching the metadata call is worth the trade-off of having some items
-in the database that are not accessible to the user. which really shouldn't cause any issues.
 
 ## The generic webhook URL
 

--- a/src/API/Webhook/Index.php
+++ b/src/API/Webhook/Index.php
@@ -137,18 +137,19 @@ final class Index
             return api_error($message, Status::BAD_REQUEST);
         }
 
+        $mainBackend = $backends[0];
         try {
             if (1 === count($backends)) {
                 return $this->create_item(
-                    userContext: $backends[0]['userContext'],
-                    backendName: $backends[0]['backendName'],
-                    client: $backends[0]['client'],
+                    userContext: $mainBackend['userContext'],
+                    backendName: $mainBackend['backendName'],
+                    client: $mainBackend['client'],
                     request: $request,
                     isGeneric: $isGeneric
                 );
             }
 
-            $client = $backends[0]['client'];
+            $client = $mainBackend['client'];
             assert($client instanceof iClient, 'ClientInterface is expected here');
             $entity = $client->parseWebhook($request, [Options::IS_GENERIC => $isGeneric]);
         } catch (Throwable $e) {
@@ -157,8 +158,8 @@ final class Index
                 level: Level::Error,
                 message: "Failed to process webhook for '{user}@{backend}'. {msg}.",
                 context: [
-                    'user' => $backends[0]['userContext']->name,
-                    'backend' => $backends[0]['backendName'],
+                    'user' => $mainBackend['userContext']->name,
+                    'backend' => $mainBackend['backendName'],
                     'msg' => $e->getMessage(),
                     ...exception_log($e),
                 ]
@@ -166,13 +167,13 @@ final class Index
             return api_response(Status::NOT_MODIFIED);
         }
 
-        if (!$entity->hasGuids() && !$entity->hasRelativeGuid()) {
+        if (false === $entity->hasGuids() && false === $entity->hasRelativeGuid()) {
             $this->write(
                 request: $request,
                 level: Level::Info,
                 message: "Ignoring '{user}@{backend}' {item.type} '{item.title}'. No valid/supported external ids.",
                 context: [
-                    'user' => $backends[0]['userContext']->name,
+                    'user' => $mainBackend['userContext']->name,
                     'backend' => $entity->via,
                     'item' => [
                         'title' => $entity->getName(),
@@ -183,13 +184,13 @@ final class Index
             return api_response(Status::NOT_MODIFIED);
         }
 
-        if ((0 === (int)$entity->episode || null === $entity->season) && $entity->isEpisode()) {
+        if ((0 === (int)$entity->episode || null === $entity->season) && true === $entity->isEpisode()) {
             $this->write(
                 request: $request,
                 level: Level::Notice,
                 message: "Ignoring '{user}@{backend}' {item.type} '{item.title}'. No episode/season number present.",
                 context: [
-                    'user' => $backends[0]['userContext']->name,
+                    'user' => $mainBackend['userContext']->name,
                     'backend' => $entity->via,
                     'item' => [
                         'title' => $entity->getName(),
@@ -204,18 +205,32 @@ final class Index
         }
 
         foreach ($backends as $target) {
+            $perUserRequest = $request->withAttribute(
+                'backend',
+                ag_sets(ag($request->getAttributes(), 'backend', []), [
+                    'id' => ag($target['userContext']->config->get($target['backendName']), 'uuid'),
+                    'name' => $target['backendName'],
+                ])
+            )->withAttribute(
+                'user',
+                ag_sets(ag($request->getAttributes(), 'backend', []), [
+                    'id' => ag($target['userContext']->config->get($target['backendName']), 'user'),
+                    'name' => $target['userContext']->name,
+                ])
+            );
+
             try {
                 $this->create_item(
                     userContext: $target['userContext'],
                     backendName: $target['backendName'],
                     client: $target['client'],
-                    request: $request,
+                    request: $perUserRequest,
                     isGeneric: $isGeneric
                 );
             } catch (Throwable $e) {
                 if (false === $isGeneric) {
                     $this->write(
-                        request: $request,
+                        request: $perUserRequest,
                         level: Level::Error,
                         message: "Failed to process '{user}@{backend}' {item.type} '{item.title}'. {msg}.",
                         context: [

--- a/src/Backends/Emby/Action/ParseWebhook.php
+++ b/src/Backends/Emby/Action/ParseWebhook.php
@@ -283,6 +283,10 @@ final class ParseWebhook
 
             return new Response(status: true, response: $entity);
         } catch (Throwable $e) {
+            if (true === ag($opts, Options::IS_GENERIC, false)) {
+                return new Response(status: false, extra: ['http_code' => Status::OK->value]);
+            }
+
             return new Response(
                 status: false,
                 error: new Error(

--- a/src/Backends/Emby/EmbyClient.php
+++ b/src/Backends/Emby/EmbyClient.php
@@ -214,7 +214,8 @@ class EmbyClient implements iClient
         $response = Container::get(ParseWebhook::class)(
             context: $this->context,
             guid: $this->guid,
-            request: $request
+            request: $request,
+            opts: $opts
         );
 
         if ($response->hasError()) {

--- a/src/Backends/Jellyfin/Action/GetMetaData.php
+++ b/src/Backends/Jellyfin/Action/GetMetaData.php
@@ -61,9 +61,6 @@ class GetMetaData
                     $cacheKey = null;
                 } else {
                     $cacheKey = $context->clientName . '_' . $context->backendName . '_' . $id . '_metadata';
-                    if (true === (bool)ag($opts, Options::IS_GENERIC, false)) {
-                        $cacheKey = $context->clientName . "_{$context->backendId}_" . $id . '_metadata';
-                    }
                 }
 
                 $url = $context->backendUrl->withPath(

--- a/src/Backends/Jellyfin/Action/ParseWebhook.php
+++ b/src/Backends/Jellyfin/Action/ParseWebhook.php
@@ -255,6 +255,10 @@ final class ParseWebhook
 
             return new Response(status: true, response: $entity);
         } catch (Throwable $e) {
+            if (true === ag($opts, Options::IS_GENERIC, false)) {
+                return new Response(status: false, extra: ['http_code' => Status::OK->value]);
+            }
+
             return new Response(
                 status: false,
                 error: new Error(

--- a/src/Backends/Jellyfin/Action/ParseWebhook.php
+++ b/src/Backends/Jellyfin/Action/ParseWebhook.php
@@ -144,8 +144,8 @@ final class ParseWebhook
 
         try {
             $obj = $this->getItemDetails(context: $context, id: $id, opts: [
-                Options::LOG_CONTEXT => ['request' => $json],
                 ...$opts,
+                Options::LOG_CONTEXT => ['request' => $json],
             ]);
 
             $isPlayed = (bool)ag($json, 'Played');
@@ -255,7 +255,7 @@ final class ParseWebhook
 
             return new Response(status: true, response: $entity);
         } catch (Throwable $e) {
-            if (true === ag($opts, Options::IS_GENERIC, false)) {
+            if (true === (bool)ag($opts, Options::IS_GENERIC, false)) {
                 return new Response(status: false, extra: ['http_code' => Status::OK->value]);
             }
 

--- a/src/Backends/Jellyfin/JellyfinClient.php
+++ b/src/Backends/Jellyfin/JellyfinClient.php
@@ -246,10 +246,7 @@ class JellyfinClient implements iClient
         }
 
         if (false === $response->isSuccessful()) {
-            throw new HttpException(
-                ag($response->extra, 'message', fn() => $response->error->format()),
-                ag($response->extra, 'http_code', 400),
-            );
+            $this->throwError($response, HttpException::class, ag($response->extra, 'http_code', 400));
         }
 
         return $response->response;

--- a/src/Backends/Jellyfin/JellyfinClient.php
+++ b/src/Backends/Jellyfin/JellyfinClient.php
@@ -238,7 +238,8 @@ class JellyfinClient implements iClient
         $response = Container::get(ParseWebhook::class)(
             context: $this->context,
             guid: $this->guid,
-            request: $request
+            request: $request,
+            opts: $opts
         );
 
         if ($response->hasError()) {

--- a/src/Backends/Plex/Action/GetMetaData.php
+++ b/src/Backends/Plex/Action/GetMetaData.php
@@ -48,9 +48,6 @@ final class GetMetaData
                     $cacheKey = null;
                 } else {
                     $cacheKey = $context->clientName . '_' . $context->backendName . '_' . $id . '_metadata';
-                    if (true === (bool)ag($opts, Options::IS_GENERIC, false)) {
-                        $cacheKey = $context->clientName . "_{$context->backendId}_" . $id . '_metadata';
-                    }
                 }
 
                 $url = $context->backendUrl->withPath('/library/metadata/' . $id)

--- a/src/Backends/Plex/Action/ParseWebhook.php
+++ b/src/Backends/Plex/Action/ParseWebhook.php
@@ -271,6 +271,10 @@ final class ParseWebhook
 
             return new Response(status: true, response: $entity);
         } catch (Throwable $e) {
+            if (true === ag($opts, Options::IS_GENERIC, false)) {
+                return new Response(status: false, extra: ['http_code' => Status::OK->value]);
+            }
+
             return new Response(
                 status: false,
                 error: new Error(

--- a/src/Backends/Plex/PlexClient.php
+++ b/src/Backends/Plex/PlexClient.php
@@ -251,7 +251,8 @@ class PlexClient implements iClient
         $response = Container::get(ParseWebhook::class)(
             context: $this->context,
             guid: $this->guid,
-            request: $request
+            request: $request,
+            opts: $opts
         );
 
         if ($response->hasError()) {

--- a/src/Listeners/ProcessProgressEvent.php
+++ b/src/Listeners/ProcessProgressEvent.php
@@ -145,7 +145,7 @@ final readonly class ProcessProgressEvent
         }
 
         if (empty($list)) {
-            $writer(Level::Error, 'There are no backends to send the events to.');
+            $writer(Level::Warning, 'There are no backends to send the events to.');
             return $e;
         }
 


### PR DESCRIPTION
This pull request introduces several updates to improve the webhook handling system, enhance code readability, and address specific edge cases. The most significant changes include refactoring the webhook processing logic, adding support for generic webhook requests, and improving error handling across various backend integrations.

### Webhook Processing Enhancements:
* Refactored `src/API/Webhook/Index.php` to use a single `$mainBackend` variable for consistent access to the primary backend configuration, improving code readability and maintainability. [[1]](diffhunk://#diff-93a38fbb2639e3bfe64b8528b3241faf5251a2b00ab642970976a8d82aae41a0R140-R152) [[2]](diffhunk://#diff-93a38fbb2639e3bfe64b8528b3241faf5251a2b00ab642970976a8d82aae41a0L159-R176) [[3]](diffhunk://#diff-93a38fbb2639e3bfe64b8528b3241faf5251a2b00ab642970976a8d82aae41a0L185-R193)
* Added support for per-user request attributes to ensure better handling of multiple backends in webhook processing.

### Generic Webhook Support:
* Updated `create_item` in `src/API/Webhook/Index.php` to handle `HttpException` gracefully for generic requests, returning a `NOT_MODIFIED` response instead of throwing errors.
* Added logic to backend-specific webhook parsers (`Emby`, `Jellyfin`, and `Plex`) to return a success response with `OK` status for generic requests, even when an exception occurs. [[1]](diffhunk://#diff-8a182e3e081cd0622eb96569045802ceb4654a8620cc327b06578ae3af4f1867R286-R289) [[2]](diffhunk://#diff-bca74bbcf204a0c0ae029b4710f9bbc2a91b9cf0e67d339793a4918702bb11dcR258-R261) [[3]](diffhunk://#diff-4f96698c331bafd2e7039e1fc5dc5b54236df7405dd4c3e2cf5e8d15fd512a4dR274-R277)

### Backend Integration Improvements:
* Modified backend client methods (`parseWebhook`) to accept additional options (`opts`) for better flexibility in handling webhook requests. [[1]](diffhunk://#diff-903428db1420600efad79ade32e9a73489c6986fb198471014ad57d49a62a3a4L217-R218) [[2]](diffhunk://#diff-149a9e0751ec0af4537b80f42fc953a7385b8d81c36182b68adc56f72edeff94L241-R250) [[3]](diffhunk://#diff-8c939d21f50fa1a32b7b18767c4b0be3bc66360533efb079d386e9893aaa1acaL254-R255)
* Removed redundant caching logic for generic requests in `GetMetaData` actions for `Jellyfin` and `Plex`, simplifying the metadata retrieval process. [[1]](diffhunk://#diff-f1c9bca51513f5eaf2668cadb2c8ba69000c70516658eb060de7d30167ffa26eL64-L66) [[2]](diffhunk://#diff-f660073174f67b16bcecd611898f2d3b638013e69cc9dfd44e4b17935f3d3995L51-L53)

### Documentation Update:
* Updated `guides/webhooks-v2.md` to remove outdated sections about the downsides of the new webhook system and improve clarity by fixing minor grammatical issues.

### Logging Adjustment:
* Changed the log level from `Error` to `Warning` in `ProcessProgressEvent` to better reflect the severity of cases where no backends are available to process events.