### PR TITLE
Document downsides of the new generic webhook system and caching behavior.

### DIFF
--- a/guides/webhooks-v2.md
+++ b/guides/webhooks-v2.md
@@ -37,6 +37,16 @@ Eventually, we will be removing the old webhook system alongside the related set
 more user-friendly and enforces good practices and defaults, as we noticed many users don't really understand the old
 system and how to set it up correctly.
 
+## Downsides of the new system
+
+The only downside of the new system is that the generic events are triggered to all users that match the backend, and
+due to us caching the metadata call result, it will be added to the all users databases, even if they don't have access
+to the item.
+
+This is something we can improve in the future by switching out of the cache per backend id to per user again, but for
+now, we will be keeping it as is. The boost from caching the metadata call is worth the trade-off of having some items
+in the database that are not accessible to the user. which really shouldn't cause any issues.
+
 ## The generic webhook URL
 
 The new webhook generic URL is `/v1/api/webhook`, of course, if you have enabled secure all endpoints you need to


### PR DESCRIPTION
## Documentation updates:

* Added a new section, "Downsides of the new system," to explain that generic events are triggered for all users matching the backend, which can result in metadata being cached and added to databases of users without access to the item. The section also notes that this trade-off is currently acceptable due to performance benefits but may be improved in the future.