### PR TITLE
Improving Webhook-v2 generic events handling

### DIFF
--- a/frontend/components/EventView.vue
+++ b/frontend/components/EventView.vue
@@ -43,6 +43,12 @@
               </button>
             </p>
             <p class="control">
+              <button class="button" @click="() => copyText(JSON.stringify(item,null,2))" :disabled="isLoading"
+                      v-tooltip.bottom="'Copy event.'">
+                <span class="icon"><i class="fas fa-copy"/></span>
+              </button>
+            </p>
+            <p class="control">
               <button class="button is-info" @click="loadContent()" :class="{ 'is-loading': isLoading }"
                       :disabled="isLoading" v-tooltip.bottom="'Reload event data.'">
                 <span class="icon"><i class="fas fa-sync"/></span>
@@ -65,7 +71,7 @@
       <div class="column is-12">
         <div class="notification">
           <p class="title is-5">
-            Event <span class="tag is-info">{{ item.event }}</span>
+            Event <span class="tag is-info is-clickable" @click="copyText(item.id)">{{ item.event }}</span>
             <template v-if="item.reference">
               with reference <span class="tag is-info is-light">{{ item.reference }}</span>
             </template>

--- a/frontend/pages/events.vue
+++ b/frontend/pages/events.vue
@@ -140,7 +140,7 @@
           <ul>
             <li>Resetting event will return it to the queue to be dispatched again.</li>
             <li>Stopping event will prevent it from being dispatched.</li>
-            <li>Events with status of <span class="tag is-warning">Running</span> Cannot be cancelled or stopped.</li>
+            <li>Events with status of <span class="tag is-warning">Running</span> cannot be cancelled or stopped.</li>
             <li>The filter <i class="fa fa-filter"/> button on top can be used for both filtering the displayed
               results, and on submit it will search the backend for the given event name.
             </li>

--- a/guides/webhooks-v2.md
+++ b/guides/webhooks-v2.md
@@ -37,16 +37,6 @@ Eventually, we will be removing the old webhook system alongside the related set
 more user-friendly and enforces good practices and defaults, as we noticed many users don't really understand the old
 system and how to set it up correctly.
 
-## Downsides of the new system
-
-The only downside of the new system is that the generic events are triggered to all users that match the backend, and
-due to us caching the metadata call result, it will be added to the all users databases, even if they don't have access
-to the item.
-
-This is something we can improve in the future by switching out of the cache per backend id to per user again, but for
-now, we will be keeping it as is. The boost from caching the metadata call is worth the trade-off of having some items
-in the database that are not accessible to the user. which really shouldn't cause any issues.
-
 ## The generic webhook URL
 
 The new webhook generic URL is `/v1/api/webhook`, of course, if you have enabled secure all endpoints you need to

--- a/src/API/Webhook/Index.php
+++ b/src/API/Webhook/Index.php
@@ -228,23 +228,22 @@ final class Index
                     isGeneric: $isGeneric
                 );
             } catch (Throwable $e) {
-                if (false === $isGeneric) {
-                    $this->write(
-                        request: $perUserRequest,
-                        level: Level::Error,
-                        message: "Failed to process '{user}@{backend}' {item.type} '{item.title}'. {msg}.",
-                        context: [
-                            'user' => $target['userContext']->name,
-                            'backend' => $target['backendName'],
-                            'item' => [
-                                'title' => $entity->getName(),
-                                'type' => $entity->type,
-                            ],
-                            'msg' => $e->getMessage(),
-                            ...exception_log($e),
-                        ]
-                    );
-                }
+                $this->write(
+                    request: $perUserRequest,
+                    level: Level::Error,
+                    message: "Failed to process '{user}@{backend}' {item.type} '{item.title}'. '{error.message}' at '{error.file}:{error.line}'. {trace}",
+                    context: [
+                        'user' => $target['userContext']->name,
+                        'backend' => $target['backendName'],
+                        'trace' => json_encode($e->getTrace(), flags: JSON_UNESCAPED_SLASHES),
+                        'item' => [
+                            'title' => $entity->getName(),
+                            'type' => $entity->type,
+                        ],
+                        'msg' => $e->getMessage(),
+                        ...exception_log($e),
+                    ]
+                );
             }
         }
 
@@ -438,7 +437,7 @@ final class Index
             $context['attributes'] = $attributes;
         }
 
-        $message = "[GWH] {$message}";
+        $message = "[G] {$message}";
 
         if (true === (Config::get('logs.context') || $forceContext)) {
             $this->logfile->log($level, $message, $context);

--- a/src/Backends/Emby/EmbyClient.php
+++ b/src/Backends/Emby/EmbyClient.php
@@ -393,6 +393,7 @@ class EmbyClient implements iClient
     public function getMetadata(string|int $id, array $opts = []): array
     {
         $response = Container::get(GetMetaData::class)(context: $this->context, id: $id, opts: $opts);
+
         if (false === $response->isSuccessful()) {
             $this->throwError($response);
         }
@@ -726,9 +727,13 @@ class EmbyClient implements iClient
     private function throwError(Response $response, string $className = RuntimeException::class, int $code = 0): void
     {
         throw new $className(
-            message: ag($response->extra, 'message', fn() => $response->error->format()),
+            message: ag(
+                $response->extra,
+                'message',
+                fn() => $response->error?->format() ?? 'An unexpected error occurred.'
+            ),
             code: $code,
-            previous: $response->error->previous
+            previous: $response->error?->previous
         );
     }
 }

--- a/src/Backends/Jellyfin/Action/GetMetaData.php
+++ b/src/Backends/Jellyfin/Action/GetMetaData.php
@@ -57,10 +57,14 @@ class GetMetaData
         return $this->tryResponse(
             context: $context,
             fn: function () use ($context, $id, $opts) {
-                if (true === (bool)ag($opts, Options::NO_CACHE, false)) {
-                    $cacheKey = null;
-                } else {
-                    $cacheKey = $context->clientName . '_' . $context->backendName . '_' . $id . '_metadata';
+                $cacheKey = null;
+                $isGeneric = true === (bool)ag($opts, Options::IS_GENERIC, false);
+                if (true !== (bool)ag($opts, Options::NO_CACHE, false)) {
+                    $cacheKey = r("{client}_{split}_{id}_metadata", [
+                        'id' => $id,
+                        'client' => $context->clientName,
+                        'split' => true === $isGeneric ? $context->backendId : $context->backendName,
+                    ]);
                 }
 
                 $url = $context->backendUrl->withPath(

--- a/src/Backends/Jellyfin/Action/ParseWebhook.php
+++ b/src/Backends/Jellyfin/Action/ParseWebhook.php
@@ -228,21 +228,15 @@ final class ParseWebhook
                 ); // -- Convert to milliseconds.
             }
 
-            $ots = [
-                'override' => $fields
-            ];
+            $entityOpts = ['override' => $fields];
 
             if (true === (bool)ag($opts, Options::IS_GENERIC, false)) {
-                $ots[Options::IS_GENERIC] = true;
-                $ots[iCache::class] = $this->cache;
+                $entityOpts[Options::IS_GENERIC] = true;
+                $entityOpts[iCache::class] = $this->cache;
             }
 
-            $entity = $this->createEntity(
-                context: $context,
-                guid: $guid,
-                item: $obj,
-                opts: $ots,
-            )->setIsTainted(isTainted: true === in_array($event, self::WEBHOOK_TAINTED_EVENTS));
+            $entity = $this->createEntity(context: $context, guid: $guid, item: $obj, opts: $entityOpts)
+                ->setIsTainted(isTainted: true === in_array($event, self::WEBHOOK_TAINTED_EVENTS));
 
             if (false === $entity->hasGuids() && false === $entity->hasRelativeGuid()) {
                 return new Response(

--- a/src/Backends/Jellyfin/JellyfinClient.php
+++ b/src/Backends/Jellyfin/JellyfinClient.php
@@ -441,6 +441,7 @@ class JellyfinClient implements iClient
     public function getMetadata(string|int $id, array $opts = []): array
     {
         $response = Container::get(GetMetaData::class)(context: $this->context, id: $id, opts: $opts);
+
         if (false === $response->isSuccessful()) {
             $this->throwError($response);
         }
@@ -776,9 +777,13 @@ class JellyfinClient implements iClient
     private function throwError(Response $response, string $className = RuntimeException::class, int $code = 0): void
     {
         throw new $className(
-            message: ag($response->extra, 'message', fn() => $response->error->format()),
+            message: ag(
+                $response->extra,
+                'message',
+                fn() => $response->error?->format() ?? 'An unexpected error occurred.'
+            ),
             code: $code,
-            previous: $response->error->previous
+            previous: $response->error?->previous
         );
     }
 }

--- a/src/Backends/Plex/Action/GetMetaData.php
+++ b/src/Backends/Plex/Action/GetMetaData.php
@@ -44,12 +44,16 @@ final class GetMetaData
         return $this->tryResponse(
             context: $context,
             fn: function () use ($context, $id, $opts) {
-                if (true === (bool)ag($opts, Options::NO_CACHE, false)) {
-                    $cacheKey = null;
-                } else {
-                    $cacheKey = $context->clientName . '_' . $context->backendName . '_' . $id . '_metadata';
+                $cacheKey = null;
+                $isGeneric = true === (bool)ag($opts, Options::IS_GENERIC, false);
+                if (false === (bool)ag($opts, Options::NO_CACHE, false)) {
+                    $cacheKey = r("{client}_{split}_{id}_metadata", [
+                        'id' => $id,
+                        'client' => $context->clientName,
+                        'split' => true === $isGeneric ? $context->backendId : $context->backendName,
+                    ]);
                 }
-
+                
                 $url = $context->backendUrl->withPath('/library/metadata/' . $id)
                     ->withQuery(http_build_query(array_merge_recursive(['includeGuids' => 1], $opts['query'] ?? [])));
 

--- a/src/Backends/Plex/PlexClient.php
+++ b/src/Backends/Plex/PlexClient.php
@@ -979,9 +979,13 @@ class PlexClient implements iClient
     private function throwError(Response $response, string $className = RuntimeException::class, int $code = 0): void
     {
         throw new $className(
-            message: ag($response->extra, 'message', fn() => $response->error->format()),
+            message: ag(
+                $response->extra,
+                'message',
+                fn() => $response->error?->format() ?? 'An unexpected error occurred.'
+            ),
             code: $code,
-            previous: $response->error->previous
+            previous: $response->error?->previous
         );
     }
 }

--- a/src/Libs/Extends/LoggerProxy.php
+++ b/src/Libs/Extends/LoggerProxy.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Libs\Extends;
+
+use Closure;
+use Monolog\Level;
+use Psr\Log\LoggerInterface;
+use Stringable;
+
+/**
+ * LoggerProxy is PSR logger implementation that passes log messages to a callback function.
+ */
+final readonly class LoggerProxy implements LoggerInterface
+{
+    public function __construct(private Closure $callback)
+    {
+    }
+
+    /**
+     * Create a new LoggerProxy instance.
+     *
+     * @param Closure{mixed,string,array} $callback The callback to handle log messages.
+     * @return self
+     */
+    public static function create(Closure $callback): self
+    {
+        return new self($callback);
+    }
+
+    public function log($level, Stringable|string $message, array $context = []): void
+    {
+        if (false === ($level instanceof Level)) {
+            $level = Level::tryFrom($level) ?? Level::Notice;
+        }
+        ($this->callback)($level, $message, $context);
+    }
+
+    public function emergency(Stringable|string $message, array $context = []): void
+    {
+        $this->log(Level::Emergency, $message, $context);
+    }
+
+    public function alert(Stringable|string $message, array $context = []): void
+    {
+        $this->log(Level::Alert, $message, $context);
+    }
+
+    public function critical(Stringable|string $message, array $context = []): void
+    {
+        $this->log(Level::Critical, $message, $context);
+    }
+
+    public function error(Stringable|string $message, array $context = []): void
+    {
+        $this->log(Level::Error, $message, $context);
+    }
+
+    public function warning(Stringable|string $message, array $context = []): void
+    {
+        $this->log(Level::Warning, $message, $context);
+    }
+
+    public function notice(Stringable|string $message, array $context = []): void
+    {
+        $this->log(Level::Notice, $message, $context);
+    }
+
+    public function info(Stringable|string $message, array $context = []): void
+    {
+        $this->log(Level::Info, $message, $context);
+    }
+
+    public function debug(Stringable|string $message, array $context = []): void
+    {
+        $this->log(Level::Debug, $message, $context);
+    }
+
+}

--- a/src/Listeners/ProcessRequestEvent.php
+++ b/src/Listeners/ProcessRequestEvent.php
@@ -9,14 +9,17 @@ use App\Libs\Container;
 use App\Libs\Entity\StateInterface as iState;
 use App\libs\Events\DataEvent;
 use App\Libs\Exceptions\RuntimeException;
+use App\Libs\Extends\LoggerProxy;
 use App\Libs\Extends\ProxyHandler;
 use App\Libs\Mappers\Import\DirectMapper;
 use App\Libs\Mappers\ImportInterface as iImport;
 use App\Libs\Options;
+use App\Libs\UserContext;
 use App\Model\Events\EventListener;
 use Monolog\Level;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface as iLogger;
+use Throwable;
 
 #[EventListener(self::NAME)]
 final readonly class ProcessRequestEvent
@@ -47,6 +50,7 @@ final readonly class ProcessRequestEvent
         $e->stopPropagation();
 
         $user = ag($e->getOptions(), Options::CONTEXT_USER, 'main');
+        $isGeneric = true === (bool)ag($e->getOptions(), Options::IS_GENERIC, false);
 
         try {
             $userContext = getUserContext(user: $user, mapper: $this->mapper, logger: $this->logger);
@@ -57,6 +61,21 @@ final readonly class ProcessRequestEvent
 
         $entity = Container::get(iState::class)::fromArray($e->getData())
             ->setIsTainted((bool)ag($e->getOptions(), 'tainted', false));
+
+        if (true === $isGeneric) {
+            try {
+                // -- revalidate the metadata based on user context.
+                $backend = makeBackend(backend: $userContext->config->get($entity->via), name: $entity->via, options: [
+                    iLogger::class => LoggerProxy::create($writer),
+                    UserContext::class => $userContext,
+                ]);
+
+                $backend->getMetadata(ag($entity->getMetadata($entity->via), iState::COLUMN_ID));
+            } catch (Throwable $ex) {
+                $writer(Level::Info, $ex->getMessage());
+                return $e;
+            }
+        }
 
         if (null !== ($lastSync = ag($userContext->get($entity->via, []), 'import.lastSync'))) {
             $lastSync = makeDate($lastSync);


### PR DESCRIPTION
This PR solve the downside of the new Webhook-v2 generic event handling, which was generating phantom records for users who doesn't have access to the items. 

=======

This pull request introduces multiple enhancements and fixes across the frontend, backend, and documentation. Key changes include adding new UI features for event handling, improving error handling in backend services, and optimizing caching mechanisms for webhook processing. Additionally, minor corrections were made to documentation and frontend text.

### Frontend Enhancements:
* Added a "Copy event" button in `EventView.vue` to allow users to copy event details as JSON.
* Made the event tag in `EventView.vue` clickable to copy the event ID.

### Backend Improvements:
* Enhanced error handling in `EmbyClient` and `JellyfinClient` by providing more descriptive error messages and utilizing null-safe operators. [[1]](diffhunk://#diff-903428db1420600efad79ade32e9a73489c6986fb198471014ad57d49a62a3a4L729-R736) [[2]](diffhunk://#diff-149a9e0751ec0af4537b80f42fc953a7385b8d81c36182b68adc56f72edeff94L779-R786)
* Introduced caching improvements for generic webhooks in `Jellyfin` and `Plex` backends, including support for global cache keys and optional cache skipping. [[1]](diffhunk://#diff-9c70a4076abedee4e97ee018171d3af95634cda0bc7de99ea4523538add1eb10R242-R268) [[2]](diffhunk://#diff-b8e321159c3b4c88d04c7bf683f4536d0fc5bfe8ed358839a7620bb09cfcded4L171-R173)

### Webhook Processing Updates:
* Added `iCache` dependency to `ParseWebhook` classes in `Jellyfin` and `Plex` backends for better cache management during webhook parsing. [[1]](diffhunk://#diff-bca74bbcf204a0c0ae029b4710f9bbc2a91b9cf0e67d339793a4918702bb11dcR71-R74) [[2]](diffhunk://#diff-4f96698c331bafd2e7039e1fc5dc5b54236df7405dd4c3e2cf5e8d15fd512a4dR72-R75)
* Adjusted metadata caching logic to differentiate between generic and non-generic webhook events. [[1]](diffhunk://#diff-f1c9bca51513f5eaf2668cadb2c8ba69000c70516658eb060de7d30167ffa26eL60-R67) [[2]](diffhunk://#diff-f660073174f67b16bcecd611898f2d3b638013e69cc9dfd44e4b17935f3d3995L47-R54)

### Documentation and Text Fixes:
* Removed outdated information about the downsides of the new webhook system in `webhooks-v2.md`.
* Fixed a minor grammatical error in `events.vue` by correcting the capitalization of "cannot."