### PR TITLE
forgot to remove beta tag from guide.

### DIFF
--- a/guides/webhooks.md
+++ b/guides/webhooks.md
@@ -1,4 +1,4 @@
-# Webhooks v2 _BETA_
+# Webhooks
 
 ## Getting started
 


### PR DESCRIPTION
This pull request includes a minor update to the `guides/webhooks.md` file, removing the "_BETA_" label from the Webhooks v2 heading to reflect its stable release status.