### PR TITLE
fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ box, this tool support `Jellyfin`, `Plex` and `Emby` media servers.
 
 ### 2025-05-30
 
-The new [webhooks](/guides/webhooks.md) system is now available, please start mirating your systems to use it as, we
+The new [webhooks](/guides/webhooks.md) system is now available, please start migrating your systems to use it as, we
 have deprecated the old webhook system, and it will be removed in the next release. The new system is more robust and
 user-friendly compared to the old one.
 


### PR DESCRIPTION
This pull request includes a minor correction to the `README.md` file. The change fixes a typo, replacing "mirating" with "migrating" in the description of the new webhook system.