### PR TITLE
Minor bug fixes

### DIFF
--- a/src/Backends/Jellyfin/Action/Export.php
+++ b/src/Backends/Jellyfin/Action/Export.php
@@ -211,10 +211,10 @@ class Export extends Import
                 'id' => ag($item, 'Id')
             ]));
 
+            $lastPlayed = makeDate($entity->updated)->format(Date::ATOM);
+
             if ($context->clientName === JellyfinClient::CLIENT_NAME) {
-                $url = $url->withQuery(http_build_query([
-                    'DatePlayed' => makeDate($entity->updated)->format(Date::ATOM)
-                ]));
+                $url = $url->withQuery(http_build_query(['DatePlayed' => $lastPlayed]));
             }
 
             $logContext['item']['url'] = $url;
@@ -246,6 +246,31 @@ class Export extends Import
                     ]
                 )
             );
+
+            /**
+             * A workaround for some API limitations,
+             * Jellyfin: sometimes doesn't reset the `PlaybackPositionTicks`.
+             * Emby: Doesn't support sending `LastPlayedDate` in the initial request.
+             */
+            if (true === $entity->isWatched()) {
+                $queue->add(
+                    $this->http->request(
+                        method: Method::POST,
+                        url: (string)$context->backendUrl->withPath(r('/Users/{user}/Items/{id}/UserData', [
+                            'user' => $context->backendUser,
+                            'id' => ag($item, 'Id')
+                        ])),
+                        options: $context->backendHeaders + [
+                            'json' => [
+                                'Played' => true,
+                                'PlaybackPositionTicks' => 0,
+                                'LastPlayedDate' => $lastPlayed,
+                            ],
+                            'user_data' => [Options::NO_LOGGING => true]
+                        ]
+                    )
+                );
+            }
         } catch (Throwable $e) {
             $this->logger->error(
                 ...lw(

--- a/src/Commands/Backend/RestoreCommand.php
+++ b/src/Commands/Backend/RestoreCommand.php
@@ -332,6 +332,14 @@ class RestoreCommand extends Command
         }
 
         foreach ($this->queue->getQueue() as $response) {
+            if (true === (bool)ag($response->getInfo('user_data'), Options::NO_LOGGING, false)) {
+                try {
+                    $response->getStatusCode();
+                } catch (Throwable) {
+                }
+                continue;
+            }
+
             $context = ag($response->getInfo('user_data'), 'context', []);
             $context['backend'] = $name;
             $context['user'] = $userContext->name;

--- a/src/Libs/Path.php
+++ b/src/Libs/Path.php
@@ -1,0 +1,498 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Libs;
+
+use RuntimeException;
+
+/**
+ * Class Path
+ * A utility class for handling and manipulating filesystem paths.
+ * @property-read Path $parent The parent directory of the path.
+ * @property-read Path $absolute The absolute path.
+ */
+final readonly class Path
+{
+    public string $path;
+    public string $name;
+    public string $stem;
+    public string $suffix;
+
+    /**
+     * Constructor.
+     *
+     * @param Path|string $path The initial path.
+     */
+    public function __construct(Path|string $path)
+    {
+        $this->path = (string)$path;
+        $this->name = basename($this->path);
+        $this->stem = pathinfo($this->path, PATHINFO_FILENAME);
+        $this->suffix = pathinfo($this->path, PATHINFO_EXTENSION);
+    }
+
+    /**
+     * Factory method to create a new Path instance.
+     *
+     * @param Path|string $path The path to create the instance for.
+     * @return self A new Path object.
+     */
+    public static function make(Path|string $path): self
+    {
+        return new self($path);
+    }
+
+    /**
+     * Converts the Path object to a string.
+     *
+     * @return string The string representation of the path.
+     */
+    public function __toString(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * Joins the current path with additional paths.
+     *
+     * @param Path|string ...$paths Paths to join.
+     * @return self A new Path object with the joined path.
+     */
+    public function joinPath(Path|string ...$paths): self
+    {
+        $segments = array_map(fn($p) => (string)$p, array_merge([$this->path], $paths));
+        return new self(join(DIRECTORY_SEPARATOR, $segments));
+    }
+
+    /**
+     * Checks if the path exists.
+     *
+     * @return bool True if the path exists, false otherwise.
+     */
+    public function exists(): bool
+    {
+        return file_exists($this->path);
+    }
+
+    /**
+     * Checks if the path is a directory.
+     *
+     * @return bool True if the path is a directory, false otherwise.
+     */
+    public function isDir(): bool
+    {
+        return is_dir($this->path);
+    }
+
+    /**
+     * Checks if the path is a file.
+     *
+     * @return bool True if the path is a file, false otherwise.
+     */
+    public function isFile(): bool
+    {
+        return is_file($this->path);
+    }
+
+    /**
+     * Creates a directory at the path.
+     *
+     * @param int $mode The permissions mode (default: 0777).
+     * @param bool $recursive Whether to create directories recursively.
+     * @param bool $exist_ok Whether to ignore if the directory already exists.
+     * @throws RuntimeException If the directory already exists and $exist_ok is false.
+     */
+    public function mkdir(int $mode = 0777, bool $recursive = false, bool $exist_ok = false): void
+    {
+        if (!$exist_ok && $this->exists()) {
+            throw new RuntimeException("Directory already exists: {$this->path}");
+        }
+        @mkdir($this->path, $mode, $recursive);
+    }
+
+    /**
+     * Deletes the file at the path.
+     *
+     * @throws RuntimeException If the path is not a file.
+     */
+    public function unlink(): void
+    {
+        if ($this->isFile()) {
+            unlink($this->path);
+            return;
+        }
+
+        throw new RuntimeException("Not a file: {$this->path}");
+    }
+
+    /**
+     * Deletes the directory at the path.
+     *
+     * @throws RuntimeException If the path is not a directory.
+     */
+    public function rmdir(): void
+    {
+        if ($this->isDir()) {
+            rmdir($this->path);
+            return;
+        }
+        throw new RuntimeException("Not a directory: {$this->path}");
+    }
+
+    /**
+     * Reads the contents of the file as a string.
+     *
+     * @return string The file contents.
+     * @throws RuntimeException If the path is not a file.
+     */
+    public function read(): string
+    {
+        if (!$this->isFile()) {
+            throw new RuntimeException("Not a file: {$this->path}");
+        }
+        return file_get_contents($this->path);
+    }
+
+    /**
+     * Writes a string to the file.
+     *
+     * @param string $data The data to write.
+     */
+    public function write(string $data): void
+    {
+        file_put_contents($this->path, $data);
+    }
+
+    /**
+     * Returns the absolute path.
+     *
+     * @return self A new Path object with the absolute path.
+     */
+    public function absolute(): self
+    {
+        return new self($this->normalize($this->path));
+    }
+
+    /**
+     * Normalizes the path to its absolute, canonical form.
+     *
+     * @param string|Path $path The path to normalize.
+     * @param string $separator The directory separator (default: DIRECTORY_SEPARATOR).
+     *
+     * @return Path A new Path object with the normalized path.
+     */
+    public function normalize(string|Path $path, string $separator = DIRECTORY_SEPARATOR): Path
+    {
+        $path = (string)$path;
+        $isAbsolute = str_starts_with($path, $separator);
+
+        //-- if exists, simply use PHP's realpath, it doesn't work for non-existing paths.
+        if (false !== ($rp = realpath($path))) {
+            return new self($rp);
+        }
+
+        //-- Replace all / and \ with the system separator
+        $path = str_replace(['/', '\\'], $separator, $path);
+
+        //-- Windows: preserve drive letter or UNC prefix
+        $prefix = '';
+        if (str_starts_with(PHP_OS, 'WIN')) {
+            if (1 === preg_match('/^[a-zA-Z]:\\/', $path, $m)) {
+                $prefix = $m[0];
+                $path = substr($path, strlen($prefix));
+            } elseif (1 === preg_match('/^\\\\[^\\]+\\[^\\]+/', $path, $m)) {
+                $prefix = $m[0];
+                $path = substr($path, strlen($prefix));
+            }
+        }
+
+        $parts = array_filter(explode($separator, $path), fn($p) => $p !== '' && $p !== '.');
+        $stack = [];
+        foreach ($parts as $part) {
+            if ('..' === $part) {
+                array_pop($stack);
+            } else {
+                $stack[] = $part;
+            }
+        }
+
+        $normalized = $prefix . implode($separator, $stack);
+
+        if ($isAbsolute && false === str_starts_with($normalized, $separator)) {
+            $normalized = $separator . ltrim($normalized, $separator);
+        }
+        return new self('' === $normalized ? ($prefix ?: $separator) : $normalized);
+    }
+
+    /**
+     * Gets the name of the file or directory.
+     *
+     * @return string The name of the file or directory.
+     */
+    public function name(): string
+    {
+        return basename($this->path);
+    }
+
+    /**
+     * Gets the file extension (suffix).
+     *
+     * @return string The file extension.
+     */
+    public function suffix(): string
+    {
+        return pathinfo($this->path, PATHINFO_EXTENSION);
+    }
+
+    /**
+     * Gets the file name without the extension (stem).
+     *
+     * @return string The file name without the extension.
+     */
+    public function stem(): string
+    {
+        return pathinfo($this->path, PATHINFO_FILENAME);
+    }
+
+    /**
+     * Gets the parent directory of the path.
+     *
+     * @return self A new Path object for the parent directory.
+     */
+    public function parent(): self
+    {
+        return new self(dirname($this->path));
+    }
+
+    /**
+     * Creates a new path with a different name in the same directory.
+     *
+     * @param string $name The new name.
+     * @return self A new Path object with the updated name.
+     */
+    public function withName(string $name): self
+    {
+        return $this->parent()->joinPath($name);
+    }
+
+    /**
+     * Creates a new path with a different file extension.
+     *
+     * @param string $suffix The new file extension.
+     * @return self A new Path object with the updated extension.
+     */
+    public function withSuffix(string $suffix): self
+    {
+        return new self(preg_replace('/\.[^.]+$/', '', $this->path) . $suffix);
+    }
+
+    /**
+     * Finds path names matching a pattern.
+     *
+     * @param string $pattern The glob pattern.
+     * @return array An array of matching path names.
+     */
+    public function glob(string $pattern): array
+    {
+        return glob($this->joinPath($pattern)->path);
+    }
+
+    /**
+     * Iterates over the contents of a directory.
+     *
+     * @return array An array of Path objects for the directory contents.
+     * @throws RuntimeException If the path is not a directory.
+     */
+    public function iterDir(): array
+    {
+        if (!$this->isDir()) {
+            throw new RuntimeException("Not a directory: {$this->path}");
+        }
+
+        $items = scandir($this->path);
+        return array_map(fn($item) => new self($this->joinPath($item)->path), array_diff($items, ['.', '..']));
+    }
+
+    /**
+     * Changes the permissions of the path.
+     *
+     * @param int $mode The new permission mode.
+     * @throws RuntimeException If the operation fails.
+     */
+    public function chmod(int $mode): void
+    {
+        if (!@chmod($this->path, $mode)) {
+            throw new RuntimeException("Failed to change mode for: {$this->path}");
+        }
+    }
+
+    /**
+     * Gets the owner of the file or directory.
+     *
+     * @return string The owner's username.
+     */
+    public function owner(): string
+    {
+        return posix_getpwuid(fileowner($this->path))['name'];
+    }
+
+    /**
+     * Gets the group of the file or directory.
+     *
+     * @return string The group's name.
+     */
+    public function group(): string
+    {
+        return posix_getgrgid(filegroup($this->path))['name'];
+    }
+
+    /**
+     * Checks if the path is absolute.
+     *
+     * @return bool True if the path is absolute, false otherwise.
+     */
+    public function isAbsolute(): bool
+    {
+        if (true === str_starts_with(PHP_OS, 'WIN')) {
+            return 1 === preg_match('%^(?:[a-zA-Z]:[\\\/]|\\\\)%i', $this->path);
+        }
+        return str_starts_with($this->path, '/');
+    }
+
+    /**
+     * Checks if the path is relative.
+     *
+     * @return bool True if the path is relative, false otherwise.
+     */
+    public function isRelative(): bool
+    {
+        return !$this->isAbsolute();
+    }
+
+    /**
+     * Checks if the current path refers to the same file as another path.
+     *
+     * @param Path|string $other The other path to compare.
+     * @return bool True if the paths refer to the same file, false otherwise.
+     */
+    public function sameFile(Path|string $other): bool
+    {
+        return (string)$this->normalize($this->path) === (string)$this->normalize((string)$other);
+    }
+
+    /**
+     * Creates a symbolic link to the target path.
+     *
+     * @param Path|string $target The target path.
+     * @throws RuntimeException If the operation fails.
+     */
+    public function symlinkTo(Path|string $target): void
+    {
+        if (!symlink((string)$target, $this->path)) {
+            throw new RuntimeException("Could not create symlink from {$this->path} to {$target}");
+        }
+    }
+
+    /**
+     * Checks if the path is a symbolic link.
+     *
+     * @return bool True if the path is a symbolic link, false otherwise.
+     */
+    public function isSymlink(): bool
+    {
+        return is_link($this->path);
+    }
+
+    /**
+     * Resolves the path to its absolute, canonical form.
+     *
+     * @return self A new Path object with the resolved path.
+     */
+    public function resolve(): self
+    {
+        return $this->normalize($this->path);
+    }
+
+    /**
+     * Gets the relative path from another path.
+     *
+     * @param Path|string $other The base path.
+     * @return self A new Path object with the relative path.
+     * @throws RuntimeException If the current path is not relative to the base path.
+     */
+    public function relativeTo(Path|string $other): self
+    {
+        $other = (string)$this->normalize((string)$other);
+        $thisReal = (string)$this->normalize($this->path);
+
+        if (!str_starts_with($thisReal, $other . DIRECTORY_SEPARATOR)) {
+            throw new RuntimeException("{$this->path} is not relative to {$other}");
+        }
+
+        return new self(substr($thisReal, strlen($other) + 1));
+    }
+
+    /**
+     * Checks if the path matches a pattern.
+     *
+     * @param string $pattern The pattern to match.
+     * @return bool True if the path matches the pattern, false otherwise.
+     */
+    public function match(string $pattern): bool
+    {
+        return fnmatch($pattern, $this->path);
+    }
+
+    /**
+     * Gets the status information of the file or directory.
+     *
+     * @return array An array of status information.
+     */
+    public function stat(): array
+    {
+        return stat($this->path);
+    }
+
+    /**
+     * Renames the path to a new target.
+     *
+     * @param Path|string $target The new target path.
+     */
+    public function rename(Path|string $target): void
+    {
+        rename($this->path, (string)$target);
+    }
+
+    /**
+     * Replaces the path with a new target.
+     *
+     * @param Path|string $target The new target path.
+     */
+    public function replace(Path|string $target): void
+    {
+        $this->rename($target);
+    }
+
+    /**
+     * Creates an empty file or updates the modification time.
+     *
+     * @param int $mode The permissions mode (default: 0777).
+     * @param int|null $time The modification time (default: current time).
+     */
+    public function touch(int $mode = 0777, int|null $time = null): void
+    {
+        touch($this->path, $time ?? time());
+        chmod($this->path, $mode);
+    }
+
+    public function __get(string $name)
+    {
+        return match ($name) {
+            'parent' => $this->parent(),
+            'absolute' => $this->absolute(),
+            default => throw new RuntimeException("Unknown property: {$name}"),
+        };
+    }
+
+}

--- a/src/Libs/Path.php
+++ b/src/Libs/Path.php
@@ -197,11 +197,11 @@ final readonly class Path
 
         //-- Windows: preserve drive letter or UNC prefix
         $prefix = '';
-        if (str_starts_with(PHP_OS, 'WIN')) {
-            if (1 === preg_match('/^[a-zA-Z]:\\/', $path, $m)) {
+        if (true === str_starts_with(PHP_OS, 'WIN')) {
+            if (1 === preg_match('/^[a-zA-Z]:\\\\/', $path, $m)) {
                 $prefix = $m[0];
                 $path = substr($path, strlen($prefix));
-            } elseif (1 === preg_match('/^\\\\[^\\]+\\[^\\]+/', $path, $m)) {
+            } elseif (1 === preg_match('/^\\\\\\\\[^\\\\]+\\\\[^\\\\]+/', $path, $m)) {
                 $prefix = $m[0];
                 $path = substr($path, strlen($prefix));
             }

--- a/src/Listeners/ProcessPushEvent.php
+++ b/src/Listeners/ProcessPushEvent.php
@@ -72,7 +72,7 @@ final readonly class ProcessPushEvent
             'via' => $item->via,
             'title' => $item->getName(),
         ]);
-        
+
         $options = $e->getOptions();
         $list = [];
         $supported = Config::get('supported', []);
@@ -186,6 +186,13 @@ final readonly class ProcessPushEvent
         ]);
 
         foreach ($this->queue->getQueue() as $response) {
+            if (true === (bool)ag($response->getInfo('user_data'), Options::NO_LOGGING, false)) {
+                try {
+                    $response->getStatusCode();
+                } catch (Throwable) {
+                }
+                continue;
+            }
             $context = ag($response->getInfo('user_data'), 'context', []);
             $context['user'] = $user;
 

--- a/tests/Libs/PathTest.php
+++ b/tests/Libs/PathTest.php
@@ -514,12 +514,49 @@ class PathTest extends TestCase
 
     public function test_normalizePath_public_windows(): void
     {
+        // Regular Windows path
         $winPath = Path::make('C:\foo\bar\..\baz\.\qux');
         $normalized = $winPath->normalize('C:\foo\bar\..\baz\.\qux', '\\');
         $this->assertSame(
             'C:\foo\baz\qux',
             (string)$normalized,
             'Public normalize should normalize Windows path correctly'
+        );
+
+        // UNC path with ..
+        $unc1 = Path::make('\\\\server\\share\\folder\\..\\file.txt');
+        $normalized1 = $unc1->normalize('\\\\server\\share\\folder\\..\\file.txt', '\\');
+        $this->assertSame(
+            '\\\\server\\share\\file.txt',
+            (string)$normalized1,
+            'Normalize should correctly handle UNC path with ..'
+        );
+
+        // UNC path with .
+        $unc2 = Path::make('\\\\server\\share\\.\\dir\\file.txt');
+        $normalized2 = $unc2->normalize('\\\\server\\share\\.\\dir\\file.txt', '\\');
+        $this->assertSame(
+            '\\\\server\\share\\dir\\file.txt',
+            (string)$normalized2,
+            'Normalize should correctly handle UNC path with .'
+        );
+
+        // UNC path with multiple .. going up
+        $unc3 = Path::make('\\\\server\\share\\dir1\\dir2\\..\\..\\file');
+        $normalized3 = $unc3->normalize('\\\\server\\share\\dir1\\dir2\\..\\..\\file', '\\');
+        $this->assertSame(
+            '\\\\server\\share\\file',
+            (string)$normalized3,
+            'Normalize should handle multiple .. correctly in UNC path'
+        );
+
+        // UNC path with redundant slashes
+        $unc4 = Path::make('\\\\server\\share\\\\nested\\\\\\dir\\\\');
+        $normalized4 = $unc4->normalize('\\\\server\\share\\\\nested\\\\\\dir\\\\', '\\');
+        $this->assertSame(
+            '\\\\server\\share\\nested\\dir',
+            (string)$normalized4,
+            'Normalize should collapse redundant slashes in UNC path'
         );
     }
 

--- a/tests/Libs/PathTest.php
+++ b/tests/Libs/PathTest.php
@@ -1,0 +1,548 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Libs;
+
+use App\Libs\Path;
+use PHPUnit\Framework\TestCase;
+
+class PathTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'path_test_' . uniqid();
+        mkdir($this->tmpDir);
+    }
+
+    protected function tearDown(): void
+    {
+        if (false === is_dir($this->tmpDir) || false === file_exists($this->tmpDir)) {
+            return;
+        }
+
+        $fn = function (string $dir, $fn): void {
+            if (false === file_exists($dir) || false === str_starts_with($dir, $this->tmpDir)) {
+                return;
+            }
+
+            foreach (scandir($dir) as $item) {
+                if ($item !== '.' && $item !== '..') {
+                    $path = $dir . DIRECTORY_SEPARATOR . $item;
+                    if (is_dir($path)) {
+                        $fn($path, $fn);
+                    } elseif (is_file($path)) {
+                        unlink($path);
+                    }
+                }
+            }
+            rmdir($dir);
+        };
+
+        $fn($this->tmpDir, $fn);
+    }
+
+    public function test_MakeAndToString(): void
+    {
+        $path = Path::make($this->tmpDir);
+        $this->assertSame($this->tmpDir, (string)$path, 'Path::make should return correct string');
+    }
+
+    public function test_join(): void
+    {
+        $path = Path::make($this->tmpDir);
+        $joined = $path->joinPath('foo', 'bar');
+        $this->assertStringEndsWith(
+            'foo' . DIRECTORY_SEPARATOR . 'bar',
+            (string)$joined,
+            'joinPath should join segments'
+        );
+    }
+
+    public function testJoinVariants(): void
+    {
+        $path = Path::make($this->tmpDir);
+        $joined1 = $path->joinPath('foo', 'bar');
+        $joined2 = $path->joinPath('foo', 'bar');
+        $this->assertSame((string)$joined1, (string)$joined2, 'joinPath variants should be consistent');
+    }
+
+    public function test_ExistsIsDirIsFile(): void
+    {
+        $dir = Path::make($this->tmpDir);
+        $this->assertTrue($dir->exists(), 'Directory should exist');
+        $this->assertTrue($dir->isDir(), 'Should be a directory');
+        $this->assertFalse($dir->isFile(), 'Should not be a file');
+
+        $filePath = $dir->joinPath('file.txt');
+        file_put_contents((string)$filePath, 'data');
+        $file = Path::make((string)$filePath);
+        $this->assertTrue($file->exists(), 'File should exist');
+        $this->assertTrue($file->isFile(), 'Should be a file');
+        $this->assertFalse($file->isDir(), 'Should not be a directory');
+    }
+
+    public function testIsDirIsFileVariants(): void
+    {
+        $dir = Path::make($this->tmpDir);
+        $file = $dir->joinPath('file.txt');
+        $file->write('data');
+        $file2 = $dir->joinPath('file2.txt');
+        $file2->write('data');
+        $this->assertTrue($dir->isDir(), 'Should be a directory');
+        $this->assertTrue($dir->isDir(), 'Should be a directory (repeat)');
+        $this->assertTrue($file->isFile(), 'Should be a file');
+        $this->assertTrue($file->isFile(), 'Should be a file (repeat)');
+        $this->assertTrue($file2->isFile(), 'Should be a file2');
+        $this->assertTrue($file2->isFile(), 'Should be a file2 (repeat)');
+    }
+
+    public function test_MkdirAndRmdir(): void
+    {
+        $sub_dir = Path::make($this->tmpDir)->joinPath('sub_dir');
+        $sub_dir->mkdir();
+        $this->assertTrue($sub_dir->exists(), 'Subdir should exist after mkdir');
+        $this->assertTrue($sub_dir->isDir(), 'Subdir should be a directory');
+        $sub_dir->rmdir();
+        $this->assertFalse($sub_dir->exists(), 'Subdir should be removed');
+    }
+
+    public function test_MkdirExistOk(): void
+    {
+        $sub_dir = Path::make($this->tmpDir)->joinPath('sub_dir');
+        $sub_dir->mkdir();
+        $sub_dir->mkdir(0777, false, true); // Should not throw
+        $this->assertTrue($sub_dir->exists(), 'Subdir should still exist');
+    }
+
+    public function test_MkdirThrowsIfExists(): void
+    {
+        $sub_dir = Path::make($this->tmpDir)->joinPath('sub_dir');
+        $sub_dir->mkdir();
+        $this->expectException(\RuntimeException::class, 'Should throw if mkdir on existing dir');
+        $sub_dir->mkdir();
+    }
+
+    public function test_Unlink(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('file.txt');
+        $file->write('abc');
+        $this->assertTrue($file->isFile(), 'File should exist before unlink');
+        $file->unlink();
+        $this->assertFalse($file->exists(), 'File should be removed');
+    }
+
+    public function test_UnlinkThrowsIfNotFile(): void
+    {
+        $dir = Path::make($this->tmpDir);
+        $this->expectException(\RuntimeException::class, 'Should throw if unlink on dir');
+        $dir->unlink();
+    }
+
+    public function test_ReadWriteText(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('file.txt');
+        $file->write('hello');
+        $this->assertSame('hello', $file->read(), 'Read should return written text');
+    }
+
+    public function testReadWriteVariants(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('file.txt');
+        $file->write('abc');
+        $this->assertSame('abc', $file->read(), 'Read should return written text');
+        $file2 = Path::make($this->tmpDir)->joinPath('file2.txt');
+        $file2->write('def');
+        $this->assertSame('def', $file2->read(), 'Read should return written text for file2');
+    }
+
+    public function test_ReadTextThrowsIfNotFile(): void
+    {
+        $dir = Path::make($this->tmpDir);
+        $this->expectException(\RuntimeException::class, 'Should throw if read on dir');
+        $dir->read();
+    }
+
+    public function testWriteTextAndReadText(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('file.txt');
+        $file->write('hello');
+        $this->assertSame('hello', $file->read(), 'Read should return written text');
+    }
+
+    public function test_Absolute(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('file.txt');
+        $file->write('abc');
+        $abs = $file->absolute();
+        $this->assertTrue(is_string((string)$abs), 'Absolute should return string');
+        $this->assertTrue($abs->exists(), 'Absolute path should exist');
+    }
+
+    public function test_NameSuffixStem(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('foo.bar.txt');
+        $this->assertSame('foo.bar.txt', $file->name(), 'Name should return filename');
+        $this->assertSame('txt', $file->suffix(), 'Suffix should return extension');
+        $this->assertSame('foo.bar', $file->stem(), 'Stem should return filename without extension');
+    }
+
+    public function test_Parent(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('foo.txt');
+        $parent = $file->parent();
+        $this->assertSame($this->tmpDir, (string)$parent, 'Parent should return parent directory');
+    }
+
+    public function test_WithName(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('foo.txt');
+        $newFile = $file->withName('bar.txt');
+        $this->assertStringEndsWith('bar.txt', (string)$newFile, 'withName should change filename');
+    }
+
+    public function test_WithSuffix(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('foo.txt');
+        $newFile = $file->withSuffix('.md');
+        $this->assertStringEndsWith('.md', (string)$newFile, 'withSuffix should change extension');
+    }
+
+    public function test_with_name(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('foo.txt');
+        $newFile = $file->withName('bar.txt');
+        $this->assertStringEndsWith('bar.txt', (string)$newFile, 'withName should change filename');
+    }
+
+    public function test_with_suffix(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('foo.txt');
+        $newFile = $file->withSuffix('.md');
+        $this->assertStringEndsWith('.md', (string)$newFile, 'withSuffix should change extension');
+    }
+
+    public function test_Glob(): void
+    {
+        $file1 = Path::make($this->tmpDir)->joinPath('a.txt');
+        $file2 = Path::make($this->tmpDir)->joinPath('b.txt');
+        $file1->write('1');
+        $file2->write('2');
+        $dir = Path::make($this->tmpDir);
+        $matches = $dir->glob('*.txt');
+        $this->assertCount(2, $matches, 'glob should find both files');
+    }
+
+    public function testGlobVariants(): void
+    {
+        $file1 = Path::make($this->tmpDir)->joinPath('a.txt');
+        $file2 = Path::make($this->tmpDir)->joinPath('b.txt');
+        $file1->write('1');
+        $file2->write('2');
+        $dir = Path::make($this->tmpDir);
+        $matches1 = $dir->glob('*.txt');
+        $matches2 = $dir->glob('a.*');
+        $this->assertContains((string)$file1, $matches1, 'glob should contain a.txt');
+        $this->assertContains((string)$file2, $matches1, 'glob should contain b.txt');
+        $this->assertContains((string)$file1, $matches2, 'glob should contain a.txt for a.*');
+    }
+
+    public function test_iterDir(): void
+    {
+        $file1 = Path::make($this->tmpDir)->joinPath('a.txt');
+        $file2 = Path::make($this->tmpDir)->joinPath('b.txt');
+        $file1->write('1');
+        $file2->write('2');
+        $dir = Path::make($this->tmpDir);
+        $items = $dir->iterDir();
+        $this->assertCount(2, $items, 'iterDir should return both files');
+        foreach ($items as $item) {
+            $this->assertInstanceOf(Path::class, $item, 'iterDir should return Path objects');
+        }
+    }
+
+    public function testIterDirVariants(): void
+    {
+        $file1 = Path::make($this->tmpDir)->joinPath('a.txt');
+        $file2 = Path::make($this->tmpDir)->joinPath('b.txt');
+        $file1->write('1');
+        $file2->write('2');
+        $dir = Path::make($this->tmpDir);
+        $items1 = $dir->iterDir();
+        $items2 = $dir->iterdir();
+        $this->assertCount(2, $items1, 'iterDir should return both files');
+        $this->assertCount(2, $items2, 'iterdir should return both files');
+        foreach ($items1 as $item) {
+            $this->assertInstanceOf(Path::class, $item, 'iterDir should return Path objects');
+        }
+        foreach ($items2 as $item) {
+            $this->assertInstanceOf(Path::class, $item, 'iterdir should return Path objects');
+        }
+    }
+
+    public function test_IterDirThrowsIfNotDir(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('file.txt');
+        $file->write('abc');
+        $this->expectException(\RuntimeException::class, 'Should throw if iterDir on file');
+        $file->iterDir();
+    }
+
+    public function testIterDirThrows(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('file.txt');
+        $file->write('abc');
+        $this->expectException(\RuntimeException::class, 'Should throw if iterDir on file');
+        $file->iterDir();
+    }
+
+    public function test_Chmod(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('file.txt');
+        $file->write('abc');
+        $file->chmod(0644);
+        $this->assertTrue($file->exists(), 'chmod should not remove file');
+    }
+
+    public function test_OwnerGroup(): void
+    {
+        if (false === extension_loaded('posix')) {
+            $this->markTestSkipped('POSIX extension is not available.');
+        }
+
+        $file = Path::make($this->tmpDir)->joinPath('file.txt');
+        $file->write('abc');
+        $owner = $file->owner();
+        $group = $file->group();
+        $this->assertIsString($owner, 'owner should return string');
+        $this->assertIsString($group, 'group should return string');
+    }
+
+    public function testOwnerGroupVariants(): void
+    {
+        if (!function_exists('posix_getpwuid') || !function_exists('posix_getgrgid')) {
+            $this->markTestSkipped('POSIX extension is not available.');
+        }
+        $file = Path::make($this->tmpDir)->joinPath('file.txt');
+        $file->write('abc');
+        $owner1 = $file->owner();
+        $group1 = $file->group();
+        $owner2 = $file->owner();
+        $group2 = $file->group();
+        $this->assertIsString($owner1, 'owner should return string');
+        $this->assertIsString($group1, 'group should return string');
+        $this->assertIsString($owner2, 'owner should return string (repeat)');
+        $this->assertIsString($group2, 'group should return string (repeat)');
+    }
+
+    public function test_IsAbsolute(): void
+    {
+        $absPath = Path::make(DIRECTORY_SEPARATOR . 'foo');
+        $relPath = Path::make('foo');
+        $this->assertTrue($absPath->isAbsolute(), 'Should be absolute path');
+        $this->assertFalse($relPath->isAbsolute(), 'Should be relative path');
+    }
+
+    public function testUnlinkThrowsOnDir(): void
+    {
+        $dir = Path::make($this->tmpDir);
+        $this->expectException(\RuntimeException::class, 'Should throw if unlink on dir');
+        $dir->unlink();
+    }
+
+    public function testRmdirThrowsOnFile(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('file.txt');
+        $file->write('abc');
+        $this->expectException(\RuntimeException::class, 'Should throw if rmdir on file');
+        $file->rmdir();
+    }
+
+    public function testChmodThrows(): void
+    {
+        $path = Path::make('/nonexistent/path');
+        $this->expectException(\RuntimeException::class, 'Should throw if chmod fails');
+        $path->chmod(0644);
+    }
+
+    public function test_EmptyPath(): void
+    {
+        $path = Path::make("");
+        $this->assertFalse($path->exists(), 'Empty path should not exist');
+        $this->assertFalse($path->isDir(), 'Empty path should not be a directory');
+        $this->assertFalse($path->isFile(), 'Empty path should not be a file');
+        $this->assertSame('', $path->name(), 'Empty path name should be empty string');
+        $this->assertSame('', $path->suffix(), 'Empty path suffix should be empty string');
+        $this->assertSame('', $path->stem(), 'Empty path stem should be empty string');
+    }
+
+    public function test_RecursiveMkdir(): void
+    {
+        $subdir = Path::make($this->tmpDir)->joinPath('foo', 'bar');
+        $subdir->mkdir(0777, true);
+        $this->assertTrue($subdir->exists(), 'Recursive mkdir should create subdir');
+        $this->assertTrue($subdir->isDir(), 'Subdir should be a directory');
+    }
+
+    public function test_ParentAndAbsolute(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('foo.txt');
+        $parent = $file->parent();
+        $this->assertSame($this->tmpDir, (string)$parent, 'Parent should return parent directory');
+        $file->write('abc');
+        $abs = $file->absolute();
+        $this->assertTrue($abs->exists(), 'Absolute path should exist');
+    }
+
+    public function test_is_relative(): void
+    {
+        $base = Path::make($this->tmpDir);
+        $file = $base->joinPath('file.txt');
+        $file->write('abc');
+        $this->assertFalse($file->isRelative(), "Assert that path is relative and not absolute. {$file->path}");
+
+        $cwd = getcwd();
+        chdir($this->tmpDir);
+
+        $base = Path::make('foo.txt');
+        $base->write('abc');
+        chdir($cwd);
+        $this->assertTrue($base->isRelative(), 'Assert that path is relative');
+    }
+
+    public function test_sameFile(): void
+    {
+        $file1 = Path::make($this->tmpDir)->joinPath('file.txt');
+        $file2 = Path::make($this->tmpDir)->joinPath('file.txt');
+        $file1->write('abc');
+        $this->assertTrue($file1->sameFile($file2), 'Should be same file');
+        $file3 = Path::make($this->tmpDir)->joinPath('other.txt');
+        $file3->write('def');
+        $this->assertFalse($file1->sameFile($file3), 'Should not be same file');
+    }
+
+    public function test_symlinkTo_and_resolve(): void
+    {
+        if (str_starts_with(PHP_OS, 'WIN')) {
+            $this->markTestSkipped('Symlink creation is not supported or requires admin privileges on Windows.');
+        }
+
+        $target = Path::make($this->tmpDir)->joinPath('target.txt');
+        $target->write('abc');
+        $link = Path::make($this->tmpDir)->joinPath('link.txt');
+        $link->symlinkTo($target);
+        $this->assertTrue(is_link((string)$link), 'Should create symlink');
+        $resolved = $link->resolve();
+        $this->assertSame((string)$target, (string)$resolved, 'resolve should return target');
+    }
+
+    public function test_relativeTo(): void
+    {
+        $base = Path::make($this->tmpDir);
+        $file = $base->joinPath('foo.txt');
+        $file->write('abc');
+        $rel = $file->relativeTo($base);
+        $this->assertSame('foo.txt', (string)$rel, 'relativeTo should return relative path');
+        $this->expectException(\RuntimeException::class, 'Should throw if relativeTo fails');
+        $file->relativeTo('/nonexistent');
+    }
+
+    public function test_match(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('foo.txt');
+        $file->write('abc');
+        $this->assertTrue($file->match('*.txt'), 'Should match *.txt');
+        $this->assertFalse($file->match('*.md'), 'Should not match *.md');
+    }
+
+    public function test_stat(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('foo.txt');
+        $file->write('abc');
+        $stat = $file->stat();
+        $this->assertIsArray($stat, 'stat should return array');
+        $this->assertArrayHasKey('size', $stat, 'stat array should have size key');
+    }
+
+    public function test_rename(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('foo.txt');
+        $file->write('abc');
+        $newFile = Path::make($this->tmpDir)->joinPath('bar.txt');
+        $file->rename($newFile);
+        $this->assertFalse($file->exists(), 'File should not exist after rename');
+        $this->assertTrue($newFile->exists(), 'New file should exist after rename');
+    }
+
+    public function test_virtual_properties(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('foo.bar.txt');
+        $file->write('abc');
+        $this->assertSame($file->name(), $file->name, 'Virtual property name should match method');
+        $this->assertSame($file->stem(), $file->stem, 'Virtual property stem should match method');
+        $this->assertSame($file->suffix(), $file->suffix, 'Virtual property suffix should match method');
+        $this->assertInstanceOf(Path::class, $file->parent, 'Virtual property parent should be Path');
+        $this->assertInstanceOf(Path::class, $file->absolute, 'Virtual property absolute should be Path');
+        $this->assertSame(
+            (string)$file->absolute(),
+            (string)$file->absolute,
+            'Virtual property absolute should match method'
+        );
+    }
+
+    public function test_virtual_property_exception(): void
+    {
+        $file = Path::make($this->tmpDir)->joinPath('foo.txt');
+        $this->expectException(\RuntimeException::class);
+        /** @noinspection PhpUndefinedFieldInspection */
+        $file->unknown_property;
+    }
+
+    public function test_normalizePath_public_unix(): void
+    {
+        $path = Path::make('/foo/bar/../baz/./qux');
+        $normalized = $path->normalize('/foo/bar/../baz/./qux', '/');
+        $this->assertSame(
+            '/foo/baz/qux',
+            (string)$normalized,
+            'Public normalize should normalize Unix path correctly'
+        );
+    }
+
+    public function test_normalizePath_public_windows(): void
+    {
+        $winPath = Path::make('C:\foo\bar\..\baz\.\qux');
+        $normalized = $winPath->normalize('C:\foo\bar\..\baz\.\qux', '\\');
+        $this->assertSame(
+            'C:\foo\baz\qux',
+            (string)$normalized,
+            'Public normalize should normalize Windows path correctly'
+        );
+    }
+
+    public function test_isSymlink()
+    {
+        if (str_starts_with(PHP_OS, 'WIN')) {
+            $this->markTestSkipped('Symlink checks are not reliable on Windows.');
+        }
+
+        $target = Path::make($this->tmpDir)->joinPath('target.txt');
+        $target->write('abc');
+        $link = Path::make($this->tmpDir)->joinPath('link.txt');
+        $link->symlinkTo($target);
+        $this->assertTrue($link->isSymlink(), 'Should be a symlink');
+        $this->assertFalse($target->isSymlink(), 'Target should not be a symlink');
+    }
+
+    public function test_Touch()
+    {
+        $file = Path::make($this->tmpDir)->joinPath('file.txt');
+        $file->touch();
+        $this->assertTrue($file->exists(), 'File should exist after touch');
+        $this->assertTrue($file->isFile(), 'Should be a file after touch');
+        $this->assertSame('', $file->read(), 'File should be empty after touch');
+    }
+
+}

--- a/tests/Libs/PathTest.php
+++ b/tests/Libs/PathTest.php
@@ -6,6 +6,7 @@ namespace Tests\Libs;
 
 use App\Libs\Path;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class PathTest extends TestCase
 {
@@ -121,7 +122,7 @@ class PathTest extends TestCase
     {
         $sub_dir = Path::make($this->tmpDir)->joinPath('sub_dir');
         $sub_dir->mkdir();
-        $this->expectException(\RuntimeException::class, 'Should throw if mkdir on existing dir');
+        $this->expectException(RuntimeException::class);
         $sub_dir->mkdir();
     }
 
@@ -137,7 +138,7 @@ class PathTest extends TestCase
     public function test_UnlinkThrowsIfNotFile(): void
     {
         $dir = Path::make($this->tmpDir);
-        $this->expectException(\RuntimeException::class, 'Should throw if unlink on dir');
+        $this->expectException(RuntimeException::class);
         $dir->unlink();
     }
 
@@ -161,7 +162,7 @@ class PathTest extends TestCase
     public function test_ReadTextThrowsIfNotFile(): void
     {
         $dir = Path::make($this->tmpDir);
-        $this->expectException(\RuntimeException::class, 'Should throw if read on dir');
+        $this->expectException(RuntimeException::class);
         $dir->read();
     }
 
@@ -286,7 +287,7 @@ class PathTest extends TestCase
     {
         $file = Path::make($this->tmpDir)->joinPath('file.txt');
         $file->write('abc');
-        $this->expectException(\RuntimeException::class, 'Should throw if iterDir on file');
+        $this->expectException(RuntimeException::class);
         $file->iterDir();
     }
 
@@ -294,7 +295,7 @@ class PathTest extends TestCase
     {
         $file = Path::make($this->tmpDir)->joinPath('file.txt');
         $file->write('abc');
-        $this->expectException(\RuntimeException::class, 'Should throw if iterDir on file');
+        $this->expectException(RuntimeException::class);
         $file->iterDir();
     }
 
@@ -348,7 +349,7 @@ class PathTest extends TestCase
     public function testUnlinkThrowsOnDir(): void
     {
         $dir = Path::make($this->tmpDir);
-        $this->expectException(\RuntimeException::class, 'Should throw if unlink on dir');
+        $this->expectException(RuntimeException::class);
         $dir->unlink();
     }
 
@@ -356,14 +357,14 @@ class PathTest extends TestCase
     {
         $file = Path::make($this->tmpDir)->joinPath('file.txt');
         $file->write('abc');
-        $this->expectException(\RuntimeException::class, 'Should throw if rmdir on file');
+        $this->expectException(RuntimeException::class);
         $file->rmdir();
     }
 
     public function testChmodThrows(): void
     {
         $path = Path::make('/nonexistent/path');
-        $this->expectException(\RuntimeException::class, 'Should throw if chmod fails');
+        $this->expectException(RuntimeException::class);
         $path->chmod(0644);
     }
 
@@ -445,7 +446,7 @@ class PathTest extends TestCase
         $file->write('abc');
         $rel = $file->relativeTo($base);
         $this->assertSame('foo.txt', (string)$rel, 'relativeTo should return relative path');
-        $this->expectException(\RuntimeException::class, 'Should throw if relativeTo fails');
+        $this->expectException(RuntimeException::class);
         $file->relativeTo('/nonexistent');
     }
 
@@ -495,7 +496,7 @@ class PathTest extends TestCase
     public function test_virtual_property_exception(): void
     {
         $file = Path::make($this->tmpDir)->joinPath('foo.txt');
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         /** @noinspection PhpUndefinedFieldInspection */
         $file->unknown_property;
     }


### PR DESCRIPTION
This pull request introduces several updates to improve API interactions, enhance error handling, and add platform-specific process checks. The most significant changes include implementing workarounds for API limitations in Jellyfin and Emby, introducing a new mechanism to skip logging for certain API responses, and adding Windows-specific process checks in utility functions.

### Improvements to API interactions:

* **Workarounds for Jellyfin and Emby API limitations**: Added logic to handle cases where Jellyfin doesn't reset `PlaybackPositionTicks` and Emby doesn't support sending `LastPlayedDate` in the initial request. This includes sending additional POST requests with updated playback data if an item is marked as watched in both `Export.php` and `Push.php`. [[1]](diffhunk://#diff-e66e8b83a6ba4907561827ffd01da203894c7f9fec9c0769a74a5d94c1d6ff43R249-R273) [[2]](diffhunk://#diff-464916a14b47b711960530cf7e74b61cf89079c27570ebab43c5cf9d9fa374aeR293-R317)

* **Refactoring `DatePlayed` handling**: Extracted the `DatePlayed` value into a reusable variable (`$lastPlayed`) to simplify and standardize its usage in both `Export.php` and `Push.php`. [[1]](diffhunk://#diff-e66e8b83a6ba4907561827ffd01da203894c7f9fec9c0769a74a5d94c1d6ff43R214-R217) [[2]](diffhunk://#diff-464916a14b47b711960530cf7e74b61cf89079c27570ebab43c5cf9d9fa374aeR267-R269)

### Enhancements to error handling:

* **Skipping logging for specific responses**: Introduced a mechanism to skip logging for API responses marked with the `Options::NO_LOGGING` flag. This change was applied across multiple files, including `RestoreCommand.php`, `ExportCommand.php`, and `ProcessPushEvent.php`. [[1]](diffhunk://#diff-1b57055445f1ad991edc5c5b5fa317fc4102a9a48b0b699cbf5aedc9b550667eR335-R342) [[2]](diffhunk://#diff-99f113b21111224bc177743a42dbd246a27de0162f4f970427465fc7fc7cb5abR479-R492) [[3]](diffhunk://#diff-a51d62ea17ba4aec1f9d117fee5f36276b0428840781a9fa43af45813a918e58R189-R195)

* **Improved status code handling**: Updated the status code comparison in `ExportCommand.php` to use a more robust `Status::tryFrom` method, ensuring better maintainability and readability.

### Platform-specific improvements:

* **Windows-specific process checks**: Added support for checking process activity on Windows systems using the `tasklist` command in the `isSchedulerRunning` utility function. This ensures compatibility with Windows environments when verifying process states. [[1]](diffhunk://#diff-320bf238cc9fcad891d6d752e09d1a3000bf326b07b63f6704a36e55a72130bdR456-R486) [[2]](diffhunk://#diff-320bf238cc9fcad891d6d752e09d1a3000bf326b07b63f6704a36e55a72130bdR499)