### PR TITLE
Update the last played date during progress update.

### DIFF
--- a/src/Backends/Emby/Action/Progress.php
+++ b/src/Backends/Emby/Action/Progress.php
@@ -15,6 +15,7 @@ use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Enums\Http\Method;
 use App\Libs\Exceptions\Backends\InvalidArgumentException;
 use App\Libs\Exceptions\Backends\RuntimeException;
+use App\Libs\Extends\Date;
 use App\Libs\Options;
 use App\Libs\QueueRequests;
 use DateTimeInterface;
@@ -258,6 +259,7 @@ class Progress
                                 ],
                                 'json' => [
                                     'PlaybackPositionTicks' => (string)floor($entity->getPlayProgress() * 1_00_00),
+                                    'LastPlayedDate' => makeDate($senderDate)->format(Date::ATOM),
                                 ],
                                 'user_data' => [
                                     'id' => $key,

--- a/src/Backends/Jellyfin/Action/Progress.php
+++ b/src/Backends/Jellyfin/Action/Progress.php
@@ -15,6 +15,7 @@ use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Enums\Http\Method;
 use App\Libs\Exceptions\Backends\InvalidArgumentException;
 use App\Libs\Exceptions\Backends\RuntimeException;
+use App\Libs\Extends\Date;
 use App\Libs\Options;
 use App\Libs\QueueRequests;
 use DateTimeInterface;
@@ -280,6 +281,7 @@ class Progress
                                 ],
                                 'json' => [
                                     'PlaybackPositionTicks' => (string)floor($entity->getPlayProgress() * 1_00_00),
+                                    'LastPlayedDate' => makeDate($senderDate)->format(Date::ATOM),
                                 ],
                                 'user_data' => [
                                     'id' => $key,


### PR DESCRIPTION
This pull request introduces functionality to include the `LastPlayedDate` in the JSON payload for progress updates in both the Emby and Jellyfin backends. It also adds a new dependency on the `Date` utility class. The main changes focus on enhancing the data sent during playback progress updates.

### Enhancements to progress updates:

* **Emby backend**:
  - Added `LastPlayedDate` to the JSON payload in the `action` method, using the `makeDate` function to format the date as `Date::ATOM`. (`src/Backends/Emby/Action/Progress.php`, [src/Backends/Emby/Action/Progress.phpR262](diffhunk://#diff-54f4fad2b3793014495cbf5c7be86ef9ae2d23be6b64410ed8e83ebaa5ccc2d6R262))
  - Imported the `Date` utility class to support the new functionality. (`src/Backends/Emby/Action/Progress.php`, [src/Backends/Emby/Action/Progress.phpR18](diffhunk://#diff-54f4fad2b3793014495cbf5c7be86ef9ae2d23be6b64410ed8e83ebaa5ccc2d6R18))

* **Jellyfin backend**:
  - Added `LastPlayedDate` to the JSON payload in the `action` method, using the `makeDate` function to format the date as `Date::ATOM`. (`src/Backends/Jellyfin/Action/Progress.php`, [src/Backends/Jellyfin/Action/Progress.phpR284](diffhunk://#diff-ade8e15b3bc6c8993d125495db1b1a72499f488c193b6723f8b2714f1044ae8bR284))
  - Imported the `Date` utility class to support the new functionality. (`src/Backends/Jellyfin/Action/Progress.php`, [src/Backends/Jellyfin/Action/Progress.phpR18](diffhunk://#diff-ade8e15b3bc6c8993d125495db1b1a72499f488c193b6723f8b2714f1044ae8bR18))