### PR TITLE
Add minimum progress update threshold. Closes #706

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -19,6 +19,7 @@ use Monolog\Level;
 return (function () {
     $inContainer = inContainer();
     $progressTimeCheck = fn(int $v, int $d): int => 0 === $v || $v >= 180 ? $v : $d;
+    $progressToMS = fn(int $v): int => $v < 60 ? ($v * 1000) : 60000;
 
     $config = [
         'name' => 'WatchState',
@@ -91,6 +92,8 @@ return (function () {
             'threshold' => $progressTimeCheck((int)env('WS_PROGRESS_THRESHOLD', 0), 60 * 10),
             // -- Minimum time to consider item as progress sync-able.
             'minThreshold' => 180,
+            // -- Minimum time to consider item as progress sync-able in milliseconds.
+            'minimum' => $progressToMS((int)env('WS_PROGRESS_MINIMUM', 60)),
         ],
     ];
 

--- a/config/env.spec.php
+++ b/config/env.spec.php
@@ -316,6 +316,28 @@ return (function () {
             'description' => 'Enable this option to disable matching episodes by GUIDs and rely on relative GUIDs to match.',
             'type' => 'bool',
         ],
+        [
+            'key' => 'WS_PROGRESS_MINIMUM',
+            'description' => 'Time in seconds to consider progress update as valid.',
+            'type' => 'string',
+            'validate' => function (mixed $value): string {
+                if (!is_numeric($value) && empty($value)) {
+                    throw new ValidationException('Invalid minimum progress. Empty value.');
+                }
+
+                if (false === is_numeric($value)) {
+                    throw new ValidationException('Invalid minimum progress. Must be a number.');
+                }
+
+                $cmp = (int)$value;
+
+                if ($cmp < 60) {
+                    throw new ValidationException('Invalid minimum progress. Must be at least 60 seconds.');
+                }
+
+                return $value;
+            },
+        ],
     ];
 
     $validateCronExpression = function (string $value): string {

--- a/src/Libs/Entity/StateEntity.php
+++ b/src/Libs/Entity/StateEntity.php
@@ -596,6 +596,7 @@ final class StateEntity implements iState
     public function hasPlayProgress(): bool
     {
         $allowUpdate = (int)Config::get('progress.threshold', 0);
+        $minimumProgress = (int)Config::get('progress.minimum', 60000);
 
         if ($this->isWatched() && $allowUpdate < 1) {
             return false;
@@ -605,7 +606,7 @@ final class StateEntity implements iState
             if (0 !== (int)ag($metadata, iState::COLUMN_WATCHED, 0) && $allowUpdate < 1) {
                 continue;
             }
-            if ((int)ag($metadata, iState::COLUMN_META_DATA_PROGRESS, 0) > 1000) {
+            if ((int)ag($metadata, iState::COLUMN_META_DATA_PROGRESS, 0) > $minimumProgress) {
                 return true;
             }
         }
@@ -624,12 +625,13 @@ final class StateEntity implements iState
         }
 
         $compare = [];
+        $minimumProgress = (int)Config::get('progress.minimum', 60000);
 
         foreach ($this->getMetadata() as $backend => $metadata) {
             if (0 !== (int)ag($metadata, iState::COLUMN_WATCHED, 0) && $allowUpdate < 1) {
                 continue;
             }
-            if ((int)ag($metadata, iState::COLUMN_META_DATA_PROGRESS, 0) < 1000) {
+            if ((int)ag($metadata, iState::COLUMN_META_DATA_PROGRESS, 0) < $minimumProgress) {
                 continue;
             }
 
@@ -650,7 +652,7 @@ final class StateEntity implements iState
                 continue;
             }
 
-            if ($progress < 1000 || $lastDate->getTimestamp() > makeDate($datetime)->getTimestamp()) {
+            if ($progress < $minimumProgress || $lastDate->getTimestamp() > makeDate($datetime)->getTimestamp()) {
                 continue;
             }
 

--- a/tests/Fixtures/MovieEntity.php
+++ b/tests/Fixtures/MovieEntity.php
@@ -33,7 +33,7 @@ return [
             iState::COLUMN_META_DATA_EXTRA => [
                 iState::COLUMN_META_DATA_EXTRA_DATE => '2020-01-03',
             ],
-            iState::COLUMN_META_DATA_PROGRESS => 5000,
+            iState::COLUMN_META_DATA_PROGRESS => 65000,
             iState::COLUMN_META_DATA_ADDED_AT => 1,
             iState::COLUMN_META_DATA_PLAYED_AT => 2,
         ],

--- a/tests/Libs/StateEntityTest.php
+++ b/tests/Libs/StateEntityTest.php
@@ -864,7 +864,7 @@ class StateEntityTest extends TestCase
 
         $testData = ag_set($this->testMovie, 'watched', 0);
         $testData = ag_set($testData, 'metadata.test_plex.watched', 0);
-        $testData = ag_set($testData, 'metadata.test_plex.progress', 5000);
+        $testData = ag_set($testData, 'metadata.test_plex.progress', 65000);
         $entity = new StateEntity($testData);
 
         $this->assertTrue(
@@ -879,7 +879,7 @@ class StateEntityTest extends TestCase
         $testData = ag_set($testData, 'metadata.test_plex.watched', 0);
         $entity = new StateEntity($testData);
         $this->assertSame(
-            5000,
+            65000,
             $entity->getPlayProgress(),
             'When hasPlayProgress() when valid play progress is set, returns true'
         );
@@ -891,7 +891,7 @@ class StateEntityTest extends TestCase
 
         $entity = new StateEntity($testData);
         $this->assertSame(
-            5000,
+            65000,
             $entity->getPlayProgress(),
             'When hasPlayProgress() when valid play progress is set, returns true'
         );


### PR DESCRIPTION
This pull request introduces a configurable minimum threshold for play progress, allowing the minimum valid progress time to be set via an environment variable. The changes update both the application logic and related tests to support this new configuration.

**Configuration enhancements:**

* Added a new environment variable `WS_PROGRESS_MINIMUM` to set the minimum play progress time (in seconds), with validation to ensure it is at least 60 seconds. (`config/env.spec.php`)
* Updated `config.php` to compute and store the minimum progress time in milliseconds using the new environment variable. (`config/config.php`) [[1]](diffhunk://#diff-f55db4bc294bbb90108ccfcbdd11881f4707473ad9384b382e2a6b653e118471R22) [[2]](diffhunk://#diff-f55db4bc294bbb90108ccfcbdd11881f4707473ad9384b382e2a6b653e118471R95-R96)

**Application logic updates:**

* Modified `StateEntity` methods to use the configurable `progress.minimum` value (in milliseconds) instead of a hardcoded threshold for determining valid play progress. (`src/Libs/Entity/StateEntity.php`) [[1]](diffhunk://#diff-637551b8c400cf24a4fb266b92252b52be43cbffee40642d368ec1f16642c7ecR599) [[2]](diffhunk://#diff-637551b8c400cf24a4fb266b92252b52be43cbffee40642d368ec1f16642c7ecL608-R609) [[3]](diffhunk://#diff-637551b8c400cf24a4fb266b92252b52be43cbffee40642d368ec1f16642c7ecR628-R634) [[4]](diffhunk://#diff-637551b8c400cf24a4fb266b92252b52be43cbffee40642d368ec1f16642c7ecL653-R655)

**Test updates:**

* Updated test fixtures and assertions to use the new default minimum progress value (65000 ms) instead of the previous value (5000 ms), ensuring tests reflect the new configuration. (`tests/Fixtures/MovieEntity.php`, `tests/Libs/StateEntityTest.php`) [[1]](diffhunk://#diff-efba1668c01300827f5d330ca94237131a75fa7a2ef391493b43ebd6453afb9bL36-R36) [[2]](diffhunk://#diff-6b4ccc9bd3d129ac761d8a7462e3b27960c9853d48182503613f030558954023L867-R867) [[3]](diffhunk://#diff-6b4ccc9bd3d129ac761d8a7462e3b27960c9853d48182503613f030558954023L882-R882) [[4]](diffhunk://#diff-6b4ccc9bd3d129ac761d8a7462e3b27960c9853d48182503613f030558954023L894-R894)