### PR TITLE
Update URLCheck to add more templates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![Build Status](https://github.com/arabcoders/WatchState/actions/workflows/build.yml/badge.svg)
 ![MIT License](https://img.shields.io/github/license/arabcoders/WatchState.svg)
 ![Docker pull](https://img.shields.io/docker/pulls/arabcoders/watchstate.svg)
+![ghcr pull](https://ghcr-badge.elias.eu.org/shield/arabcoders/watchstate/watchstate)
 
 This tool primary goal is to sync your backends **users** play state without relying on third party services, out of the
 box, this tool support `Jellyfin`, `Plex` and `Emby` media servers.

--- a/frontend/app/components/BackendAdd.vue
+++ b/frontend/app/components/BackendAdd.vue
@@ -584,7 +584,7 @@ const plex_get_token = async (notify = true) => {
       backend.value.token = json.authToken
       await nextTick();
       plex_oauth.value = {}
-      notification('success', 'Success', `Plex token generated inserted successfully.`)
+      notification('success', 'Success', `Successfully authenticated with plex.tv.`)
       if (plex_window.value) {
         try {
           plex_window.value.close()

--- a/frontend/app/pages/url_check.vue
+++ b/frontend/app/pages/url_check.vue
@@ -46,8 +46,9 @@
                 <div class="select is-fullwidth">
                   <select v-model="use_template" :disabled="is_loading">
                     <option value="" v-text="'Select a template'" disabled/>
-                    <option v-for="template in templates" :key="template.key" :value="template.key"
-                            v-text="template.key"/>
+                    <option v-for="template in templates" :key="template.key" :value="template.key">
+                      {{ template.id }}. {{ template.key }}
+                    </option>
                   </select>
                 </div>
               </div>
@@ -267,6 +268,10 @@
             <li>You can add this special header <code>ws-timeout</code> to control the connection timeout for the http
               library.
             </li>
+            <li>To get the value of <code>machineIdentifier</code> for plex <code>X-Plex-Client-Identifier</code>
+              header. First run <code>Plex: Info</code>, you will find a field named <code>machineIdentifier</code> This
+              value should go in the identifier header.
+            </li>
           </ul>
         </Message>
       </div>
@@ -290,7 +295,32 @@ const toggle_body = ref(true)
 const use_template = ref("")
 const templates = ref([
   {
-    "key": "Plex Media Server",
+    "id": 1,
+    "key": "Jellyfin/Emby Server",
+    "override": {
+      "method": "GET",
+      "url": "http://[ip:port]/items",
+      "headers": [
+        {"key": "Accept", "value": "application/json"},
+        {"key": "X-MediaBrowser-Token", "value": "[API_KEY]"},
+      ]
+    },
+  },
+  {
+    "id": 2,
+    "key": "Plex: Info",
+    "override": {
+      "method": "GET",
+      "url": "http://[ip:port]/",
+      "headers": [
+        {"key": "Accept", "value": "application/json"},
+        {"key": "X-Plex-Token", "value": "[PLEX_TOKEN]"},
+      ]
+    },
+  },
+  {
+    "id": 3,
+    "key": "Plex: Libraries",
     "override": {
       "method": "GET",
       "url": "http://[ip:port]/library/sections",
@@ -301,13 +331,25 @@ const templates = ref([
     },
   },
   {
-    "key": "Jellyfin/Emby Server",
+    "id": 4,
+    "key": "Plex.tv: External Users",
     "override": {
       "method": "GET",
-      "url": "http://[ip:port]/items",
+      "url": "http://plex.tv/api/users",
       "headers": [
-        {"key": "Accept", "value": "application/json"},
-        {"key": "X-MediaBrowser-Token", "value": "[API_KEY]"},
+        {"key": "X-Plex-Token", "value": "[PLEX_TOKEN]"},
+      ]
+    },
+  },
+  {
+    "id": 5,
+    "key": "Plex.tv: Home Users",
+    "override": {
+      "method": "GET",
+      "url": "http://plex.tv/api/v2/home/users/",
+      "headers": [
+        {"key": "X-Plex-Token", "value": "[PLEX_TOKEN]"},
+        {"key": "X-Plex-Client-Identifier", "value": "[machineIdentifier]"},
       ]
     },
   },
@@ -333,9 +375,8 @@ watch(use_template, async newValue => {
     return
   }
 
-  item.value = template.override
+  item.value = JSON.parse(JSON.stringify(template.override))
   await nextTick()
-
   use_template.value = ""
 })
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,5 +32,11 @@
         "vue-router": "^4.5.1",
         "vue-toastification": "2.0.0-rc.5",
         "vuedraggable": "^4.1.0"
+    },
+    "pnpm": {
+        "onlyBuiltDependencies": [
+            "esbuild",
+            "@parcel/watcher"
+        ]
     }
 }

--- a/src/API/Backends/Add.php
+++ b/src/API/Backends/Add.php
@@ -101,6 +101,8 @@ final class Add
                 options: $config->get('options', []),
             );
 
+            set_time_limit(60 * 10);
+
             if (false === $instance->validateContext($context)) {
                 return api_error('Context information validation failed.', Status::BAD_REQUEST);
             }

--- a/src/API/System/UrlChecker.php
+++ b/src/API/System/UrlChecker.php
@@ -52,6 +52,8 @@ final class UrlChecker
         }
 
         try {
+            set_time_limit(60 * 10);
+
             $response = $client->request($method->value, $url, [
                 'timeout' => $timeout,
                 'headers' => $headers


### PR DESCRIPTION
This pull request introduces several improvements and enhancements across the documentation, frontend, and backend code. The most significant changes are the expansion of template support and usage instructions for the URL checker, updates to authentication messaging, and adjustments to backend timeouts for long-running operations.

**Frontend: URL Checker Enhancements**
* Added new templates for Plex and Jellyfin/Emby servers in the `url_check.vue` page, including support for Plex info, libraries, external users, and home users. Templates now include an `id` field and more detailed header configurations.
* Improved template selection UI to display both the template `id` and `key`, making it easier to identify templates.
* Updated instructions to clarify how to obtain and use the `machineIdentifier` for Plex requests, specifically for the `X-Plex-Client-Identifier` header.
* Fixed template usage logic to deep copy the selected template override, preventing unintended mutations.

**Backend: Timeout Improvements**
* Increased the PHP execution timeout to 10 minutes in both `BackendAdd` and `UrlChecker` API endpoints to handle longer-running operations without premature termination. [[1]](diffhunk://#diff-eadd71ece56330765fbabe7f86f49110c234dda2967dd4b8aa5e24df41862e50R104-R105) [[2]](diffhunk://#diff-07a87697f86d9e131ba716188862988c2d6098be31fb6b7863e16c1f29224da1R55-R56)

**Documentation**
* Added a badge for GHCR (GitHub Container Registry) pulls to the `README.md` for better visibility of container usage statistics.

**Frontend: Authentication Messaging**
* Updated the success notification message when authenticating with Plex to be clearer and more user-friendly.