### PR TITLE
feat: add support for plex new nfo agent

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -258,21 +258,23 @@ If there are no errors, the database has been repaired successfully. And you can
 
 # Which Providers id `GUIDs` supported by for PlexClient?
 
-* tvdb://(id) `New plex agent`
-* imdb://(id) `New plex agent`
-* tmdb://(id) `New plex agent`
-* com.plexapp.agents.imdb://(id)?lang=en `(Legacy plex agent)`
-* com.plexapp.agents.tmdb://(id)?lang=en `(Legacy plex agent)`
-* com.plexapp.agents.themoviedb://(id)?lang=en `(Legacy plex agent)`
-* com.plexapp.agents.thetvdb://(seriesId)?lang=en `(Legacy plex agent)`
-* com.plexapp.agents.xbmcnfo://(id)?lang=en `(XBMC NFO Movies agent)`
-* com.plexapp.agents.xbmcnfotv://(id)?lang=en `(XBMC NFO TV agent)`
+* tvdb://(id)
+* imdb://(id)
+* tmdb://(id)
+* tv.plex.agents.nfo.movie://movie/(provider)_(id) `Where the provider one of supported providers`
+* tv.plex.agents.nfo.series://(show|episode)/(provider)_(id) `Where the provider one of supported providers`
+  
+## Legacy Plex Agents
+
+* com.plexapp.agents.imdb://(id)?lang=en
+* com.plexapp.agents.tmdb://(id)?lang=en
+* com.plexapp.agents.themoviedb://(id)?lang=en
+* com.plexapp.agents.thetvdb://(seriesId)?lang=en
+* com.plexapp.agents.xbmcnfo://(id)?lang=en `(XBMC NFO Movies agent) -> imdb|tmdb://(movieId)?lang=en`
+* com.plexapp.agents.xbmcnfotv://(id)?lang=en `(XBMC NFO TV agent) -> tvdb://(serisId)?lang=en`
 * com.plexapp.agents.hama://(db)\d?-(id)?lang=en `(HAMA multi source db agent mainly for anime)`
-* com.plexapp.agents.ytinforeader://(id)
-  ?lang=en [ytinforeader.bundle](https://github.com/arabcoders/plex-ytdlp-info-reader-agent)
-  With [jp_scanner.py](https://github.com/arabcoders/plex-daily-scanner) as scanner.
-* com.plexapp.agents.cmdb://(id)
-  ?lang=en [cmdb.bundle](https://github.com/arabcoders/cmdb.bundle) `(User custom metadata database)`.
+* com.plexapp.agents.ytinforeader://(id)?lang=en [ytinforeader.bundle](https://github.com/arabcoders/plex-ytdlp-info-reader-agent) With [jp_scanner.py](https://github.com/arabcoders/plex-daily-scanner) as scanner.
+* com.plexapp.agents.cmdb://(id)?lang=en [cmdb.bundle](https://github.com/arabcoders/cmdb.bundle) `(User custom metadata database)`.
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         ],
         "lint": "vendor/bin/mago lint",
         "frontend:update": "bun --cwd=./frontend/ update --latest",
+        "frontend:format": "bun --cwd=./frontend/ format",
         "frontend:gen": "bun --cwd=./frontend/ generate",
         "frontend:dev": "bun --cwd=./frontend/ dev",
         "frontend:tc": "bun --cwd=./frontend/ typecheck",

--- a/composer.lock
+++ b/composer.lock
@@ -2126,7 +2126,7 @@
     },
     {
       "name": "symfony/polyfill-uuid",
-      "version": "v1.36.0",
+      "version": "v1.37.0",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/polyfill-uuid.git",
@@ -2185,7 +2185,7 @@
         "uuid"
       ],
       "support": {
-        "source": "https://github.com/symfony/polyfill-uuid/tree/v1.36.0"
+        "source": "https://github.com/symfony/polyfill-uuid/tree/v1.37.0"
       },
       "funding": [
         {

--- a/frontend/app/components/EventView.vue
+++ b/frontend/app/components/EventView.vue
@@ -210,14 +210,37 @@
         <div v-if="toggleLogs" class="relative">
           <code
             class="ws-terminal ws-terminal-panel ws-terminal-panel-lg"
-            :class="wrapLines ? 'whitespace-pre-wrap' : 'whitespace-pre'"
+            :class="wrapLines ? 'ws-wrap-anywhere whitespace-pre-wrap' : 'whitespace-pre'"
           >
             <span
               v-for="(logLine, index) in filteredRows"
-              :key="`log_line-${index}`"
-              class="block pt-1"
-              v-text="logLine"
-            />
+              :key="`${logLine.id}-${index}`"
+              class="block"
+              ><span
+                v-if="logLine?.date || logLine?.item_id"
+                class="mr-[1ch] inline-flex items-baseline whitespace-normal"
+              >
+                <template v-if="logLine?.date"
+                  >[<UTooltip :text="`${moment(logLine.date).format(TOOLTIP_DATE_FORMAT)}`">
+                    <span class="cursor-help">{{
+                      moment(logLine.date).format('HH:mm:ss')
+                    }}</span> </UTooltip
+                  >]</template
+                >
+                <button
+                  v-if="logLine?.item_id"
+                  type="button"
+                  :class="[
+                    'cursor-pointer font-[inherit] leading-[inherit] text-primary underline-offset-2 hover:underline',
+                    logLine?.date ? 'ml-[1ch]' : '',
+                  ]"
+                  @click="goto_history_item(logLine)"
+                >
+                  View
+                </button>
+              </span>
+              <span>{{ String(logLine.text).trim() }}</span>
+            </span>
           </code>
           <UTooltip text="Copy logs">
             <UButton
@@ -226,7 +249,9 @@
               size="sm"
               icon="i-lucide-copy"
               class="absolute right-3 top-3"
-              @click="() => copyText(filteredRows.join('\n'))"
+              @click="
+                () => copyText(filteredRows.map((logLine) => formatLogLine(logLine)).join('\n'))
+              "
             />
           </UTooltip>
         </div>
@@ -280,10 +305,11 @@ import { createError, useHead } from '#app';
 import moment from 'moment';
 import { useStorage } from '@vueuse/core';
 import { useDialog } from '~/composables/useDialog';
-import type { EventsItem, GenericError } from '~/types';
+import type { EventsItem, GenericError, LogEntry } from '~/types';
 import {
   copyText,
   getEventStatusClass,
+  goto_history_item,
   makeEventName,
   notification,
   parse_api_response,
@@ -320,13 +346,23 @@ watch(toggleFilter, () => {
   }
 });
 
-const filteredRows = computed<Array<string>>(() => {
+const filteredRows = computed<Array<LogEntry>>(() => {
+  const rows = item.value.logs ?? [];
+
   if (!query.value) {
-    return item.value.logs ?? [];
+    return rows;
   }
 
-  return item.value.logs?.filter((m) => m.toLowerCase().includes(query.value.toLowerCase())) ?? [];
+  const queryValue = query.value.toLowerCase();
+
+  return rows.filter((logLine) => logLine.text.toLowerCase().includes(queryValue));
 });
+
+const formatLogLine = (logLine: LogEntry): string => {
+  const prefix = logLine.date ? `[${logLine.date}] ` : '';
+
+  return `${prefix}${String(logLine.text).trim()}`;
+};
 
 const getEventStatusColor = (status: number) => {
   const value = getEventStatusClass(status);

--- a/frontend/app/layouts/default.vue
+++ b/frontend/app/layouts/default.vue
@@ -259,6 +259,8 @@ type NavEntry = {
   label: string;
   icon: string;
   matchPath?: string;
+  exactMatch?: boolean;
+  excludeMatchPaths?: Array<string>;
   to?: string;
   href?: string;
   target?: string;
@@ -531,6 +533,25 @@ const isPathActive = (matchPath?: string) => {
   return current === target || current.startsWith(`${target}/`);
 };
 
+const isNavigationEntryActive = (entry: NavEntry) => {
+  if (!entry.matchPath) {
+    return false;
+  }
+
+  const current = normalizePath(route.path);
+  const target = normalizePath(entry.matchPath);
+
+  if (entry.excludeMatchPaths?.some((path) => isPathActive(path))) {
+    return false;
+  }
+
+  if (true === entry.exactMatch) {
+    return current === target;
+  }
+
+  return isPathActive(entry.matchPath);
+};
+
 const topLevelNavigationEntries = computed(() =>
   getTopLevelNavigationEntries({
     apiUser: apiUser.value,
@@ -547,6 +568,8 @@ const topLevelNavEntries = computed<Array<NavEntry>>(() =>
     href: entry.href,
     target: entry.target,
     matchPath: entry.matchPath,
+    exactMatch: entry.exactMatch,
+    excludeMatchPaths: entry.excludeMatchPaths,
     onSelect:
       'history' === entry.id
         ? () => dEvent('history_main_link_clicked', { clear: true })
@@ -579,7 +602,7 @@ const makeNavigationItem = (entry: NavEntry) => ({
   to: entry.to,
   href: entry.href,
   target: entry.target,
-  active: isPathActive(entry.matchPath),
+  active: isNavigationEntryActive(entry),
   onSelect: entry.onSelect,
 });
 
@@ -693,7 +716,7 @@ const routeSearchGroups = computed<Array<SearchGroup>>(() => {
 
 const pageTitle = computed(() => {
   const match = allNavEntries.value
-    .filter((entry) => isPathActive(entry.matchPath))
+    .filter((entry) => isNavigationEntryActive(entry))
     .sort(
       (left, right) => normalizePath(right.matchPath).length - normalizePath(left.matchPath).length,
     )[0];

--- a/frontend/app/pages/backend/[backend]/libraries.vue
+++ b/frontend/app/pages/backend/[backend]/libraries.vue
@@ -374,11 +374,28 @@ const forwardCommand = async (library: LibraryItem): Promise<void> => {
   await navigateTo(makeConsoleCommand(r(command.command, util as unknown as JsonObject)));
 };
 
+const getIgnoreIds = (targetLibrary: LibraryItem, nextIgnoredState: boolean): Array<string> => {
+  const targetId = String(targetLibrary.id);
+  const ignoreIds = items.value
+    .filter((item) => (String(item.id) === targetId ? nextIgnoredState : item.ignored))
+    .map((item) => String(item.id));
+
+  return Array.from(new Set(ignoreIds));
+};
+
 const toggleIgnore = async (library: LibraryItem): Promise<void> => {
   try {
     const newState = !library.ignored;
-    const response = await request(`/backend/${backend}/library/${library.id}`, {
-      method: newState ? 'POST' : 'DELETE',
+    const ignoreIds = getIgnoreIds(library, newState);
+
+    const response = await request(`/backend/${backend}`, {
+      method: 'PATCH',
+      body: JSON.stringify([
+        {
+          key: 'options.ignore',
+          value: ignoreIds.join(','),
+        },
+      ]),
     });
     const data = await parse_api_response<any>(response);
 

--- a/frontend/app/pages/help/index.vue
+++ b/frontend/app/pages/help/index.vue
@@ -113,5 +113,11 @@ const choices: Array<{ number: number; title: string; text: string; url: string 
     text: 'API documentation current version.',
     url: '/help/api',
   },
+  {
+    number: 9,
+    title: 'Backend OpenAPI',
+    text: 'Browse the bundled Plex, Jellyfin, and Emby upstream routes.',
+    url: '/help/openapi',
+  },
 ];
 </script>

--- a/frontend/app/pages/help/openapi.vue
+++ b/frontend/app/pages/help/openapi.vue
@@ -1,0 +1,1047 @@
+<template>
+  <main class="w-full min-w-0 max-w-full space-y-4">
+    <div class="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+      <div class="min-w-0 space-y-1">
+        <div
+          class="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.2em] text-toned"
+        >
+          <UIcon :name="pageShell.icon" class="size-4" />
+          <span>{{ pageShell.sectionLabel }}</span>
+          <span>/</span>
+          <span>{{ pageShell.pageLabel }}</span>
+        </div>
+
+        <div class="space-y-1">
+          <h1 class="text-xl font-semibold text-highlighted sm:text-2xl">{{ specTitle }}</h1>
+          <p class="text-sm text-toned">{{ specMeta }}</p>
+        </div>
+      </div>
+
+      <div class="flex flex-wrap items-center justify-end gap-2">
+        <UInput
+          v-if="showFilter || query"
+          id="filter"
+          v-model="query"
+          type="search"
+          placeholder="Filter routes"
+          icon="i-lucide-filter"
+          size="sm"
+          class="w-full sm:w-72"
+        />
+
+        <USelect
+          v-model="selectedBackend"
+          :items="backendItems"
+          value-key="value"
+          label-key="label"
+          color="neutral"
+          variant="outline"
+          size="sm"
+          class="w-full sm:w-44"
+          :disabled="isLoading"
+        />
+
+        <UButton
+          color="neutral"
+          :variant="showFilter ? 'soft' : 'outline'"
+          size="sm"
+          icon="i-lucide-filter"
+          @click="toggleFilter"
+        >
+          <span class="hidden sm:inline">Filter</span>
+        </UButton>
+
+        <a :href="specUrl" target="_blank" rel="noopener noreferrer">
+          <UButton color="neutral" variant="outline" size="sm" icon="i-lucide-file-code-2">
+            <span class="hidden sm:inline">JSON</span>
+          </UButton>
+        </a>
+      </div>
+    </div>
+
+    <UAlert
+      v-if="isLoading"
+      color="info"
+      variant="soft"
+      icon="i-lucide-loader-circle"
+      title="Loading"
+      description="Loading routes. Please wait..."
+      :ui="{ icon: 'animate-spin' }"
+    />
+
+    <UAlert
+      v-else-if="error"
+      color="error"
+      variant="soft"
+      icon="i-lucide-triangle-alert"
+      title="Unable to load routes"
+      :description="error"
+    />
+
+    <template v-else>
+      <UAlert
+        v-if="filteredRoutes.length < 1"
+        color="warning"
+        variant="soft"
+        icon="i-lucide-triangle-alert"
+        :title="query ? 'No results' : 'No routes found'"
+      >
+        <template #description>
+          <div class="space-y-2 text-sm text-default">
+            <p v-if="query">
+              No routes match <strong>{{ query }}</strong
+              >.
+            </p>
+            <p v-else>No routes are available for the selected backend.</p>
+          </div>
+        </template>
+      </UAlert>
+
+      <div v-else class="grid items-start gap-4 xl:grid-cols-2">
+        <UCard
+          v-for="route in filteredRoutes"
+          :key="route.key"
+          class="border border-default/70 bg-default/90 shadow-sm"
+          :ui="cardUi"
+        >
+          <template #header>
+            <button
+              type="button"
+              class="flex w-full items-start gap-3 text-left"
+              :aria-expanded="isExpanded(route.key)"
+              @click="toggleExpanded(route.key)"
+            >
+              <UIcon
+                :name="isExpanded(route.key) ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'"
+                class="mt-1 size-4 shrink-0 text-toned"
+              />
+
+              <div class="min-w-0 flex-1 space-y-2">
+                <div class="flex flex-wrap items-center gap-2">
+                  <UBadge
+                    :color="methodColor(route.method)"
+                    variant="soft"
+                    size="sm"
+                    class="font-mono"
+                  >
+                    {{ route.method }}
+                  </UBadge>
+
+                  <div class="min-w-0 font-mono text-sm font-semibold text-highlighted">
+                    <span class="ws-wrap-anywhere">{{ route.path }}</span>
+                  </div>
+                </div>
+
+                <p class="text-sm leading-6 text-default">{{ route.summary }}</p>
+
+                <div class="flex flex-wrap items-center gap-2 text-xs text-toned">
+                  <UBadge
+                    v-for="tag in route.tags"
+                    :key="`${route.key}-${tag}`"
+                    color="neutral"
+                    variant="outline"
+                    size="sm"
+                  >
+                    {{ tag }}
+                  </UBadge>
+
+                  <UBadge
+                    v-if="route.operationId"
+                    color="neutral"
+                    variant="outline"
+                    size="sm"
+                    icon="i-lucide-braces"
+                  >
+                    {{ route.operationId }}
+                  </UBadge>
+
+                  <UBadge
+                    v-if="route.deprecated"
+                    color="warning"
+                    variant="soft"
+                    size="sm"
+                    icon="i-lucide-triangle-alert"
+                  >
+                    Deprecated
+                  </UBadge>
+                </div>
+              </div>
+            </button>
+          </template>
+
+          <div v-if="isExpanded(route.key)" class="space-y-3">
+            <section v-if="route.parameters.length > 0" class="space-y-3">
+              <div class="inline-flex items-center gap-2 text-sm font-semibold text-highlighted">
+                <UIcon name="i-lucide-sliders-horizontal" class="size-4 text-toned" />
+                <span>Parameters</span>
+              </div>
+
+              <div class="space-y-3">
+                <div
+                  v-for="parameter in route.parameters"
+                  :key="`${route.key}-param-${parameter.key}`"
+                  class="rounded-md border border-default bg-default/70 px-3 py-3"
+                >
+                  <div class="flex flex-wrap items-center gap-2">
+                    <div class="font-mono text-sm font-semibold text-highlighted">
+                      {{ parameter.name }}
+                    </div>
+
+                    <UBadge color="neutral" variant="soft" size="sm">
+                      {{ parameter.location }}
+                    </UBadge>
+
+                    <UBadge v-if="parameter.required" color="warning" variant="soft" size="sm">
+                      Required
+                    </UBadge>
+
+                    <UBadge
+                      v-if="parameter.schemaSummary"
+                      color="neutral"
+                      variant="outline"
+                      size="sm"
+                    >
+                      {{ parameter.schemaSummary }}
+                    </UBadge>
+                  </div>
+
+                  <p v-if="parameter.description" class="mt-2 text-sm leading-6 text-default">
+                    {{ parameter.description }}
+                  </p>
+
+                  <pre
+                    v-if="shouldShowShape(parameter.schemaSummary, parameter.shape)"
+                    class="mt-3 overflow-x-auto rounded-md border border-default bg-default/70 p-3 text-xs text-toned"
+                  ><code>{{ parameter.shape }}</code></pre>
+                </div>
+              </div>
+            </section>
+
+            <section v-if="route.requestBody" class="space-y-3">
+              <div class="inline-flex items-center gap-2 text-sm font-semibold text-highlighted">
+                <UIcon name="i-lucide-arrow-up-from-line" class="size-4 text-toned" />
+                <span>Request Body</span>
+              </div>
+
+              <div class="rounded-md border border-default bg-default/70 px-3 py-3">
+                <div class="flex flex-wrap items-center gap-2">
+                  <UBadge color="neutral" variant="soft" size="sm">
+                    {{ route.requestBody.mediaType }}
+                  </UBadge>
+
+                  <UBadge
+                    v-if="route.requestBody.required"
+                    color="warning"
+                    variant="soft"
+                    size="sm"
+                  >
+                    Required
+                  </UBadge>
+
+                  <UBadge
+                    v-if="route.requestBody.schemaSummary"
+                    color="neutral"
+                    variant="outline"
+                    size="sm"
+                  >
+                    {{ route.requestBody.schemaSummary }}
+                  </UBadge>
+                </div>
+
+                <p v-if="route.requestBody.description" class="text-sm leading-6 text-default">
+                  {{ route.requestBody.description }}
+                </p>
+
+                <pre
+                  v-if="shouldShowShape(route.requestBody.schemaSummary, route.requestBody.shape)"
+                  class="overflow-x-auto rounded-md border border-default bg-default/70 p-3 text-xs text-toned"
+                ><code>{{ route.requestBody.shape }}</code></pre>
+
+                <div v-else-if="!route.requestBody.schemaSummary" class="text-sm text-toned">
+                  No request schema documented.
+                </div>
+              </div>
+            </section>
+
+            <section class="space-y-3">
+              <div class="inline-flex items-center gap-2 text-sm font-semibold text-highlighted">
+                <UIcon name="i-lucide-arrow-down-to-line" class="size-4 text-toned" />
+                <span>Responses</span>
+              </div>
+
+              <div v-if="route.responses.length > 0" class="space-y-3">
+                <div
+                  v-for="response in route.responses"
+                  :key="`${route.key}-response-${response.status}`"
+                  class="rounded-md border border-default bg-default/70 px-3 py-3"
+                >
+                  <div class="flex flex-wrap items-center gap-2">
+                    <UBadge :color="responseColor(response.status)" variant="soft" size="sm">
+                      {{ response.status }}
+                    </UBadge>
+
+                    <span class="text-sm font-medium text-highlighted">{{ response.label }}</span>
+
+                    <UBadge v-if="response.mediaType" color="neutral" variant="outline" size="sm">
+                      {{ response.mediaType }}
+                    </UBadge>
+
+                    <UBadge
+                      v-if="response.schemaSummary"
+                      color="neutral"
+                      variant="outline"
+                      size="sm"
+                    >
+                      {{ response.schemaSummary }}
+                    </UBadge>
+                  </div>
+
+                  <p v-if="response.showDescription" class="mt-2 text-sm leading-6 text-default">
+                    {{ response.description }}
+                  </p>
+
+                  <pre
+                    v-if="shouldShowShape(response.schemaSummary, response.shape)"
+                    class="mt-3 overflow-x-auto rounded-md border border-default bg-default/70 p-3 text-xs text-toned"
+                  ><code>{{ response.shape }}</code></pre>
+
+                  <div v-else-if="!response.schemaSummary" class="mt-2 text-sm text-toned">
+                    No response body documented.
+                  </div>
+                </div>
+              </div>
+
+              <div v-else class="text-sm text-toned">No responses documented.</div>
+            </section>
+          </div>
+        </UCard>
+      </div>
+    </template>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { useHead } from '#app';
+import { awaitElement, parse_api_response } from '~/utils';
+import { requireTopLevelPageShell } from '~/utils/topLevelNavigation';
+import type {
+  GenericError,
+  OpenAPIDocument,
+  OpenAPIMediaType,
+  OpenAPIOperation,
+  OpenAPIParameter,
+  OpenAPIPathItem,
+  OpenAPIReference,
+  OpenAPIRequestBody,
+  OpenAPIResponse,
+  OpenAPISchema,
+} from '~/types';
+
+type BackendKey = 'plex' | 'jellyfin' | 'emby';
+type OpenAPIMethodKey = 'get' | 'put' | 'post' | 'delete' | 'options' | 'head' | 'patch' | 'trace';
+type RouteMethod = 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH' | 'TRACE';
+type MediaTypePreference = {
+  mediaType: string;
+  content: OpenAPIMediaType;
+};
+
+type BackendItem = {
+  value: BackendKey;
+  label: string;
+  file: string;
+};
+
+type RouteParameterItem = {
+  key: string;
+  name: string;
+  location: string;
+  description: string;
+  required: boolean;
+  schemaSummary: string;
+  shape: string;
+};
+
+type RouteRequestBodyItem = {
+  description: string;
+  required: boolean;
+  mediaType: string;
+  schemaSummary: string;
+  shape: string;
+};
+
+type RouteResponseItem = {
+  status: string;
+  label: string;
+  description: string;
+  showDescription: boolean;
+  mediaType: string;
+  schemaSummary: string;
+  shape: string;
+};
+
+type RouteEntry = {
+  key: string;
+  method: RouteMethod;
+  path: string;
+  summary: string;
+  operationId: string;
+  tags: Array<string>;
+  deprecated: boolean;
+  parameters: Array<RouteParameterItem>;
+  requestBody: RouteRequestBodyItem | null;
+  responses: Array<RouteResponseItem>;
+};
+
+useHead({ title: 'Backend OpenAPI' });
+
+const pageShell = requireTopLevelPageShell('openapi');
+
+const backendItems: Array<BackendItem> = [
+  { value: 'plex', label: 'Plex', file: '/guides/openapi/plex.json' },
+  { value: 'jellyfin', label: 'Jellyfin', file: '/guides/openapi/jellyfin.json' },
+  { value: 'emby', label: 'Emby', file: '/guides/openapi/emby.json' },
+];
+
+const METHOD_KEYS: Array<{ key: OpenAPIMethodKey; label: RouteMethod }> = [
+  { key: 'get', label: 'GET' },
+  { key: 'post', label: 'POST' },
+  { key: 'put', label: 'PUT' },
+  { key: 'patch', label: 'PATCH' },
+  { key: 'delete', label: 'DELETE' },
+  { key: 'head', label: 'HEAD' },
+  { key: 'options', label: 'OPTIONS' },
+  { key: 'trace', label: 'TRACE' },
+];
+
+const MEDIA_TYPE_PREFERENCE: Array<string> = [
+  'application/json',
+  'application/json; profile="CamelCase"',
+  'application/json; profile="PascalCase"',
+  'application/*+json',
+  'text/json',
+  'application/xml',
+  'text/plain',
+  'text/html',
+];
+
+const cardUi = {
+  header: 'p-4',
+  body: 'px-4 pb-4 pt-0',
+};
+
+const selectedBackend = ref<BackendKey>('plex');
+const query = ref<string>('');
+const showFilter = ref<boolean>(false);
+const spec = ref<OpenAPIDocument | null>(null);
+const error = ref<string>('');
+const isLoading = ref<boolean>(true);
+const expandedRoutes = ref<Record<string, boolean>>({});
+
+const activeBackend = computed<BackendItem>(() => {
+  const fallback: BackendItem = backendItems[0] as BackendItem;
+
+  return backendItems.find((item) => item.value === selectedBackend.value) ?? fallback;
+});
+
+const specUrl = computed<string>(() => activeBackend.value.file);
+const specTitle = computed<string>(
+  () => spec.value?.info?.title?.trim() || activeBackend.value.label,
+);
+const specVersion = computed<string>(() => spec.value?.info?.version?.trim() || 'Unknown');
+const specMeta = computed<string>(() => {
+  const parts = [activeBackend.value.label];
+
+  if ('Unknown' !== specVersion.value) {
+    parts.push(`v${specVersion.value}`);
+  }
+
+  return parts.join(' / ');
+});
+
+const refLabel = (ref: string): string => {
+  return ref
+    .replace(/^#\/components\//, '')
+    .replace(/^schemas\//, '')
+    .replace(/^responses\//, '');
+};
+
+const isReference = (value: unknown): value is OpenAPIReference => {
+  return !!value && 'object' === typeof value && '$ref' in value && 'string' === typeof value.$ref;
+};
+
+const resolveRefValue = (ref: string): unknown => {
+  if (!ref.startsWith('#/')) {
+    return null;
+  }
+
+  const doc = spec.value;
+  if (!doc) {
+    return null;
+  }
+
+  const parts = ref.replace(/^#\//, '').split('/');
+  let current: unknown = doc;
+
+  for (const part of parts) {
+    if (!current || 'object' !== typeof current || false === part in current) {
+      return null;
+    }
+
+    current = (current as Record<string, unknown>)[part];
+  }
+
+  return current;
+};
+
+const resolveSchema = (
+  schema?: OpenAPISchema | OpenAPIReference | null,
+  visited: Set<string> = new Set(),
+): OpenAPISchema | null => {
+  if (!schema) {
+    return null;
+  }
+
+  if (!isReference(schema)) {
+    return schema;
+  }
+
+  if (visited.has(schema.$ref)) {
+    return { title: refLabel(schema.$ref) };
+  }
+
+  const nextVisited = new Set(visited);
+  nextVisited.add(schema.$ref);
+  const resolved = resolveRefValue(schema.$ref);
+
+  if (resolved && 'object' === typeof resolved) {
+    return resolveSchema(resolved as OpenAPISchema | OpenAPIReference, nextVisited);
+  }
+
+  return { title: refLabel(schema.$ref) };
+};
+
+const resolveParameter = (
+  parameter: OpenAPIParameter | OpenAPIReference,
+): OpenAPIParameter | null => {
+  if (!isReference(parameter)) {
+    return parameter;
+  }
+
+  const resolved = resolveRefValue(parameter.$ref);
+  if (resolved && 'object' === typeof resolved) {
+    return resolved as OpenAPIParameter;
+  }
+
+  return null;
+};
+
+const resolveRequestBody = (
+  requestBody?: OpenAPIRequestBody | OpenAPIReference,
+): OpenAPIRequestBody | null => {
+  if (!requestBody) {
+    return null;
+  }
+
+  if (!isReference(requestBody)) {
+    return requestBody;
+  }
+
+  const resolved = resolveRefValue(requestBody.$ref);
+  if (resolved && 'object' === typeof resolved) {
+    return resolved as OpenAPIRequestBody;
+  }
+
+  return null;
+};
+
+const resolveResponse = (response: OpenAPIResponse | OpenAPIReference): OpenAPIResponse | null => {
+  if (!isReference(response)) {
+    return response;
+  }
+
+  const resolved = resolveRefValue(response.$ref);
+  if (resolved && 'object' === typeof resolved) {
+    if (isReference(resolved)) {
+      return resolveResponse(resolved);
+    }
+
+    return resolved as OpenAPIResponse;
+  }
+
+  return null;
+};
+
+const pickMediaType = (content?: Record<string, OpenAPIMediaType>): MediaTypePreference | null => {
+  if (!content) {
+    return null;
+  }
+
+  for (const preferred of MEDIA_TYPE_PREFERENCE) {
+    if (preferred in content) {
+      const preferredContent = content[preferred];
+      if (preferredContent) {
+        return { mediaType: preferred, content: preferredContent };
+      }
+    }
+
+    if ('application/*+json' === preferred) {
+      const match = Object.entries(content).find(([mediaType]) => mediaType.includes('+json'));
+      if (match) {
+        return { mediaType: match[0], content: match[1] };
+      }
+    }
+  }
+
+  const first = Object.entries(content)[0];
+  if (!first) {
+    return null;
+  }
+
+  return { mediaType: first[0], content: first[1] };
+};
+
+const compactDescription = (value?: string): string => {
+  return value?.replace(/\s+/g, ' ').trim() || '';
+};
+
+const schemaTypeLabel = (schema?: OpenAPISchema | OpenAPIReference | null): string => {
+  if (!schema) {
+    return '';
+  }
+
+  if (isReference(schema)) {
+    return refLabel(schema.$ref);
+  }
+
+  if (schema.allOf && schema.allOf.length > 0) {
+    const labels = schema.allOf
+      .map((item) => schemaTypeLabel(item))
+      .filter((item) => item.length > 0);
+    if (labels.length > 0) {
+      return labels.join(' & ');
+    }
+  }
+
+  if (schema.oneOf && schema.oneOf.length > 0) {
+    return schema.oneOf
+      .map((item) => schemaTypeLabel(item))
+      .filter((item) => item.length > 0)
+      .join(' | ');
+  }
+
+  if (schema.anyOf && schema.anyOf.length > 0) {
+    return schema.anyOf
+      .map((item) => schemaTypeLabel(item))
+      .filter((item) => item.length > 0)
+      .join(' | ');
+  }
+
+  if ('array' === schema.type) {
+    return `array<${schemaTypeLabel(schema.items) || 'unknown'}>`;
+  }
+
+  if (schema.enum && schema.enum.length > 0) {
+    const base = schema.enum.map((item) => String(item)).join(' | ');
+    return true === schema.nullable ? `${base} | null` : base;
+  }
+
+  const label = schema.format
+    ? `${schema.type || 'value'} (${schema.format})`
+    : schema.type || schema.title || 'object';
+
+  return true === schema.nullable ? `${label} | null` : label;
+};
+
+const mergeAllOfSchema = (schema: OpenAPISchema): OpenAPISchema => {
+  if (!schema.allOf || schema.allOf.length < 1) {
+    return schema;
+  }
+
+  const merged: OpenAPISchema = {
+    ...schema,
+    properties: { ...(schema.properties ?? {}) },
+    required: [...(schema.required ?? [])],
+  };
+
+  for (const part of schema.allOf) {
+    const resolved = resolveSchema(part);
+    if (!resolved) {
+      continue;
+    }
+
+    const normalized = mergeAllOfSchema(resolved);
+    merged.properties = {
+      ...(merged.properties ?? {}),
+      ...(normalized.properties ?? {}),
+    };
+    merged.required = Array.from(
+      new Set([...(merged.required ?? []), ...(normalized.required ?? [])]),
+    );
+
+    if (!merged.type && normalized.type) {
+      merged.type = normalized.type;
+    }
+
+    if (!merged.additionalProperties && undefined !== normalized.additionalProperties) {
+      merged.additionalProperties = normalized.additionalProperties;
+    }
+  }
+
+  return merged;
+};
+
+const schemaShape = (
+  schema?: OpenAPISchema | OpenAPIReference | null,
+  depth: number = 0,
+  seen: Set<string> = new Set(),
+): string => {
+  if (!schema) {
+    return '';
+  }
+
+  if (isReference(schema)) {
+    const name = refLabel(schema.$ref);
+
+    if (seen.has(schema.$ref) || depth > 3) {
+      return name;
+    }
+
+    const resolved = resolveSchema(schema, seen);
+
+    if (!resolved) {
+      return name;
+    }
+
+    const nextSeen = new Set(seen);
+    nextSeen.add(schema.$ref);
+    const nested = schemaShape(resolved, depth + 1, nextSeen);
+    return nested ? `${name} ${nested}` : name;
+  }
+
+  const normalized = mergeAllOfSchema(schema);
+
+  if (normalized.oneOf && normalized.oneOf.length > 0) {
+    return normalized.oneOf.map((item) => schemaTypeLabel(item)).join(' | ');
+  }
+
+  if (normalized.anyOf && normalized.anyOf.length > 0) {
+    return normalized.anyOf.map((item) => schemaTypeLabel(item)).join(' | ');
+  }
+
+  if ('array' === normalized.type) {
+    return `[${schemaShape(normalized.items, depth + 1, seen) || schemaTypeLabel(normalized.items) || 'unknown'}]`;
+  }
+
+  if (normalized.properties && Object.keys(normalized.properties).length > 0) {
+    const indent = '  '.repeat(depth);
+    const innerIndent = '  '.repeat(depth + 1);
+    const lines = Object.entries(normalized.properties)
+      .slice(0, 8)
+      .map(([key, value]) => {
+        const required = normalized.required?.includes(key) ? '' : '?';
+        const rendered = schemaShape(value, depth + 1, seen) || schemaTypeLabel(value) || 'unknown';
+        return `${innerIndent}${key}${required}: ${rendered}`;
+      });
+
+    if (Object.keys(normalized.properties).length > 8) {
+      lines.push(`${innerIndent}...`);
+    }
+
+    return ['{', ...lines, `${indent}}`].join('\n');
+  }
+
+  if ('object' === normalized.type && normalized.additionalProperties) {
+    if (true === normalized.additionalProperties) {
+      return 'Record<string, unknown>';
+    }
+
+    return `Record<string, ${schemaTypeLabel(normalized.additionalProperties) || 'unknown'}>`;
+  }
+
+  if (normalized.example) {
+    return JSON.stringify(normalized.example, null, 2);
+  }
+
+  return schemaTypeLabel(normalized);
+};
+
+const summarizeParameter = (
+  routeKey: string,
+  parameter: OpenAPIParameter | OpenAPIReference,
+  index: number,
+): RouteParameterItem | null => {
+  const resolved = resolveParameter(parameter);
+  if (!resolved) {
+    return null;
+  }
+
+  const schema = resolveSchema(resolved.schema);
+
+  return {
+    key: `${routeKey}-${resolved.in ?? 'unknown'}-${resolved.name ?? index}`,
+    name: resolved.name ?? `parameter_${index + 1}`,
+    location: resolved.in ?? 'unknown',
+    description: compactDescription(resolved.description),
+    required: true === resolved.required,
+    schemaSummary: schemaTypeLabel(resolved.schema ?? schema),
+    shape: schemaShape(schema ?? resolved.schema),
+  };
+};
+
+const summarizeRequestBody = (
+  requestBody?: OpenAPIRequestBody | OpenAPIReference,
+): RouteRequestBodyItem | null => {
+  const resolved = resolveRequestBody(requestBody);
+  if (!resolved) {
+    return null;
+  }
+
+  const media = pickMediaType(resolved.content);
+  if (!media) {
+    return {
+      description: compactDescription(resolved.description),
+      required: true === resolved.required,
+      mediaType: 'none',
+      schemaSummary: '',
+      shape: '',
+    };
+  }
+
+  const schema = resolveSchema(media.content.schema);
+
+  return {
+    description: compactDescription(resolved.description),
+    required: true === resolved.required,
+    mediaType: media.mediaType,
+    schemaSummary: schemaTypeLabel(media.content.schema ?? schema),
+    shape: schemaShape(schema ?? media.content.schema),
+  };
+};
+
+const summarizeResponse = (
+  status: string,
+  response: OpenAPIResponse | OpenAPIReference,
+): RouteResponseItem | null => {
+  const resolved = resolveResponse(response);
+  if (!resolved) {
+    return null;
+  }
+
+  const media = pickMediaType(resolved.content);
+  const schema = resolveSchema(media?.content.schema);
+  const description = compactDescription(resolved.description);
+  const label = description || 'Response';
+
+  return {
+    status,
+    label,
+    description,
+    showDescription: false,
+    mediaType: media?.mediaType ?? '',
+    schemaSummary: schemaTypeLabel(media?.content.schema ?? schema),
+    shape: schemaShape(schema ?? media?.content.schema),
+  };
+};
+
+const buildSummary = (pathItem: OpenAPIPathItem, operation: OpenAPIOperation): string => {
+  const candidates = [
+    operation.summary,
+    pathItem.summary,
+    operation.description,
+    pathItem.description,
+  ];
+
+  for (const candidate of candidates) {
+    const text = compactDescription(candidate);
+    if (text) {
+      return text;
+    }
+  }
+
+  return 'No summary provided.';
+};
+
+const routeEntries = computed<Array<RouteEntry>>(() => {
+  const paths = spec.value?.paths ?? {};
+
+  return Object.entries(paths)
+    .flatMap(([path, pathItem]): Array<RouteEntry> => {
+      return METHOD_KEYS.flatMap(({ key, label }): Array<RouteEntry> => {
+        const operation = pathItem[key];
+        if (!operation) {
+          return [];
+        }
+
+        const routeKey = `${label}:${path}`;
+        const parameters = [...(pathItem.parameters ?? []), ...(operation.parameters ?? [])]
+          .map((parameter, index) => summarizeParameter(routeKey, parameter, index))
+          .filter((item): item is RouteParameterItem => null !== item);
+
+        const responses = Object.entries(operation.responses ?? {})
+          .map(([status, response]) => summarizeResponse(status, response))
+          .filter((item): item is RouteResponseItem => null !== item)
+          .sort((left, right) =>
+            left.status.localeCompare(right.status, undefined, { numeric: true }),
+          );
+
+        return [
+          {
+            key: routeKey,
+            method: label,
+            path,
+            summary: buildSummary(pathItem, operation),
+            operationId: operation.operationId?.trim() || '',
+            tags: Array.isArray(operation.tags)
+              ? operation.tags.filter((tag) => tag.trim().length > 0)
+              : [],
+            deprecated: true === operation.deprecated,
+            parameters,
+            requestBody: summarizeRequestBody(operation.requestBody),
+            responses,
+          },
+        ];
+      });
+    })
+    .sort((left, right) => {
+      if (left.path === right.path) {
+        return left.method.localeCompare(right.method);
+      }
+
+      return left.path.localeCompare(right.path);
+    });
+});
+
+const filteredRoutes = computed<Array<RouteEntry>>(() => {
+  const search = query.value.trim().toLowerCase();
+
+  if (!search) {
+    return routeEntries.value;
+  }
+
+  return routeEntries.value.filter((entry) => {
+    const values = [
+      entry.method,
+      entry.path,
+      entry.summary,
+      entry.operationId,
+      ...entry.tags,
+      ...entry.parameters.map(
+        (item) => `${item.name} ${item.location} ${item.description} ${item.shape}`,
+      ),
+      ...(entry.requestBody
+        ? [
+            `${entry.requestBody.description} ${entry.requestBody.mediaType} ${entry.requestBody.shape} ${entry.requestBody.schemaSummary}`,
+          ]
+        : []),
+      ...entry.responses.map(
+        (item) =>
+          `${item.status} ${item.description} ${item.mediaType} ${item.shape} ${item.schemaSummary}`,
+      ),
+    ];
+
+    return values.some((value) => value.toLowerCase().includes(search));
+  });
+});
+
+const toggleFilter = (): void => {
+  showFilter.value = !showFilter.value;
+
+  if (!showFilter.value) {
+    query.value = '';
+    return;
+  }
+
+  awaitElement('#filter', (_, elm) => (elm as HTMLInputElement).focus());
+};
+
+const isExpanded = (key: string): boolean => {
+  return true === expandedRoutes.value[key];
+};
+
+const toggleExpanded = (key: string): void => {
+  expandedRoutes.value = {
+    ...expandedRoutes.value,
+    [key]: !isExpanded(key),
+  };
+};
+
+const shouldShowShape = (summary: string, shape: string): boolean => {
+  if (!shape) {
+    return false;
+  }
+
+  const normalizedSummary = summary.trim();
+  const normalizedShape = shape.trim();
+
+  if (!normalizedSummary) {
+    return true;
+  }
+
+  return normalizedSummary !== normalizedShape;
+};
+
+const loadSpec = async (): Promise<void> => {
+  try {
+    isLoading.value = true;
+    error.value = '';
+    spec.value = null;
+    expandedRoutes.value = {};
+
+    const response = await fetch(`${specUrl.value}?_=${Date.now()}`);
+    if (!response.ok) {
+      const err = await parse_api_response<GenericError>(response);
+      error.value = `${err.error.code}: ${err.error.message}`;
+      return;
+    }
+
+    spec.value = (await response.json()) as OpenAPIDocument;
+  } catch (caughtError) {
+    error.value = caughtError instanceof Error ? caughtError.message : 'Unexpected error';
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+const methodColor = (
+  method: RouteMethod,
+): 'primary' | 'success' | 'warning' | 'error' | 'neutral' => {
+  switch (method) {
+    case 'GET':
+      return 'primary';
+    case 'POST':
+      return 'success';
+    case 'PUT':
+    case 'PATCH':
+      return 'warning';
+    case 'DELETE':
+      return 'error';
+    default:
+      return 'neutral';
+  }
+};
+
+const responseColor = (status: string): 'success' | 'warning' | 'error' | 'neutral' => {
+  const code = Number.parseInt(status, 10);
+
+  if (!Number.isFinite(code)) {
+    return 'neutral';
+  }
+
+  if (code >= 200 && code < 300) {
+    return 'success';
+  }
+
+  if (code >= 300 && code < 500) {
+    return 'warning';
+  }
+
+  if (code >= 500) {
+    return 'error';
+  }
+
+  return 'neutral';
+};
+
+watch(selectedBackend, async () => await loadSpec(), { immediate: true });
+</script>

--- a/frontend/app/pages/history/[id]/index.vue
+++ b/frontend/app/pages/history/[id]/index.vue
@@ -684,6 +684,15 @@
                               : 'text-error',
                         ]"
                       />
+                      <UTooltip :text="Number(item.watched) ? 'Played' : 'Unplayed'">
+                        <UIcon
+                          :name="Number(item.watched) ? 'i-lucide-eye' : 'i-lucide-eye-off'"
+                          :class="[
+                            'size-4 shrink-0',
+                            Number(item.watched) ? 'text-success' : 'text-toned',
+                          ]"
+                        />
+                      </UTooltip>
                       <span>Metadata via</span>
                       <NuxtLink
                         :to="`/backend/${key}`"

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -266,25 +266,29 @@
                   v-for="(item, index) in log.lines"
                   :key="`${log.filename}-${index}`"
                   class="block"
-                  ><template v-if="item?.date"
-                    >[<UTooltip :text="`${moment(item.date).format(TOOLTIP_DATE_FORMAT)}`">
-                      <span class="cursor-help">{{
-                        moment(item.date).format('HH:mm:ss')
-                      }}</span> </UTooltip
-                    >]
-                  </template>
-
-                  <template v-if="item?.item_id">
+                  ><span
+                    v-if="item?.date || item?.item_id"
+                    class="mr-[1ch] inline-flex items-baseline whitespace-normal"
+                  >
+                    <template v-if="item?.date"
+                      >[<UTooltip :text="`${moment(item.date).format(TOOLTIP_DATE_FORMAT)}`">
+                        <span class="cursor-help">{{
+                          moment(item.date).format('HH:mm:ss')
+                        }}</span> </UTooltip
+                      >]</template
+                    >
                     <button
+                      v-if="item?.item_id"
                       type="button"
-                      class="inline-flex cursor-pointer items-center gap-1 text-inherit"
+                      :class="[
+                        'cursor-pointer font-[inherit] leading-[inherit] text-primary underline-offset-2 hover:underline',
+                        item?.date ? 'ml-[1ch]' : '',
+                      ]"
                       @click="goto_history_item(item)"
                     >
-                      <UIcon name="i-lucide-history" class="size-4" />
-                      <span>View</span></button
-                    >&nbsp;
-                  </template>
-
+                      View
+                    </button>
+                  </span>
                   <span>{{ String(item.text).trim() }}</span>
                 </span>
               </code>

--- a/frontend/app/pages/logs/[filename].vue
+++ b/frontend/app/pages/logs/[filename].vue
@@ -171,7 +171,10 @@
 
         <div v-else ref="logContainer" class="logbox" @scroll.passive="handleScroll">
           <code id="logView" class="logline block">
-            <span v-for="item in filterItems" :key="item.id" class="log-entry block"
+            <span
+              v-for="item in filterItems"
+              :key="item.id"
+              :class="['log-entry block', wrapLines ? '' : 'whitespace-nowrap']"
               ><template v-if="item.date"
                 >[<span class="cursor-help" :title="item.date">{{ formatDate(item.date) }}</span
                 >]:&nbsp;</template

--- a/frontend/app/types/index.d.ts
+++ b/frontend/app/types/index.d.ts
@@ -1228,3 +1228,147 @@ export interface FileDiffResult {
   /** Reference path segments showing common vs different parts */
   referenceSegments: Array<FileDiffPathSegment>;
 }
+
+/**
+ * OpenAPI local reference.
+ */
+export interface OpenAPIReference {
+  $ref: string;
+}
+
+/**
+ * OpenAPI example payload.
+ */
+export interface OpenAPIExample {
+  summary?: string;
+  description?: string;
+  value?: JsonValue | string;
+}
+
+/**
+ * OpenAPI schema object used by the help route browser.
+ */
+export interface OpenAPISchema {
+  title?: string;
+  type?: string;
+  format?: string;
+  description?: string;
+  nullable?: boolean;
+  enum?: Array<JsonPrimitive>;
+  properties?: Record<string, OpenAPISchema | OpenAPIReference>;
+  required?: Array<string>;
+  items?: OpenAPISchema | OpenAPIReference;
+  allOf?: Array<OpenAPISchema | OpenAPIReference>;
+  oneOf?: Array<OpenAPISchema | OpenAPIReference>;
+  anyOf?: Array<OpenAPISchema | OpenAPIReference>;
+  additionalProperties?: boolean | OpenAPISchema | OpenAPIReference;
+  example?: JsonValue | string;
+}
+
+/**
+ * OpenAPI media content definition.
+ */
+export interface OpenAPIMediaType {
+  schema?: OpenAPISchema | OpenAPIReference;
+  example?: JsonValue | string;
+  examples?: Record<string, OpenAPIExample>;
+}
+
+/**
+ * OpenAPI parameter definition.
+ */
+export interface OpenAPIParameter {
+  name?: string;
+  in?: string;
+  description?: string;
+  required?: boolean;
+  deprecated?: boolean;
+  schema?: OpenAPISchema | OpenAPIReference;
+  style?: string;
+  explode?: boolean;
+  example?: JsonValue | string;
+  examples?: Record<string, OpenAPIExample>;
+}
+
+/**
+ * OpenAPI request body definition.
+ */
+export interface OpenAPIRequestBody {
+  description?: string;
+  required?: boolean;
+  content?: Record<string, OpenAPIMediaType>;
+}
+
+/**
+ * OpenAPI header definition.
+ */
+export interface OpenAPIHeader {
+  description?: string;
+  required?: boolean;
+  schema?: OpenAPISchema | OpenAPIReference;
+}
+
+/**
+ * OpenAPI response definition.
+ */
+export interface OpenAPIResponse {
+  description?: string;
+  headers?: Record<string, OpenAPIHeader | OpenAPIReference>;
+  content?: Record<string, OpenAPIMediaType>;
+}
+
+/**
+ * OpenAPI components used by the local spec browser.
+ */
+export interface OpenAPIComponents {
+  schemas?: Record<string, OpenAPISchema>;
+  responses?: Record<string, OpenAPIResponse | OpenAPIReference>;
+  parameters?: Record<string, OpenAPIParameter | OpenAPIReference>;
+  requestBodies?: Record<string, OpenAPIRequestBody | OpenAPIReference>;
+  headers?: Record<string, OpenAPIHeader | OpenAPIReference>;
+}
+
+/**
+ * OpenAPI document used by the help route browser.
+ */
+export interface OpenAPIDocument {
+  openapi: string;
+  info: {
+    title: string;
+    version?: string;
+    description?: string;
+  };
+  paths?: Record<string, OpenAPIPathItem>;
+  components?: OpenAPIComponents;
+}
+
+/**
+ * OpenAPI operation shape used for listing backend routes.
+ */
+export interface OpenAPIOperation {
+  summary?: string;
+  description?: string;
+  operationId?: string;
+  tags?: Array<string>;
+  deprecated?: boolean;
+  parameters?: Array<OpenAPIParameter | OpenAPIReference>;
+  requestBody?: OpenAPIRequestBody | OpenAPIReference;
+  responses?: Record<string, OpenAPIResponse | OpenAPIReference>;
+}
+
+/**
+ * OpenAPI path item shape used for listing methods per route.
+ */
+export interface OpenAPIPathItem {
+  summary?: string;
+  description?: string;
+  parameters?: Array<OpenAPIParameter | OpenAPIReference>;
+  get?: OpenAPIOperation;
+  put?: OpenAPIOperation;
+  post?: OpenAPIOperation;
+  delete?: OpenAPIOperation;
+  options?: OpenAPIOperation;
+  head?: OpenAPIOperation;
+  patch?: OpenAPIOperation;
+  trace?: OpenAPIOperation;
+}

--- a/frontend/app/types/index.d.ts
+++ b/frontend/app/types/index.d.ts
@@ -390,7 +390,7 @@ export interface EventsItem {
   /** Event data payload (optional) */
   event_data?: JsonObject;
   /** Event logs array (optional) */
-  logs?: Array<string>;
+  logs?: Array<LogEntry>;
   /** Event options (optional) */
   options?: JsonObject;
   /** Display toggle for event data (UI state) */

--- a/frontend/app/utils/topLevelNavigation.ts
+++ b/frontend/app/utils/topLevelNavigation.ts
@@ -32,6 +32,7 @@ type TopLevelEntryId =
   | 'reset'
   | 'help'
   | 'api'
+  | 'openapi'
   | 'readme'
   | 'faq'
   | 'news'
@@ -59,6 +60,8 @@ type TopLevelNavigationDefinition = {
   href?: string;
   target?: string;
   matchPath?: string;
+  exactMatch?: boolean;
+  excludeMatchPaths?: Array<string>;
   visible?: (context: TopLevelNavigationContext) => boolean;
 };
 
@@ -306,6 +309,7 @@ const TOP_LEVEL_NAVIGATION: Array<TopLevelNavigationDefinition> = [
     icon: 'i-lucide-circle-help',
     to: '/help',
     matchPath: '/help',
+    excludeMatchPaths: ['/help/api', '/help/openapi', '/help/readme', '/help/faq', '/help/news'],
   },
   {
     id: 'api',
@@ -316,6 +320,16 @@ const TOP_LEVEL_NAVIGATION: Array<TopLevelNavigationDefinition> = [
     icon: 'i-lucide-book-open',
     to: '/help/api',
     matchPath: '/help/api',
+  },
+  {
+    id: 'openapi',
+    section: 'help',
+    label: 'OpenAPI',
+    pageLabel: 'OpenAPI',
+    breadcrumbSectionLabel: 'Help',
+    icon: 'i-lucide-braces',
+    to: '/help/openapi',
+    matchPath: '/help/openapi',
   },
   {
     id: 'readme',

--- a/src/API/Logs/Index.php
+++ b/src/API/Logs/Index.php
@@ -346,8 +346,14 @@ final class Index
      * @return array
      * @throws RandomException
      */
-    public static function formatLog(string $line, array $users = []): array
+    public static function formatLog(mixed $line, array $users = []): array
     {
+        if (!is_string($line)) {
+            $line = json_encode($line);
+        }
+
+        $line ??= '';
+
         if (empty($line)) {
             return [
                 'id' => md5((string) (hrtime(true) + random_int(1, 10_000))),
@@ -378,7 +384,7 @@ final class Index
             $logLine['item_id'] = $idMatches['item_id'];
         }
 
-        if (1 === $identMatch && in_array($identMatches['user'], $users, true)) {
+        if (1 === $identMatch && ([] === $users || in_array($identMatches['user'], $users, true))) {
             $logLine['user'] = $identMatches['user'];
             $logLine['backend'] = $identMatches['backend'];
         }

--- a/src/API/System/Events.php
+++ b/src/API/System/Events.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\API\System;
 
+use App\API\Logs\Index as LogsIndex;
 use App\Libs\Attributes\Route\Delete;
 use App\Libs\Attributes\Route\Get;
 use App\Libs\Attributes\Route\Patch;
@@ -234,6 +235,10 @@ final readonly class Events
     {
         $data = $entity->getAll();
         $data['status_name'] = $entity->getStatusText();
+
+        if (is_array($entity->logs) && count($entity->logs) > 0) {
+            $data['logs'] = array_map(LogsIndex::formatLog(...), $entity->logs);
+        }
 
         if ($delay = ag($entity->options, Options::DELAY_BY)) {
             $data['delay_by'] = $delay;

--- a/src/Backends/Plex/PlexClient.php
+++ b/src/Backends/Plex/PlexClient.php
@@ -105,6 +105,8 @@ class PlexClient implements iClient
         'com.plexapp.agents.cmdb',
         'tv.plex.agents.movie',
         'tv.plex.agents.series',
+        'tv.plex.agents.nfo.movie',
+        'tv.plex.agents.nfo.series',
     ];
 
     /**

--- a/src/Backends/Plex/PlexGuid.php
+++ b/src/Backends/Plex/PlexGuid.php
@@ -46,6 +46,14 @@ final class PlexGuid implements iGuid
     ];
 
     /**
+     * @var array<array-key,string> List of native plex NFO agents.
+     */
+    private array $guidNfo = [
+        'tv.plex.agents.nfo.movie',
+        'tv.plex.agents.nfo.series',
+    ];
+
+    /**
      * @var array<array-key,string> List of local plex agents.
      */
     private array $guidLocal = [
@@ -359,6 +367,10 @@ final class PlexGuid implements iGuid
                     $val = $this->parseLegacyAgent(guid: $val, context: $context, log: $log);
                 }
 
+                if (true === str_starts_with($val, 'tv.plex.agents.nfo.')) {
+                    $val = $this->parseNfoAgent(guid: $val, context: $context, log: $log);
+                }
+
                 if (false === str_contains($val, '://')) {
                     if (true === $log) {
                         $this->logger->info("PlexGuid: Unable to parse '{backend}: {agent}' identifier.", [
@@ -398,6 +410,10 @@ final class PlexGuid implements iGuid
 
                 // -- Plex in their infinite wisdom, sometimes report two keys for same data source.
                 if (null !== ($guid[$this->guidMapper[$key]] ?? null)) {
+                    if ($guid[$this->guidMapper[$key]] === $value) {
+                        continue;
+                    }
+
                     if (true === $log) {
                         $this->logger->warning(
                             "PlexGuid: '{client}: {backend}' reported multiple ids for same data source '{key}: {ids}' for {item.type} '{item.id}: {item.title}'.",
@@ -515,6 +531,74 @@ final class PlexGuid implements iGuid
     }
 
     /**
+     * Parse native Plex NFO agents.
+     *
+     * Typed NFO GUIDs include the source in the last path segment, such as
+     * `tv.plex.agents.nfo.movie://movie/tmdb_383498`. We normalize those to the
+     * same `<source>://<id>` format the rest of the parser already understands.
+     * Fallback NFO ids like `...://movie/858024` do not identify the source and
+     * are intentionally left untouched.
+     *
+     * @param string $guid Guid to parse.
+     * @param array $context Context data.
+     * @param bool $log Log errors. default true.
+     *
+     * @return string The parsed GUID.
+     */
+    private function parseNfoAgent(string $guid, array $context = [], bool $log = true): string
+    {
+        if (false === in_array(before($guid, '://'), $this->guidNfo, true)) {
+            return $guid;
+        }
+
+        try {
+            $payload = after($guid, '://');
+            $token = trim((string) basename($payload));
+
+            if ('' === $token || false === str_contains($token, '_')) {
+                return $guid;
+            }
+
+            [$source, $sourceId] = explode('_', $token, 2);
+            $source = strtolower(trim($source));
+            $sourceId = trim($sourceId);
+
+            if ('' === $source || '' === $sourceId || null === ($this->guidMapper[$source] ?? null)) {
+                return $guid;
+            }
+
+            return $source . '://' . before($sourceId, '?');
+        } catch (Throwable $e) {
+            if (true === $log) {
+                $this->logger->error(
+                    message: "PlexGuid: Exception '{error.kind}' was thrown unhandled during '{client}: {backend}' parsing NFO agent '{agent}' identifier. Error '{error.message}' at '{error.file}:{error.line}.",
+                    context: [
+                        'backend' => $this->context->backendName,
+                        'client' => $this->context->clientName,
+                        'error' => [
+                            'kind' => $e::class,
+                            'line' => $e->getLine(),
+                            'message' => $e->getMessage(),
+                            'file' => after($e->getFile(), ROOT_PATH),
+                        ],
+                        'agent' => $guid,
+                        'exception' => [
+                            'file' => $e->getFile(),
+                            'line' => $e->getLine(),
+                            'kind' => get_class($e),
+                            'message' => $e->getMessage(),
+                            'trace' => $e->getTrace(),
+                        ],
+                        ...$context,
+                    ],
+                );
+            }
+
+            return $guid;
+        }
+    }
+
+    /**
      * Get the Plex Guid configuration.
      *
      * @return array
@@ -524,6 +608,7 @@ final class PlexGuid implements iGuid
         return [
             'guidMapper' => $this->guidMapper,
             'guidLegacy' => $this->guidLegacy,
+            'guidNfo' => $this->guidNfo,
             'guidLocal' => $this->guidLocal,
             'guidReplacer' => $this->guidReplacer,
         ];

--- a/src/Commands/State/ImportCommand.php
+++ b/src/Commands/State/ImportCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Commands\State;
 
+use App\Backends\Common\ClientInterface as iClient;
 use App\Backends\Common\Request;
 use App\Command;
 use App\Libs\Attributes\DI\Inject;
@@ -191,9 +192,7 @@ class ImportCommand extends Command
 
         $this->mapper->setOptions($mapperOpts);
 
-        $users = get_users_context(mapper: $this->mapper, logger: $this->logger, opts: [
-            DatabaseInterface::class => $dbOpts,
-        ]);
+        $users = $this->getUsers($dbOpts);
 
         if (null !== ($user = $input->getOption('user'))) {
             $users = array_filter($users, static fn($k) => $k === $user, mode: ARRAY_FILTER_USE_KEY);
@@ -373,9 +372,7 @@ class ImportCommand extends Command
                 }
 
                 $backend['options'] = $opts;
-                $backend['class'] = make_backend(backend: $backend, name: $name, options: [
-                    UserContext::class => $userContext,
-                ]);
+                $backend['class'] = $this->makeBackend($backend, $name, $userContext);
 
                 if (null !== $after) {
                     $after = make_date($after);
@@ -420,24 +417,11 @@ class ImportCommand extends Command
                 ],
             ]);
 
-            $dbLayer = $userContext->db->getDBLayer();
-            $startedTransaction = false;
-
             try {
-                if (false === $dbLayer->inTransaction()) {
-                    $startedTransaction = $dbLayer->start();
-                }
-
-                send_requests(requests: $queue, client: $this->http, sync: $syncRequests, logger: $this->logger);
-
-                if (true === $startedTransaction && true === $dbLayer->inTransaction()) {
-                    $dbLayer->commit();
-                }
+                $userContext->db->transactional(function () use ($queue, $syncRequests): void {
+                    $this->sendRequests($queue, $syncRequests);
+                });
             } catch (Throwable $e) {
-                if (true === $startedTransaction && true === $dbLayer->inTransaction()) {
-                    $dbLayer->rollBack();
-                }
-
                 $this->logger->error(
                     ...lw(
                         message: "SYSTEM: Import requests for '{user}' backends failed. '{error.kind}' with message '{error.message}' at '{error.file}:{error.line}'.",
@@ -547,6 +531,36 @@ class ImportCommand extends Command
         ]);
 
         return self::SUCCESS;
+    }
+
+    /**
+     * @param array<string,mixed> $dbOpts
+     *
+     * @return array<string,UserContext>
+     */
+    protected function getUsers(array $dbOpts = []): array
+    {
+        return get_users_context(mapper: $this->mapper, logger: $this->logger, opts: [
+            DatabaseInterface::class => $dbOpts,
+        ]);
+    }
+
+    /**
+     * @param array<string,mixed> $backend
+     */
+    protected function makeBackend(array $backend, string $name, UserContext $userContext): iClient
+    {
+        return make_backend(backend: $backend, name: $name, options: [
+            UserContext::class => $userContext,
+        ]);
+    }
+
+    /**
+     * @param array<int,Request> $queue
+     */
+    protected function sendRequests(array $queue, bool $syncRequests): void
+    {
+        send_requests(requests: $queue, client: $this->http, sync: $syncRequests, logger: $this->logger);
     }
 
     private function in_array(array $list, string $search): bool

--- a/src/Libs/Database/DBLayer.php
+++ b/src/Libs/Database/DBLayer.php
@@ -137,12 +137,21 @@ final class DBLayer implements LoggerAwareInterface
 
             $stmt = $isStatement ? $sql : $db->prepare($sql);
 
+            if (true === $isStatement) {
+                $stmt->execute($bind);
+                return $stmt;
+            }
+
             if (!empty($bind)) {
-                array_map(
-                    static fn($k, $v) => $stmt->bindValue($k, $v, is_int($v) ? PDO::PARAM_INT : PDO::PARAM_STR),
-                    array_keys($bind),
-                    $bind,
-                );
+                foreach ($bind as $key => $value) {
+                    $type = match (true) {
+                        null === $value => PDO::PARAM_NULL,
+                        is_int($value) => PDO::PARAM_INT,
+                        default => PDO::PARAM_STR,
+                    };
+
+                    $stmt->bindValue($key, $value, $type);
+                }
             }
 
             $stmt->execute();

--- a/src/Libs/Database/PDO/PDOAdapter.php
+++ b/src/Libs/Database/PDO/PDOAdapter.php
@@ -207,13 +207,12 @@ final class PDOAdapter implements iDB
             }
 
             $this->db->query($this->stmt['insert'], $data, options: [
-                'on_failure' => function (Throwable $e) use ($entity) {
-                    if (false === str_contains($e->getMessage(), '21 bad parameter or other API misuse')) {
-                        throw $e;
-                    }
-                    $this->stmt['insert'] = null;
-                    return $this->insert($entity);
-                },
+                'on_failure' => fn(Throwable $e) => $this->retryPreparedWrite(
+                    key: 'insert',
+                    sql: $this->pdoInsert('state', iState::ENTITY_KEYS),
+                    data: $data,
+                    e: $e,
+                ),
             ]);
 
             $entity->id = (int) $this->db->lastInsertId();
@@ -432,13 +431,12 @@ final class PDOAdapter implements iDB
             }
 
             $this->db->query($this->stmt['update'], $data, options: [
-                'on_failure' => function (Throwable $e) use ($entity) {
-                    if (false === str_contains($e->getMessage(), '21 bad parameter or other API misuse')) {
-                        throw $e;
-                    }
-                    $this->stmt['update'] = null;
-                    return $this->update($entity);
-                },
+                'on_failure' => fn(Throwable $e) => $this->retryPreparedWrite(
+                    key: 'update',
+                    sql: $this->pdoUpdate('state', iState::ENTITY_KEYS),
+                    data: $data,
+                    e: $e,
+                ),
             ]);
         } catch (PDOException $e) {
             $this->stmt['update'] = null;
@@ -808,6 +806,26 @@ final class PDOAdapter implements iDB
         }
 
         return trim(str_replace('{place} = {holder}', implode(', ', $placeholders), $queryString));
+    }
+
+    /**
+     * Retry a cached write statement once when sqlite reports prepared statement misuse.
+     *
+     * @param string $key Cached statement key.
+     * @param string $sql SQL statement to prepare.
+     * @param array $data Bound statement values.
+     * @param Throwable $e Triggering exception.
+     */
+    private function retryPreparedWrite(string $key, string $sql, array $data, Throwable $e): PDOStatement
+    {
+        if (false === str_contains($e->getMessage(), '21 bad parameter or other API misuse')) {
+            throw $e;
+        }
+
+        $statement = $this->db->prepare($sql);
+        $this->stmt[$key] = $statement;
+
+        return $this->db->query($statement, $data);
     }
 
     /**

--- a/src/Libs/ServeStatic.php
+++ b/src/Libs/ServeStatic.php
@@ -35,16 +35,17 @@ final class ServeStatic implements LoggerAwareInterface
      * @var array<string, string> These files are served from outside the public directory.
      */
     private const array FILES = [
-        '/CHANGELOG.json' => __DIR__ . '/../../frontend/exported/CHANGELOG.json',
         '/API.md' => __DIR__ . '/../../API.md',
         '/README.md' => __DIR__ . '/../../README.md',
         '/NEWS.md' => __DIR__ . '/../../NEWS.md',
         '/FAQ.md' => __DIR__ . '/../../FAQ.md',
-        '/CHANGELOG.md' => __DIR__ . '/../../CHANGELOG.md',
         '/guides/API.md' => __DIR__ . '/../../API.md',
         '/guides/README.md' => __DIR__ . '/../../README.md',
         '/guides/NEWS.md' => __DIR__ . '/../../NEWS.md',
         '/guides/FAQ.md' => __DIR__ . '/../../FAQ.md',
+        '/guides/openapi/plex.json' => __DIR__ . '/../Backends/Plex/plex-openai-stable.json',
+        '/guides/openapi/jellyfin.json' => __DIR__ . '/../Backends/Jellyfin/jellyfin-openapi-stable.json',
+        '/guides/openapi/emby.json' => __DIR__ . '/../Backends/Emby/emby-openapi-stable.json',
     ];
 
     private const array MD_IMAGES = [

--- a/tests/API/Logs/IndexTest.php
+++ b/tests/API/Logs/IndexTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\API\Logs;
+
+use App\API\Logs\Index;
+use App\Libs\TestCase;
+
+final class IndexTest extends TestCase
+{
+    public function test_formatLog_extracts_context_without_user_whitelist(): void
+    {
+        $line = "[2026-04-27T10:17:56+03:00] NOTICE: Processing 'main@office_emby' - '#123: IppSec' item.";
+
+        $parsed = Index::formatLog($line);
+
+        $this->assertSame('123', $parsed['item_id'], 'Log formatter should extract history item ids from structured messages.');
+        $this->assertSame('main', $parsed['user'], 'Log formatter should expose the user even when no whitelist is provided.');
+        $this->assertSame('office_emby', $parsed['backend'], 'Log formatter should expose the backend even when no whitelist is provided.');
+        $this->assertSame('2026-04-27T10:17:56+03:00', $parsed['date'], 'Log formatter should preserve the bracketed timestamp.');
+        $this->assertSame(
+            "NOTICE: Processing 'main@office_emby' - '#123: IppSec' item.",
+            $parsed['text'],
+            'Log formatter should strip the timestamp prefix from the display text.'
+        );
+    }
+
+    public function test_formatLog_stringifies_non_string_payloads(): void
+    {
+        $parsed = Index::formatLog(['message' => 'boom', 'code' => 1]);
+
+        $this->assertSame('{"message":"boom","code":1}', $parsed['text'], 'Non-string log payloads should be stringified for API consumers.');
+        $this->assertNull($parsed['date'], 'Stringified payloads should not invent timestamps.');
+        $this->assertNull($parsed['item_id'], 'Stringified payloads should not invent item ids.');
+        $this->assertNull($parsed['user'], 'Stringified payloads should not invent users.');
+        $this->assertNull($parsed['backend'], 'Stringified payloads should not invent backends.');
+    }
+}

--- a/tests/Backends/Plex/GetLibrariesListTest.php
+++ b/tests/Backends/Plex/GetLibrariesListTest.php
@@ -152,4 +152,37 @@ class GetLibrariesListTest extends TestCase
         $this->assertNull($response->response);
         $this->assertTrue($response->error->hasException());
     }
+
+    public function test_nfo_agents_are_supported(): void
+    {
+        $payload = [
+            'MediaContainer' => [
+                'Directory' => [
+                    [
+                        'key' => '1',
+                        'title' => 'NFO Movies',
+                        'type' => 'movie',
+                        'agent' => 'tv.plex.agents.nfo.movie',
+                        'scanner' => 'Plex Movie Scanner',
+                    ],
+                    [
+                        'key' => '2',
+                        'title' => 'NFO Shows',
+                        'type' => 'show',
+                        'agent' => 'tv.plex.agents.nfo.series',
+                        'scanner' => 'Plex TV Series',
+                    ],
+                ],
+            ],
+        ];
+
+        $resp = new MockResponse(json_encode($payload), ['http_code' => 200]);
+        $client = new MockHttpClient($resp);
+        $response = new GetLibrariesList($client, $this->logger)($this->context);
+
+        $this->assertTrue($response->status);
+        $this->assertCount(2, $response->response);
+        $this->assertTrue((bool) $response->response[0]['supported']);
+        $this->assertTrue((bool) $response->response[1]['supported']);
+    }
 }

--- a/tests/Backends/Plex/ImportTest.php
+++ b/tests/Backends/Plex/ImportTest.php
@@ -98,4 +98,43 @@ class ImportTest extends PlexTestCase
         $this->assertTrue($result->isSuccessful());
         $this->assertSame([], $result->response);
     }
+
+    public function test_import_nfo_library_select_includes_selected(): void
+    {
+        $sections = [
+            'MediaContainer' => [
+                'Directory' => [
+                    [
+                        'key' => '5',
+                        'title' => 'NFO Movies',
+                        'type' => 'movie',
+                        'agent' => 'tv.plex.agents.nfo.movie',
+                    ],
+                ],
+            ],
+        ];
+
+        $http = $this->makeHttpClient(
+            $this->makeResponse($sections),
+            new MockResponse('', [
+                'http_code' => 200,
+                'response_headers' => ['X-Plex-Container-Total-Size' => '1'],
+            ]),
+        );
+        $context = $this->makeContext([Options::LIBRARY_SELECT => ['5']]);
+        $action = new Import($http, $this->logger);
+
+        $result = $action(
+            $context,
+            new PlexGuid($this->logger),
+            $context->userContext->mapper,
+            null,
+            [],
+        );
+
+        $this->assertTrue($result->isSuccessful());
+        $this->assertCount(1, $result->response);
+        $logContext = $result->response[0]->extras['logContext'] ?? [];
+        $this->assertSame(5, (int) ag($logContext, 'library.id'));
+    }
 }

--- a/tests/Backends/Plex/PlexGuidTest.php
+++ b/tests/Backends/Plex/PlexGuidTest.php
@@ -351,6 +351,11 @@ class PlexGuidTest extends TestCase
             $this->getClass()->isLocal('com.plexapp.agents.imdb://123456/1/1'),
             'Assert that the GUID is not local.'
         );
+
+        $this->assertFalse(
+            $this->getClass()->isLocal('tv.plex.agents.nfo.movie://movie/tmdb_383498'),
+            'Assert that typed NFO GUIDs are treated as non-local external ids.'
+        );
     }
 
     public function test_has()
@@ -392,10 +397,23 @@ class PlexGuidTest extends TestCase
             ], $context),
             'Assert that the GUID exists.');
 
+        $this->assertEquals([
+            Guid::GUID_IMDB => 'tt1234567',
+            Guid::GUID_TMDB => '383498',
+            Guid::GUID_TVDB => '121361',
+        ],
+            $this->getClass()->parse([
+                ['id' => 'tv.plex.agents.nfo.movie://movie/tmdb_383498'],
+                ['id' => 'tv.plex.agents.nfo.movie://movie/imdb_tt1234567'],
+                ['id' => 'tv.plex.agents.nfo.series://show/tvdb_121361'],
+            ], $context),
+            'Assert that typed NFO GUIDs are normalized into supported external ids.');
+
         $this->assertEquals([], $this->getClass()->parse([
             ['id' => ''],
             ['id' => 'com.plexapp.agents.none://123456'],
             ['id' => 'com.plexapp.agents.imdb'],
+            ['id' => 'tv.plex.agents.nfo.movie://movie/858024'],
         ], $context), 'Assert that the GUID does not exist. for invalid GUIDs.');
     }
 
@@ -433,6 +451,16 @@ class PlexGuidTest extends TestCase
             ['id' => 'com.plexapp.agents.imdb://1'],
             ['id' => 'com.plexapp.agents.imdb://2'],
         ], $context), 'Assert only the the oldest ID is returned for numeric GUIDs.');
+
+        $this->assertEquals([Guid::GUID_TVDB => '84871'], $this->getClass()->get([
+            ['id' => 'tvdb://84871'],
+            ['id' => 'tv.plex.agents.nfo.series://episode/tvdb_84871'],
+        ], $context), 'Assert typed NFO GUIDs do not conflict with identical canonical GUIDs.');
+
+        $this->assertFalse(
+            $this->logged(Level::Warning, 'reported multiple ids', true),
+            'Assert identical canonical and NFO GUIDs do not raise duplicate warnings.'
+        );
 
         // -- as we cache the ignore list for each user now,
         // -- and no longer rely on config.ignore key, we needed a workaround to update the ignore list

--- a/tests/Backends/Plex/ToEntityTest.php
+++ b/tests/Backends/Plex/ToEntityTest.php
@@ -77,4 +77,72 @@ class ToEntityTest extends PlexTestCase
         $this->assertInstanceOf(StateInterface::class, $result->response);
         $this->assertNotEmpty($result->response->parent);
     }
+
+    public function test_to_entity_uses_top_level_typed_nfo_guid(): void
+    {
+        $context = $this->makeContext();
+        $item = [
+            'ratingKey' => '42',
+            'type' => 'movie',
+            'title' => 'NFO Movie',
+            'addedAt' => 1000,
+            'guid' => 'tv.plex.agents.nfo.movie://movie/tmdb_383498',
+        ];
+
+        $action = new ToEntity(new PlexGuid($this->logger));
+        $result = $action($context, $item);
+
+        $this->assertTrue($result->isSuccessful());
+        $this->assertInstanceOf(StateInterface::class, $result->response);
+        $this->assertSame('383498', $result->response->guids['guid_tmdb'] ?? null);
+    }
+
+    public function test_to_entity_episode_uses_show_level_typed_nfo_guid_when_parent_has_no_guid_list(): void
+    {
+        $context = $this->makeContext();
+        $item = [
+            'ratingKey' => '11',
+            'type' => 'episode',
+            'title' => 'Pilot',
+            'grandparentTitle' => 'Test Show',
+            'parentIndex' => 1,
+            'index' => 1,
+            'addedAt' => 1000,
+            'Guid' => [
+                ['id' => 'tvdb://84871'],
+            ],
+            'grandparentRatingKey' => 'show-1',
+        ];
+
+        $showPayload = [
+            'MediaContainer' => [
+                'Metadata' => [
+                    [
+                        'ratingKey' => 'show-1',
+                        'type' => 'show',
+                        'title' => 'Test Show',
+                        'guid' => 'tv.plex.agents.nfo.series://show/tvdb_72408',
+                    ],
+                ],
+            ],
+        ];
+
+        Container::add(GetMetaData::class, fn() => new class($showPayload) {
+            public function __construct(private array $payload)
+            {
+            }
+
+            public function __invoke(\App\Backends\Common\Context $context, string|int $id, array $opts = []): Response
+            {
+                return new Response(status: true, response: $this->payload);
+            }
+        });
+
+        $action = new ToEntity(new PlexGuid($this->logger));
+        $result = $action($context, $item);
+
+        $this->assertTrue($result->isSuccessful());
+        $this->assertInstanceOf(StateInterface::class, $result->response);
+        $this->assertSame('72408', $result->response->parent['guid_tvdb'] ?? null);
+    }
 }

--- a/tests/Commands/State/ImportCommandTest.php
+++ b/tests/Commands/State/ImportCommandTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands\State;
+
+use App\Backends\Common\ClientInterface as iClient;
+use App\Commands\State\ImportCommand;
+use App\Libs\Config;
+use App\Libs\ConfigFile;
+use App\Libs\Database\DBLayer;
+use App\Libs\Database\PDO\PDOAdapter;
+use App\Libs\Entity\StateEntity;
+use App\Libs\LogSuppressor;
+use App\Libs\Mappers\Import\DirectMapper;
+use App\Libs\TestCase;
+use App\Libs\UserContext;
+use Monolog\Logger;
+use PDO;
+use PDOException;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Contracts\HttpClient\HttpClientInterface as iHttp;
+
+final class ImportCommandTest extends TestCase
+{
+    public function test_request_phase_runs_inside_adapter_transaction_and_rolls_back_db_failures(): void
+    {
+        Config::init(require __DIR__ . '/../../../config/config.php');
+
+        $logger = new Logger('test');
+        $db = new PDOAdapter($logger, new DBLayer(new PDO('sqlite::memory:')));
+        $db->migrations('up');
+        $db->setOptions(['class' => new StateEntity([])]);
+        $cache = new Psr16Cache(new ArrayAdapter());
+        $entity = $db->insert(new StateEntity(require __DIR__ . '/../../Fixtures/EpisodeEntity.php'));
+
+        $userContext = new UserContext(
+            name: 'main',
+            config: new ConfigFile(
+                file: __DIR__ . '/../../Fixtures/test_servers.yaml',
+                autoSave: false,
+                autoCreate: false,
+                autoBackup: false,
+            ),
+            mapper: new DirectMapper(logger: $logger, db: $db, cache: $cache),
+            cache: $cache,
+            db: $db,
+        );
+
+        $client = $this->createStub(iClient::class);
+        $client->method('pull')->willReturn([]);
+
+        $http = $this->createStub(iHttp::class);
+
+        $command = new class($userContext, $logger, $client, $http, $entity) extends ImportCommand {
+            public bool $sendRequestsCalled = false;
+
+            public function __construct(
+                private readonly UserContext $userContext,
+                Logger $logger,
+                private readonly iClient $client,
+                iHttp $http,
+                private readonly StateEntity $entity,
+            ) {
+                parent::__construct(
+                    mapper: $this->userContext->mapper,
+                    logger: $logger,
+                    suppressor: new LogSuppressor([]),
+                    http: $http,
+                );
+            }
+
+            /**
+             * @return array<string,UserContext>
+             */
+            protected function getUsers(array $dbOpts = []): array
+            {
+                return ['main' => $this->userContext];
+            }
+
+            protected function makeBackend(array $backend, string $name, UserContext $userContext): iClient
+            {
+                return $this->client;
+            }
+
+            protected function sendRequests(array $queue, bool $syncRequests): void
+            {
+                Assert::assertTrue(
+                    $this->userContext->db->getDBLayer()->inTransaction(),
+                    'Import request phase should run inside a single adapter-managed DB transaction.'
+                );
+
+                $this->sendRequestsCalled = true;
+
+                $this->userContext->db->getDBLayer()->exec('DROP TABLE state');
+                $this->userContext->db->update(clone $this->entity);
+            }
+        };
+
+        $this->checkException(
+            closure: fn() => $this->makeTester($command)->execute(['--dry-run' => true]),
+            reason: 'Import should bubble database failures from the request phase when wrapped in adapter transaction state.',
+            exception: PDOException::class,
+            exceptionMessage: 'no such table: state',
+        );
+
+        self::assertTrue($command->sendRequestsCalled, 'Import command should reach the request processing phase.');
+
+        $stateTable = $db->getDBLayer()->query(
+            sql: "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'state'"
+        )->fetchColumn();
+
+        self::assertSame('state', $stateTable, 'Failed request-phase writes should be rolled back with the adapter transaction.');
+    }
+
+    private function makeTester(ImportCommand $command): CommandTester
+    {
+        $application = new Application();
+        $application->getDefinition()->addOption(new InputOption('trace', null, InputOption::VALUE_NONE));
+        $application->addCommand($command);
+
+        return new CommandTester($application->find(ImportCommand::ROUTE));
+    }
+}

--- a/tests/Database/DBLayerTest.php
+++ b/tests/Database/DBLayerTest.php
@@ -129,6 +129,50 @@ class DBLayerTest extends TestCase
         );
     }
 
+    public function test_query_with_prepared_statement_reuse(): void
+    {
+        $this->db->insert('test', [
+            'name' => 'test',
+            'watched' => 1,
+            'added_at' => 1,
+            'updated_at' => 2,
+            'json_data' => json_encode(['id' => 1]),
+            'nullable' => null,
+        ]);
+
+        $stmt = $this->db->prepare(
+            'UPDATE test SET name = :name, nullable = :nullable, json_data = :json_data WHERE id = :id'
+        );
+
+        $this->assertSame(
+            1,
+            $this->db->query($stmt, [
+                'name' => 'first',
+                'nullable' => null,
+                'json_data' => json_encode(['id' => 2]),
+                'id' => 1,
+            ])->rowCount(),
+            'Prepared statements should execute correctly with null-bound values.'
+        );
+
+        $this->assertSame(
+            1,
+            $this->db->query($stmt, [
+                'name' => 'second',
+                'nullable' => 'set',
+                'json_data' => json_encode(['id' => 3]),
+                'id' => 1,
+            ])->rowCount(),
+            'Prepared statements should be reusable across multiple executions.'
+        );
+
+        $row = $this->db->select('test', [], ['id' => 1])->fetch(PDO::FETCH_ASSOC);
+
+        $this->assertSame('second', $row['name'], 'Prepared statement reuse should persist the latest scalar value.');
+        $this->assertSame('set', $row['nullable'], 'Prepared statement reuse should persist updated nullable values.');
+        $this->assertSame('{"id":3}', $row['json_data'], 'Prepared statement reuse should persist updated JSON payloads.');
+    }
+
     public function test_transactions_operations()
     {
         $this->db->start();

--- a/tests/Database/PDOAdapterTest.php
+++ b/tests/Database/PDOAdapterTest.php
@@ -21,7 +21,10 @@ use Error;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use PDO;
+use PDOException;
+use PDOStatement;
 use Psr\SimpleCache\CacheInterface;
+use ReflectionMethod;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
@@ -343,6 +346,65 @@ class PDOAdapterTest extends TestCase
         $this->assertNull(
             ag($item->getMetadata($item->via), iState::COLUMN_META_DATA_PLAYED_AT),
             'When watched flag is set to 0, played_at metadata should be null.'
+        );
+    }
+
+    public function test_retryPreparedWrite_returns_statement_for_bad_parameter_retry(): void
+    {
+        assert($this->db instanceof PDOAdapter);
+
+        $item = $this->db->insert(new StateEntity($this->testEpisode));
+        $item->title = 'Retried Title';
+
+        $data = $item->getAll();
+        $data[iState::COLUMN_UPDATED_AT] = time();
+
+        foreach (iState::ENTITY_ARRAY_KEYS as $key) {
+            if (!(null !== ($data[$key] ?? null) && true === is_array($data[$key]))) {
+                continue;
+            }
+
+            ksort($data[$key]);
+            $data[$key] = json_encode($data[$key], flags: JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        }
+
+        $pdoUpdate = new ReflectionMethod($this->db, 'pdoUpdate');
+        $sql = $pdoUpdate->invoke($this->db, 'state', iState::ENTITY_KEYS);
+
+        $retryPreparedWrite = new ReflectionMethod($this->db, 'retryPreparedWrite');
+        $stmt = $retryPreparedWrite->invoke(
+            $this->db,
+            'update',
+            $sql,
+            $data,
+            new PDOException('21 bad parameter or other API misuse'),
+        );
+
+        $this->assertInstanceOf(PDOStatement::class, $stmt, 'Retry path should return a PDO statement, not an entity.');
+        $this->assertSame(
+            'Retried Title',
+            $this->db->get($item)->title,
+            'Retry path should execute the rebuilt update statement successfully.'
+        );
+    }
+
+    public function test_retryPreparedWrite_rethrows_unrelated_errors(): void
+    {
+        assert($this->db instanceof PDOAdapter);
+
+        $retryPreparedWrite = new ReflectionMethod($this->db, 'retryPreparedWrite');
+
+        $this->checkException(
+            closure: fn() => $retryPreparedWrite->invoke(
+                $this->db,
+                'update',
+                'UPDATE state SET title = :title WHERE id = :id',
+                ['title' => 'Ignored', 'id' => 1],
+                new PDOException('some other database problem'),
+            ),
+            reason: 'Retry helper should only intercept sqlite API misuse errors.',
+            exception: PDOException::class,
+            exceptionMessage: 'some other database problem',
         );
     }
 

--- a/tests/Libs/ServeStaticTest.php
+++ b/tests/Libs/ServeStaticTest.php
@@ -80,6 +80,14 @@ class ServeStaticTest extends TestCase
             exceptionCode: Status::BAD_REQUEST->value,
         );
 
+        $this->checkException(
+            closure: fn() => new ServeStatic()->serve($this->createRequest('GET', '/guides/openapi/../../../README.md')),
+            reason: 'OpenAPI guide routes should not resolve outside the explicit spec aliases.',
+            exception: \League\Route\Http\Exception\NotFoundException::class,
+            exceptionMessage: 'not found',
+            exceptionCode: Status::NOT_FOUND->value,
+        );
+
         // -- Check for invalid root static path.
         $this->checkException(
             closure: fn() => new ServeStatic('/nonexistent')->serve($this->createRequest('GET', '/test.html')),
@@ -118,6 +126,19 @@ class ServeStaticTest extends TestCase
         $this->assertEquals(Status::OK->value, $response->getStatusCode());
         $this->assertEquals('text/markdown; charset=utf-8', $response->getHeaderLine('Content-Type'));
         $this->assertEquals(file_get_contents(__DIR__ . '/../../guides/identities.md'), (string)$response->getBody());
+
+        $response = new ServeStatic()->serve($this->createRequest('GET', '/guides/openapi/plex.json'));
+        $this->assertEquals(Status::OK->value, $response->getStatusCode());
+        $this->assertEquals('application/json; charset=utf-8', $response->getHeaderLine('Content-Type'));
+        $this->assertEquals(
+            file_get_contents(__DIR__ . '/../../src/Backends/Plex/plex-openai-stable.json'),
+            (string) $response->getBody()
+        );
+
+        $response = new ServeStatic()->serve($this->createRequest('HEAD', '/guides/openapi/jellyfin.json'));
+        $this->assertEquals(Status::OK->value, $response->getStatusCode());
+        $this->assertEquals('application/json; charset=utf-8', $response->getHeaderLine('Content-Type'));
+        $this->assertSame('', (string) $response->getBody());
 
         // -- test screenshots serving, as screenshots path is not in public directory and not subject
         // -- to same path restrictions as other files.


### PR DESCRIPTION
This PR adds support for Plex's native NFO agents, allowing WatchState to recognize and import libraries using the new Plex NFO movie and series agents.

The new supported agents are:

- `tv.plex.agents.nfo.movie`
- `tv.plex.agents.nfo.series`

WatchState now treats these as supported Plex agents, parses their typed GUIDs, and normalizes provider-backed IDs such as `tmdb_383498`, `imdb_tt1234567`, and `tvdb_121361` into the same canonical external IDs used by the rest of the application.

## Changes

- Added support for Plex native NFO movie and series agents.
- Added GUID parsing for typed Plex NFO identifiers such as:
  - `tv.plex.agents.nfo.movie://movie/tmdb_383498`
  - `tv.plex.agents.nfo.movie://movie/imdb_tt1234567`
  - `tv.plex.agents.nfo.series://show/tvdb_121361`
- Ensured untyped/fallback NFO IDs that do not expose a provider are ignored instead of being guessed.
- Updated Plex library detection so NFO-backed movie and show libraries are marked as supported.
- Updated Plex import and entity conversion tests to cover NFO-backed libraries, movies, shows, and episodes.
- Updated the FAQ with the new Plex NFO GUID formats and cleaned up the legacy agent list.

## Minor changes

- Added a bundled OpenAPI viewer under Help for browsing Plex, Jellyfin, and Emby upstream routes.
- Added static serving for bundled backend OpenAPI JSON files.
- Improved log formatting so event logs expose timestamps, history item links, user/backend metadata, and handle non-string payloads safely.
- Improved frontend log rendering with timestamp display, history item navigation, filtering, and copy behavior.
- Fixed navigation active-state handling for nested Help pages such as API, OpenAPI, README, FAQ, and News.
- Changed backend library ignore toggling to update the backend ignore option list directly.
- Refactored state import request handling to run through the adapter-managed transaction path.
- Fixed SQLite prepared statement reuse issues, including null/scalar binding and retry handling for `21 bad parameter or other API misuse`.