### PR TITLE
fix: allow legacy db migration command to skip tables that dont exists

### DIFF
--- a/src/Commands/Database/LegacyCommand.php
+++ b/src/Commands/Database/LegacyCommand.php
@@ -225,6 +225,10 @@ final class LegacyCommand extends Command
             $pdo->beginTransaction();
 
             foreach (self::APP_TABLES as $table) {
+                if (false === $this->tableExists($pdo, $table, 'legacy')) {
+                    continue;
+                }
+
                 $pdo->exec(sprintf('INSERT INTO "%1$s" SELECT * FROM legacy."%1$s"', $table));
             }
 
@@ -309,9 +313,17 @@ final class LegacyCommand extends Command
         return true;
     }
 
-    private function tableExists(PDO $pdo, string $table): bool
+    private function tableExists(PDO $pdo, string $table, string $schema = 'main'): bool
     {
-        $stmt = $pdo->prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = :name LIMIT 1");
+        $masterTable = match ($schema) {
+            'main' => 'sqlite_master',
+            'legacy' => 'legacy.sqlite_master',
+            default => throw new RuntimeException(r("Unsupported sqlite schema '{schema}'.", [
+                'schema' => $schema,
+            ])),
+        };
+
+        $stmt = $pdo->prepare("SELECT 1 FROM {$masterTable} WHERE type = 'table' AND name = :name LIMIT 1");
         $stmt->execute(['name' => $table]);
 
         return false !== $stmt->fetchColumn();

--- a/tests/Commands/Database/LegacyCommandTest.php
+++ b/tests/Commands/Database/LegacyCommandTest.php
@@ -107,6 +107,24 @@ final class LegacyCommandTest extends TestCase
         self::assertFileExists($legacy . '.migrated');
     }
 
+    public function test_missing_playlist_tables(): void
+    {
+        $legacy = self::$tmpPath . '/db/' . PdoFactory::OLD_DB_FILE;
+        $target = self::$tmpPath . '/db/' . PdoFactory::DB_FILE;
+
+        $this->createLegacyDb($legacy, 'main-ref', withPlaylists: false);
+
+        $tester = $this->makeTester();
+        $status = $tester->execute([
+            '--execute' => true,
+        ]);
+
+        self::assertSame(LegacyCommand::SUCCESS, $status);
+        $this->assertMigratedDb($target, 'main-ref', withPlaylists: false);
+        self::assertFileDoesNotExist($legacy);
+        self::assertFileExists($legacy . '.migrated');
+    }
+
     public function test_remove_backups(): void
     {
         mkdir(self::$tmpPath . '/users/alice', 0o755, true);
@@ -139,7 +157,7 @@ final class LegacyCommandTest extends TestCase
         return new CommandTester($application->find(LegacyCommand::ROUTE));
     }
 
-    private function createLegacyDb(string $file, string $reference): void
+    private function createLegacyDb(string $file, string $reference, bool $withPlaylists = true): void
     {
         $dir = dirname($file);
         if (false === is_dir($dir)) {
@@ -150,14 +168,19 @@ final class LegacyCommandTest extends TestCase
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
         $pdo->exec('CREATE TABLE events (id TEXT PRIMARY KEY, status INTEGER NOT NULL DEFAULT 0, reference TEXT NULL, event TEXT NOT NULL, event_data TEXT NOT NULL DEFAULT "{}", options TEXT NOT NULL DEFAULT "{}", attempts INTEGER NOT NULL DEFAULT 0, logs TEXT NOT NULL DEFAULT "{}", created_at INTEGER NOT NULL, updated_at INTEGER NULL)');
-        $pdo->exec('CREATE TABLE playlists (id INTEGER PRIMARY KEY AUTOINCREMENT, backend TEXT NOT NULL, backend_id TEXT NOT NULL, title TEXT NOT NULL, type TEXT NOT NULL DEFAULT "video", summary TEXT NULL, is_editable INTEGER NOT NULL DEFAULT 1, is_smart INTEGER NOT NULL DEFAULT 0, is_public INTEGER NOT NULL DEFAULT 0, item_count INTEGER NOT NULL DEFAULT 0, sync_id TEXT NULL, content_hash TEXT NOT NULL DEFAULT "", remote_updated_at INTEGER NOT NULL DEFAULT 0, deleted_at INTEGER NULL, metadata TEXT NOT NULL DEFAULT "{}", created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, synced_at INTEGER NOT NULL)');
-        $pdo->exec('CREATE TABLE playlist_items (id INTEGER PRIMARY KEY AUTOINCREMENT, playlist_id INTEGER NOT NULL, position INTEGER NOT NULL, state_id INTEGER NULL, backend_item_id TEXT NULL, backend_entry_id TEXT NULL, item_type TEXT NULL, title TEXT NOT NULL, metadata TEXT NOT NULL DEFAULT "{}", created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)');
+        if (true === $withPlaylists) {
+            $pdo->exec('CREATE TABLE playlists (id INTEGER PRIMARY KEY AUTOINCREMENT, backend TEXT NOT NULL, backend_id TEXT NOT NULL, title TEXT NOT NULL, type TEXT NOT NULL DEFAULT "video", summary TEXT NULL, is_editable INTEGER NOT NULL DEFAULT 1, is_smart INTEGER NOT NULL DEFAULT 0, is_public INTEGER NOT NULL DEFAULT 0, item_count INTEGER NOT NULL DEFAULT 0, sync_id TEXT NULL, content_hash TEXT NOT NULL DEFAULT "", remote_updated_at INTEGER NOT NULL DEFAULT 0, deleted_at INTEGER NULL, metadata TEXT NOT NULL DEFAULT "{}", created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, synced_at INTEGER NOT NULL)');
+            $pdo->exec('CREATE TABLE playlist_items (id INTEGER PRIMARY KEY AUTOINCREMENT, playlist_id INTEGER NOT NULL, position INTEGER NOT NULL, state_id INTEGER NULL, backend_item_id TEXT NULL, backend_entry_id TEXT NULL, item_type TEXT NULL, title TEXT NOT NULL, metadata TEXT NOT NULL DEFAULT "{}", created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)');
+        }
+
         $pdo->exec('CREATE TABLE state (id INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, updated INTEGER NOT NULL, watched INTEGER NOT NULL DEFAULT 0, via TEXT NOT NULL, title TEXT NOT NULL, year INTEGER NULL, season INTEGER NULL, episode INTEGER NULL, parent TEXT NULL, guids TEXT NULL, metadata TEXT NULL, extra TEXT NULL, created_at INTEGER NOT NULL DEFAULT 0, updated_at INTEGER NOT NULL DEFAULT 0)');
 
         $pdo->exec("INSERT INTO events (id, status, reference, event, event_data, options, attempts, logs, created_at, updated_at) VALUES ('event-1', 1, " . $pdo->quote($reference) . ", 'task.test', '{\"ok\":true}', '{}', 0, '{}', 100, 101)");
-        $pdo->exec("INSERT INTO playlists (id, backend, backend_id, title, type, summary, is_editable, is_smart, is_public, item_count, sync_id, content_hash, remote_updated_at, deleted_at, metadata, created_at, updated_at, synced_at) VALUES (7, 'plex', 'pl-1', 'Playlist', 'video', NULL, 1, 0, 0, 1, 'sync-1', 'hash', 100, NULL, '{\"kind\":\"playlist\"}', 100, 101, 102)");
         $pdo->exec("INSERT INTO state (id, type, updated, watched, via, title, year, season, episode, parent, guids, metadata, extra, created_at, updated_at) VALUES (11, 'movie', 100, 1, 'plex', 'Movie', 2024, NULL, NULL, '{\"guid_plex\":\"parent-1\"}', '{\"guid_plex\":\"movie-1\"}', '{\"plex\":{\"id\":1}}', '{\"plex\":{\"path\":\"/media/movie.mkv\"}}', 100, 101)");
-        $pdo->exec("INSERT INTO playlist_items (id, playlist_id, position, state_id, backend_item_id, backend_entry_id, item_type, title, metadata, created_at, updated_at) VALUES (13, 7, 1, 11, 'item-1', 'entry-1', 'movie', 'Movie', '{\"rank\":1}', 100, 101)");
+        if (true === $withPlaylists) {
+            $pdo->exec("INSERT INTO playlists (id, backend, backend_id, title, type, summary, is_editable, is_smart, is_public, item_count, sync_id, content_hash, remote_updated_at, deleted_at, metadata, created_at, updated_at, synced_at) VALUES (7, 'plex', 'pl-1', 'Playlist', 'video', NULL, 1, 0, 0, 1, 'sync-1', 'hash', 100, NULL, '{\"kind\":\"playlist\"}', 100, 101, 102)");
+            $pdo->exec("INSERT INTO playlist_items (id, playlist_id, position, state_id, backend_item_id, backend_entry_id, item_type, title, metadata, created_at, updated_at) VALUES (13, 7, 1, 11, 'item-1', 'entry-1', 'movie', 'Movie', '{\"rank\":1}', 100, 101)");
+        }
     }
 
     private function createV2DbWithState(string $file, string $reference): void
@@ -172,7 +195,7 @@ final class LegacyCommandTest extends TestCase
         $pdo->exec("INSERT INTO events (id, status, reference, event, event_data, options, attempts, logs, created_at, updated_at) VALUES ('existing', 1, " . $pdo->quote($reference) . ", 'task.test', '{}', '{}', 0, '{}', 1, 1)");
     }
 
-    private function assertMigratedDb(string $file, string $reference): void
+    private function assertMigratedDb(string $file, string $reference, bool $withPlaylists = true): void
     {
         self::assertFileExists($file);
 
@@ -181,8 +204,16 @@ final class LegacyCommandTest extends TestCase
 
         self::assertSame($reference, $pdo->query("SELECT reference FROM events WHERE id = 'event-1'")?->fetchColumn());
         self::assertSame('11', (string) $pdo->query("SELECT id FROM state WHERE title = 'Movie'")?->fetchColumn());
-        self::assertSame('7', (string) $pdo->query("SELECT id FROM playlists WHERE backend_id = 'pl-1'")?->fetchColumn());
-        self::assertSame('13', (string) $pdo->query("SELECT id FROM playlist_items WHERE backend_item_id = 'item-1'")?->fetchColumn());
+
+        if (true === $withPlaylists) {
+            self::assertSame('7', (string) $pdo->query("SELECT id FROM playlists WHERE backend_id = 'pl-1'")?->fetchColumn());
+            self::assertSame('13', (string) $pdo->query("SELECT id FROM playlist_items WHERE backend_item_id = 'item-1'")?->fetchColumn());
+
+            return;
+        }
+
+        self::assertSame(0, (int) $pdo->query('SELECT COUNT(*) FROM playlists')?->fetchColumn());
+        self::assertSame(0, (int) $pdo->query('SELECT COUNT(*) FROM playlist_items')?->fetchColumn());
     }
 
     private function assertExistingV2Db(string $file, string $reference): void


### PR DESCRIPTION
The migration logic in `LegacyCommand.php` now checks if a table exists in the legacy schema before attempting to copy its data, preventing migrations from older schema from failing to work.