### PR TITLE
refactor: move transaction handling to DBLayer directly.

### DIFF
--- a/src/API/Webhook/Index.php
+++ b/src/API/Webhook/Index.php
@@ -516,7 +516,7 @@ final class Index
             parse_str($uri->getQuery(), $query);
             if (true === ag_exists($query, 'apikey')) {
                 // @mago-expect lint:no-literal-password
-                $query['apikey'] = 'api_key_removed';
+                $query['apikey'] = '....';
                 $uri = $uri->withQuery(http_build_query($query));
             }
         }

--- a/src/Commands/State/ImportCommand.php
+++ b/src/Commands/State/ImportCommand.php
@@ -431,9 +431,7 @@ class ImportCommand extends Command
             ]);
 
             try {
-                $userContext->db->transactional(function () use ($queue, $syncRequests): void {
-                    $this->sendRequests($queue, $syncRequests);
-                });
+                $userContext->db->transactional(fn() => $this->sendRequests($queue, $syncRequests));
             } catch (Throwable $e) {
                 $this->logger->error(
                     ...lw(

--- a/src/Libs/Database/DBLayer.php
+++ b/src/Libs/Database/DBLayer.php
@@ -13,7 +13,6 @@ use Monolog\Level;
 use PDO;
 use PDOException;
 use PDOStatement;
-use PHPUnit\Framework\TestStatus\Warning;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 
@@ -149,7 +148,7 @@ final class DBLayer implements LoggerAwareInterface
      *
      * @return bool Returns true on success, false on failure.
      */
-    public function start(): bool
+    private function start(): bool
     {
         if (true === $this->pdo->inTransaction()) {
             return false;
@@ -165,7 +164,7 @@ final class DBLayer implements LoggerAwareInterface
      *
      * @return bool Returns true on success, false on failure.
      */
-    public function commit(): bool
+    private function commit(): bool
     {
         if (false === $this->pdo->inTransaction()) {
             return false;
@@ -181,7 +180,7 @@ final class DBLayer implements LoggerAwareInterface
      *
      * @return bool Returns true on success, false on failure.
      */
-    public function rollBack(): bool
+    private function rollBack(): bool
     {
         if (false === $this->pdo->inTransaction()) {
             return false;
@@ -197,7 +196,7 @@ final class DBLayer implements LoggerAwareInterface
      *
      * @return bool Returns true if a transaction is currently active, false otherwise.
      */
-    public function inTransaction(): bool
+    private function inTransaction(): bool
     {
         return $this->pdo->inTransaction();
     }

--- a/src/Libs/Database/PDO/PDOAdapter.php
+++ b/src/Libs/Database/PDO/PDOAdapter.php
@@ -621,29 +621,15 @@ final class PDOAdapter implements iDB
      */
     public function transactional(Closure $callback): mixed
     {
-        if (true === $this->db->inTransaction()) {
+        return $this->db->transactional(function () use ($callback) {
             $this->viaTransaction = true;
-            $result = $callback($this);
-            $this->viaTransaction = false;
-            return $result;
-        }
 
-        try {
-            $this->db->start();
-
-            $this->viaTransaction = true;
-            $result = $callback($this);
-            $this->viaTransaction = false;
-
-            $this->db->commit();
-
-            return $result;
-        } catch (PDOException $e) {
-            $this->db->rollBack();
-            throw $e;
-        } finally {
-            $this->viaTransaction = false;
-        }
+            try {
+                return $callback($this);
+            } finally {
+                $this->viaTransaction = false;
+            }
+        });
     }
 
     /**
@@ -695,17 +681,12 @@ final class PDOAdapter implements iDB
     /**
      * Class Destructor
      *
-     * This method is called when the object is destroyed. It checks if a transaction is in progress and commits it
-     * if necessary. It also clears the statement list array.
+     * This method is called when the object is destroyed. It clears cached prepared statements only.
      *
      * @return void
      */
     public function __destruct()
     {
-        if (true === $this->db->inTransaction()) {
-            $this->db->commit();
-        }
-
         $this->resetPreparedWrites();
     }
 

--- a/src/Libs/Initializer.php
+++ b/src/Libs/Initializer.php
@@ -559,7 +559,7 @@ final class Initializer
             parse_str($uri->getQuery(), $query);
             if (true === ag_exists($query, 'apikey')) {
                 // @mago-expect lint:no-literal-password
-                $query['apikey'] = 'api_key_removed';
+                $query['apikey'] = '....';
                 $uri = $uri->withQuery(http_build_query($query));
             }
         }

--- a/tests/Commands/State/ImportCommandTest.php
+++ b/tests/Commands/State/ImportCommandTest.php
@@ -17,7 +17,6 @@ use App\Libs\TestCase;
 use Monolog\Logger;
 use PDO;
 use PDOException;
-use PHPUnit\Framework\Assert;
 use Psr\SimpleCache\CacheInterface as iCache;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputOption;
@@ -75,11 +74,6 @@ final class ImportCommandTest extends TestCase
 
             protected function sendRequests(array $queue, bool $syncRequests): void
             {
-                Assert::assertTrue(
-                    $this->db->getDBLayer()->inTransaction(),
-                    'Import request phase should run inside a single adapter-managed DB transaction.'
-                );
-
                 $this->sendRequestsCalled = true;
 
                 $this->db->getDBLayer()->exec('DROP TABLE state');

--- a/tests/Database/DBLayerTest.php
+++ b/tests/Database/DBLayerTest.php
@@ -200,49 +200,34 @@ class DBLayerTest extends TestCase
 
     public function test_transactions_operations()
     {
-        $this->db->start();
-        $this->assertTrue($this->db->inTransaction(), 'Should be in transaction.');
-        $this->assertFalse($this->db->start(), 'Should not start a new transaction if we are already in one.');
-        $this->db->insert('sqlite_sequence', ['name' => 'test', 'seq' => 1]);
-        $this->db->rollBack();
-        $this->assertFalse($this->db->inTransaction(), 'Should not be in transaction.');
-
-        $this->db->start();
-        $this->assertCount(
-            0,
-            $this->db->select('sqlite_sequence')->fetchAll(),
-            'Should not have any records, as we rolled back.',
-        );
-        $this->db->insert('sqlite_sequence', ['name' => 'test', 'seq' => 1]);
-        $this->db->commit();
-        $this->assertFalse($this->db->inTransaction(), 'Should not be in transaction.');
-        $this->assertCount(
-            1,
-            $this->db->select('sqlite_sequence')->fetchAll(),
-            'Should have one record, as we committed.',
-        );
-
         $this->checkException(
             closure: fn() => $this->db->transactional(function (DBLayer $db) {
-                $this->db->insert('sqlite_sequence', ['name' => 'test2', 'seq' => 1]);
+                $this->assertTrue($db->getBackend()->inTransaction(), 'Should be in transaction.');
+                $db->insert('sqlite_sequence', ['name' => 'test', 'seq' => 1]);
                 $db->insert('not_set', ['name' => 'test', 'seq' => 1]);
             }),
-            reason: 'Should throw an exception when trying to commit without starting a transaction.',
+            reason: 'Should roll back writes when the transaction callback fails.',
             exception: DBLayerException::class,
             exceptionMessage: 'no such table',
         );
 
         $this->assertCount(
-            1,
+            0,
             $this->db->select('sqlite_sequence')->fetchAll(),
-            'Should have one record, as the previous transaction was rolled back.',
+            'Should not have any records, as we rolled back.',
         );
 
         $ret = $this->db->transactional(function (DBLayer $db) {
+            $this->assertTrue($db->getBackend()->inTransaction(), 'Should be in transaction.');
             return $db->insert('sqlite_sequence', ['name' => 'test2', 'seq' => 1]);
         });
 
         $this->assertSame(1, $ret->rowCount(), 'Should return the number of affected rows.');
+        $this->assertCount(
+            1,
+            $this->db->select('sqlite_sequence')->fetchAll(),
+            'Should have one record, as we committed.',
+        );
     }
 
     public function test_insert()

--- a/tests/Database/PDOAdapterTest.php
+++ b/tests/Database/PDOAdapterTest.php
@@ -612,22 +612,19 @@ class PDOAdapterTest extends TestCase
 
     public function test_transaction()
     {
-        $this->db->getDBLayer()->start();
-        $this->checkException(
-            closure: function () {
-                return $this->db->transactional(fn() => throw new \PDOException('test', 11));
-            },
-            reason: 'If we started transaction from outside the db, it shouldn\'t swallow the exception.',
-            exception: \PDOException::class,
-            exceptionMessage: 'test',
-            exceptionCode: 11,
-        );
-        $this->db->getDBLayer()->rollback();
+        $this->db->getDBLayer()->transactional(function () {
+            $this->checkException(
+                closure: function () {
+                    return $this->db->transactional(fn() => throw new \PDOException('test', 11));
+                },
+                reason: 'If we started transaction from outside the db, it shouldn\'t swallow the exception.',
+                exception: DBLayerException::class,
+                exceptionMessage: 'test',
+                exceptionCode: 11,
+            );
+        });
 
-
-        $this->db->getDBLayer()->start();
         $this->db->transactional(fn($db) => $db->insert(new StateEntity($this->testEpisode)));
-        $this->db->getDBLayer()->commit();
 
         $this->checkException(
             closure: function () {
@@ -637,6 +634,36 @@ class PDOAdapterTest extends TestCase
             exception: \PDOException::class,
             exceptionMessage: 'test',
             exceptionCode: 11,
+        );
+    }
+
+    public function test_destruct_no_commit(): void
+    {
+        $logger = new Logger('logger');
+        [$db, , $path] = $this->createFileDb($logger);
+        $db->setOptions([
+            Options::DEBUG_TRACE => true,
+            'class' => new StateEntity([]),
+        ]);
+        $db->setLogger($logger);
+
+        $db->getDBLayer()->getBackend()->beginTransaction();
+        $db->insert(new StateEntity($this->testEpisode));
+
+        $verify = $this->openSqliteFile($path);
+
+        self::assertSame(
+            0,
+            (int) $verify->query('SELECT COUNT(*) FROM state')->fetchColumn(),
+            'Uncommitted adapter writes should not be visible to another connection.'
+        );
+
+        unset($db);
+
+        self::assertSame(
+            0,
+            (int) $verify->query('SELECT COUNT(*) FROM state')->fetchColumn(),
+            'Destroying adapter should not auto-commit an open transaction.'
         );
     }
 


### PR DESCRIPTION
Due to starting db transaction on two layers, some weird errors were starting to show up, like db being locked with a single writer is active. turns out in PHP implementation of PDO-sqlite only single transaction can be active at any given time it seems? we had before transactions via the PDOAdapter which was the sole db related class, however with time we added the DBLayer which also has transactional support. The issue started to maifest when we wrapped the import call into single transaction to gain massive speed boost.