### PR TITLE
Fix: db reset was also resetting the migrations tables

### DIFF
--- a/API.md
+++ b/API.md
@@ -3750,7 +3750,6 @@ Receives backend webhook payloads, matches them to configured users/backends, an
   - items without supported GUIDs
   - episode events without season/episode numbers
   - generic requests that the backend parser cannot fully resolve
-- When a request is queued, WatchState creates a unique event reference based on item type, backend, user, and tainted state.
 
 ---
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -74,8 +74,8 @@ movie or episode. Specifically, it means:
 - There is no metadata indicating that the item was previously imported from that backend to make it possible to mark it
   as unplayed.
 
-In this case, the system prioritizes preserving your local play state. The item is marked as **tainted** and will be
-re-processed accordingly. To resolve this conflict and sync the backend with your local state:
+In this case, the system prioritizes preserving your local play state. The item is queued for a follow-up pass instead
+of applying the backend state directly. To resolve this conflict and sync the backend with your local state:
 
 - Go to the `Backends`.
 - Under the relevant backend, find the **Quick operations** list.
@@ -432,9 +432,10 @@ the issue. Please enable webhooks for your jellyfin backend to avoid this issue.
 
 We have added an experimental workaround for this issue in the `state:import` command. To enable it, add the env `WS_CLIENTS_JELLYFIN_FIX_PLAYED` via the `Configuration > Environment` page. It's turned off by default as it may cause some issues as it's untested in production, so please use it with caution and report any issues you find.
 
-## CODE: DM001 - Marking the item as tainted and re-processing.
+## CODE: DM001 - Item queued for re-processing.
 
-This warning appears when there is a mismatch between the local database and a backend regarding the item. This error mostly occurs in some edge cases. which can be fixed by forced state export to the backend.
+This warning appears when the backend reports an older item state than the last recorded sync point. This usually
+shows up in edge cases and can often be resolved by forcing a state export to the backend.
 
 ---
 

--- a/frontend/app/components/EventView.vue
+++ b/frontend/app/components/EventView.vue
@@ -217,7 +217,7 @@
               :key="`${logLine.id}-${index}`"
               class="block"
               ><span
-                v-if="logLine?.date || logLine?.item_id"
+                v-if="logLine?.date || hasLinks(logLine)"
                 class="mr-[1ch] inline-flex items-baseline whitespace-normal"
               >
                 <template v-if="logLine?.date"
@@ -227,17 +227,9 @@
                     }}</span> </UTooltip
                   >]</template
                 >
-                <button
-                  v-if="logLine?.item_id"
-                  type="button"
-                  :class="[
-                    'cursor-pointer font-[inherit] leading-[inherit] text-primary underline-offset-2 hover:underline',
-                    logLine?.date ? 'ml-[1ch]' : '',
-                  ]"
-                  @click="goto_history_item(logLine)"
-                >
-                  View
-                </button>
+                <span v-if="hasLinks(logLine)" :class="logLine?.date ? 'ml-[1ch]' : ''">
+                  <LogLineLinks :item="logLine" />
+                </span>
               </span>
               <span>{{ String(logLine.text).trim() }}</span>
             </span>
@@ -304,12 +296,12 @@ import { computed, onMounted, ref, watch } from 'vue';
 import { createError, useHead } from '#app';
 import moment from 'moment';
 import { useStorage } from '@vueuse/core';
+import LogLineLinks from '~/components/LogLineLinks.vue';
 import { useDialog } from '~/composables/useDialog';
 import type { EventsItem, GenericError, LogEntry } from '~/types';
 import {
   copyText,
   getEventStatusClass,
-  goto_history_item,
   makeEventName,
   notification,
   parse_api_response,
@@ -362,6 +354,10 @@ const formatLogLine = (logLine: LogEntry): string => {
   const prefix = logLine.date ? `[${logLine.date}] ` : '';
 
   return `${prefix}${String(logLine.text).trim()}`;
+};
+
+const hasLinks = (logLine: LogEntry): boolean => {
+  return Boolean(logLine.item_id || logLine.backend);
 };
 
 const getEventStatusColor = (status: number) => {

--- a/frontend/app/components/LogLineLinks.vue
+++ b/frontend/app/components/LogLineLinks.vue
@@ -1,0 +1,153 @@
+<template>
+  <span v-if="items.length > 0" class="inline-flex items-center align-middle">
+    <Popover
+      placement="bottom-start"
+      trigger="click"
+      :offset="6"
+      :show-arrow="false"
+      :z-index="13000"
+      popover-class="w-56"
+      content-class="p-1"
+    >
+      <template #trigger>
+        <UButton
+          color="neutral"
+          variant="ghost"
+          size="xs"
+          icon="i-lucide-link-2"
+          aria-label="Open related links"
+          title="Open related links"
+          class="h-5 cursor-pointer rounded px-1.5 text-primary hover:bg-primary/10 hover:text-primary"
+          :ui="{
+            base: 'min-h-0 min-w-0',
+            leadingIcon: 'size-3.5',
+          }"
+        />
+      </template>
+
+      <template #content="{ hide }">
+        <div class="space-y-1">
+          <button
+            v-for="entry in items"
+            :key="entry.key"
+            type="button"
+            class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-default hover:bg-elevated hover:text-highlighted"
+            @click="void onSelect(entry, hide)"
+          >
+            <UIcon :name="entry.icon" class="size-4 shrink-0 text-toned" />
+            <span class="truncate">{{ entry.label }}</span>
+          </button>
+        </div>
+      </template>
+    </Popover>
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { navigateTo } from '#app';
+import { useStorage } from '@vueuse/core';
+import Popover from '~/components/Popover.vue';
+import { useDialog } from '~/composables/useDialog';
+import type { LogEntry } from '~/types';
+import { goto_history_item, makeEventName } from '~/utils';
+
+type LinkItem = {
+  key: string;
+  label: string;
+  icon: string;
+  action: () => Promise<void>;
+};
+
+const props = defineProps<{
+  item: Pick<LogEntry, 'item_id' | 'event_id' | 'user' | 'backend'>;
+  openEvent?: (id: string) => void;
+}>();
+
+const dialog = useDialog();
+const api_user = useStorage('api_user', 'main');
+
+const asString = (value: unknown): string | null => {
+  if ('string' === typeof value) {
+    return '' === value ? null : value;
+  }
+
+  if ('number' === typeof value || 'boolean' === typeof value) {
+    return String(value);
+  }
+
+  return null;
+};
+
+const eventId = computed<string | null>(() => asString(props.item.event_id));
+const itemId = computed<string | null>(() => asString(props.item.item_id));
+const backend = computed<string | null>(() => asString(props.item.backend));
+const user = computed<string | null>(() => asString(props.item.user));
+
+const switchIdentity = async (identity: string): Promise<boolean> => {
+  if (identity === api_user.value) {
+    return true;
+  }
+
+  const { status } = await dialog.confirmDialog({
+    title: 'Switch Identity',
+    message: `This log is related to identity '${identity}'. You are currently using '${api_user.value}'. Do you want to switch to view it?`,
+  });
+
+  if (true !== status) {
+    return false;
+  }
+
+  api_user.value = identity;
+  return true;
+};
+
+const items = computed<Array<LinkItem>>(() => {
+  const list: Array<LinkItem> = [];
+
+  if (eventId.value && props.openEvent) {
+    list.push({
+      key: `event:${eventId.value}`,
+      label: `Event #${makeEventName(eventId.value)}`,
+      icon: 'i-lucide-activity',
+      action: async () => {
+        props.openEvent?.(eventId.value as string);
+      },
+    });
+  }
+
+  if (itemId.value) {
+    list.push({
+      key: `item:${itemId.value}`,
+      label: `History #${itemId.value}`,
+      icon: 'i-lucide-history',
+      action: async () => {
+        await goto_history_item({ item_id: itemId.value, user: user.value });
+      },
+    });
+  }
+
+  if (backend.value) {
+    list.push({
+      key: `backend:${backend.value}`,
+      label: `Backend ${backend.value}`,
+      icon: 'i-lucide-server',
+      action: async () => {
+        const identity = user.value;
+        if (identity && false === (await switchIdentity(identity))) {
+          return;
+        }
+
+        await navigateTo(`/backend/${backend.value}`);
+      },
+    });
+  }
+
+  return list;
+});
+
+const onSelect = async (entry: LinkItem, hide: () => void): Promise<void> => {
+  hide();
+  await entry.action();
+};
+</script>

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -267,7 +267,7 @@
                   :key="`${log.filename}-${index}`"
                   class="block"
                   ><span
-                    v-if="item?.date || item?.item_id"
+                    v-if="item?.date || hasLinks(item)"
                     class="mr-[1ch] inline-flex items-baseline whitespace-normal"
                   >
                     <template v-if="item?.date"
@@ -277,17 +277,9 @@
                         }}</span> </UTooltip
                       >]</template
                     >
-                    <button
-                      v-if="item?.item_id"
-                      type="button"
-                      :class="[
-                        'cursor-pointer font-[inherit] leading-[inherit] text-primary underline-offset-2 hover:underline',
-                        item?.date ? 'ml-[1ch]' : '',
-                      ]"
-                      @click="goto_history_item(item)"
-                    >
-                      View
-                    </button>
+                    <span v-if="hasLinks(item)" :class="item?.date ? 'ml-[1ch]' : ''">
+                      <LogLineLinks :item="item" :open-event="openEvent" />
+                    </span>
                   </span>
                   <span>{{ String(item.text).trim() }}</span>
                 </span>
@@ -297,28 +289,36 @@
         </UCard>
       </div>
     </section>
+
+    <UModal v-model:open="eventViewOpen" :title="eventViewTitle" :ui="eventViewModalUi">
+      <template #body>
+        <EventView v-if="selectedEventId" :id="selectedEventId" />
+      </template>
+    </UModal>
   </div>
 </template>
 
 <script setup lang="ts">
-import { nextTick, onBeforeUnmount, onMounted, onUpdated, ref, watch } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, onUpdated, ref, watch } from 'vue';
 import { useHead, useRoute } from '#app';
 import { useBreakpoints, useStorage } from '@vueuse/core';
 import { NuxtLink } from '#components';
 import moment from 'moment';
+import EventView from '~/components/EventView.vue';
 import FloatingImage from '~/components/FloatingImage.vue';
+import LogLineLinks from '~/components/LogLineLinks.vue';
 import Popover from '~/components/Popover.vue';
 import DuplicateRecordList from '~/components/DuplicateRecordList.vue';
 import {
   formatDuration,
-  goto_history_item,
+  makeEventName,
   makeName,
   parse_api_response,
   request,
   ucFirst,
   TOOLTIP_DATE_FORMAT,
 } from '~/utils';
-import type { HistoryItem, JsonObject } from '~/types';
+import type { HistoryItem, JsonObject, LogEntry } from '~/types';
 
 type IndexLogFile = {
   type: string;
@@ -326,14 +326,7 @@ type IndexLogFile = {
   date: number;
   size: number;
   modified: string;
-  lines: Array<{
-    id?: string;
-    item_id?: number;
-    user?: string;
-    backend?: string;
-    date?: string;
-    text: string;
-  }>;
+  lines: Array<LogEntry>;
 };
 
 useHead({ title: 'Index' });
@@ -349,8 +342,35 @@ const logs = ref<Array<IndexLogFile>>([]);
 const reloadingLogs = ref<boolean>(false);
 const historyLoading = ref<boolean>(true);
 const logReloadInterval = ref<ReturnType<typeof setInterval> | null>(null);
+const selectedEventId = ref<string | null>(null);
 const logReloadFrequency = 10000;
 let historyLoadToken = 0;
+
+const eventViewModalUi = {
+  content: 'max-w-5xl',
+  body: 'p-4 sm:p-5',
+};
+
+const eventViewOpen = computed({
+  get: () => null !== selectedEventId.value,
+  set: (value: boolean) => {
+    if (false === value) {
+      selectedEventId.value = null;
+    }
+  },
+});
+
+const eventViewTitle = computed(() =>
+  null === selectedEventId.value ? 'Event' : `#${makeEventName(selectedEventId.value)}`,
+);
+
+const hasLinks = (item: LogEntry): boolean => {
+  return Boolean(item.item_id || item.event_id || item.backend);
+};
+
+const openEvent = (id: string): void => {
+  selectedEventId.value = id;
+};
 
 const duplicatePopoverTrigger = computed<'click' | 'hover'>(() =>
   'mobile' === breakpoints.active().value ? 'click' : 'hover',

--- a/frontend/app/pages/logs/[filename].vue
+++ b/frontend/app/pages/logs/[filename].vue
@@ -175,19 +175,19 @@
               v-for="item in filterItems"
               :key="item.id"
               :class="['log-entry block', wrapLines ? '' : 'whitespace-nowrap']"
-              ><template v-if="item.date"
-                >[<span class="cursor-help" :title="item.date">{{ formatDate(item.date) }}</span
-                >]:&nbsp;</template
-              ><template v-if="item.item_id"
-                ><button
-                  type="button"
-                  class="mr-2 inline-flex items-center gap-1 text-primary hover:underline"
-                  @click="goto_history_item(item)"
-                >
-                  <UIcon name="i-lucide-history" class="size-4" />
-                  <span>View</span></button
-                >&nbsp;</template
               ><span
+                v-if="item.date || hasLinks(item)"
+                class="mr-[1ch] inline-flex items-baseline whitespace-normal"
+              >
+                <template v-if="item.date"
+                  >[<span class="cursor-help" :title="item.date">{{ formatDate(item.date) }}</span
+                  >]</template
+                >
+                <span v-if="hasLinks(item)" :class="item.date ? 'ml-[1ch]' : ''">
+                  <LogLineLinks :item="item" :open-event="openEvent" />
+                </span>
+              </span>
+              <span
                 :class="wrapLines ? 'whitespace-pre-wrap ws-wrap-anywhere' : 'whitespace-pre'"
                 >{{ String(item.text).trimStart() }}</span
               ></span
@@ -195,6 +195,12 @@
           </code>
         </div>
       </UCard>
+
+      <UModal v-model:open="eventViewOpen" :title="eventViewTitle" :ui="eventViewModalUi">
+        <template #body>
+          <EventView v-if="selectedEventId" :id="selectedEventId" />
+        </template>
+      </UModal>
     </template>
   </main>
 </template>
@@ -244,6 +250,8 @@ import { useHead, useRoute, useRouter } from '#app';
 import { useStorage } from '@vueuse/core';
 import { fetchEventSource } from '@microsoft/fetch-event-source';
 import moment from 'moment';
+import EventView from '~/components/EventView.vue';
+import LogLineLinks from '~/components/LogLineLinks.vue';
 import { useDialog } from '~/composables/useDialog';
 import { requireTopLevelPageShell } from '~/utils/topLevelNavigation';
 import type { GenericResponse, LogEntry } from '~/types';
@@ -251,7 +259,7 @@ import {
   copyText,
   disableOpacity,
   enableOpacity,
-  goto_history_item,
+  makeEventName,
   notification,
   parse_api_response,
   request,
@@ -282,7 +290,26 @@ const contentType = ref<'log' | 'json'>('log');
 const stream = ref<boolean>(false);
 const logContainer = ref<HTMLElement | null>(null);
 const streamController = ref<AbortController | null>(null);
+const selectedEventId = ref<string | null>(null);
 const isTodayLog = computed<boolean>(() => filename.includes(moment().format('YYYYMMDD')));
+
+const eventViewModalUi = {
+  content: 'max-w-5xl',
+  body: 'p-4 sm:p-5',
+};
+
+const eventViewOpen = computed({
+  get: () => null !== selectedEventId.value,
+  set: (value: boolean) => {
+    if (false === value) {
+      selectedEventId.value = null;
+    }
+  },
+});
+
+const eventViewTitle = computed(() =>
+  null === selectedEventId.value ? 'Event' : `#${makeEventName(selectedEventId.value)}`,
+);
 
 let scrollTimeout: ReturnType<typeof setTimeout> | null = null;
 
@@ -322,6 +349,14 @@ const filterItems = computed<Array<LogEntry>>(() => {
 
   return data.value.filter((item) => item.text.toLowerCase().includes(query.value.toLowerCase()));
 });
+
+const hasLinks = (item: LogEntry): boolean => {
+  return Boolean(item.item_id || item.event_id || item.backend);
+};
+
+const openEvent = (id: string): void => {
+  selectedEventId.value = id;
+};
 
 const loadContent = async (): Promise<void> => {
   try {

--- a/frontend/app/types/index.d.ts
+++ b/frontend/app/types/index.d.ts
@@ -220,12 +220,16 @@ export interface LogEntry {
   id: string;
   /** Associated item ID if available */
   item_id: string | null;
+  /** Associated event ID if available */
+  event_id: string | null;
   /** User associated with the log entry */
   user: string | null;
   /** Backend associated with the log entry */
   backend: string | null;
   /** Timestamp of the log entry */
   date: string | null;
+  /** Parsed log level if available */
+  level: string | null;
   /** The log message text */
   text: string;
 }

--- a/src/API/Logs/Index.php
+++ b/src/API/Logs/Index.php
@@ -358,26 +358,39 @@ final class Index
             return [
                 'id' => md5((string) (hrtime(true) + random_int(1, 10_000))),
                 'item_id' => null,
+                'event_id' => null,
                 'user' => null,
                 'backend' => null,
                 'date' => null,
+                'level' => null,
                 'text' => $line,
             ];
         }
 
         $dateRegex = '/^\[([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]+)?[+-][0-9]{2}:[0-9]{2})]/i';
+        $eventRegex = '/\[event:(?<event_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})]\s*/i';
+        $levelRegex = '/^(?:[a-z0-9_.-]+\.)?(?<level>EMERGENCY|ALERT|CRITICAL|ERROR|WARNING|NOTICE|INFO|DEBUG):\s*/i';
 
         $dateMatch = preg_match($dateRegex, $line, $matches);
         $idMatch = preg_match("/'#(?P<item_id>\d+):/", $line, $idMatches);
+        $eventMatch = preg_match($eventRegex, $line, $eventMatches);
         $identMatch = preg_match("/'((?P<client>\w+):\s)?(?P<user>\w+)@(?P<backend>\w+)'/i", $line, $identMatches);
+        $text = 1 === $dateMatch ? trim(preg_replace($dateRegex, '', $line)) : $line;
+        $levelMatch = preg_match($levelRegex, $text, $levelMatches);
+
+        if (1 === $eventMatch) {
+            $text = trim(preg_replace($eventRegex, '', $text, 1));
+        }
 
         $logLine = [
             'id' => md5($line . (hrtime(true) + random_int(1, 10_000))),
             'item_id' => null,
+            'event_id' => 1 === $eventMatch ? $eventMatches['event_id'] : null,
             'user' => null,
             'backend' => null,
             'date' => 1 === $dateMatch ? $matches[1] : null,
-            'text' => 1 === $dateMatch ? trim(preg_replace($dateRegex, '', $line)) : $line,
+            'level' => 1 === $levelMatch ? strtolower($levelMatches['level']) : null,
+            'text' => $text,
         ];
 
         if (1 === $idMatch) {

--- a/src/Commands/Database/LegacyCommand.php
+++ b/src/Commands/Database/LegacyCommand.php
@@ -125,17 +125,11 @@ final class LegacyCommand extends Command
         foreach ($targets as $target) {
             if (false === file_exists($target['source'])) {
                 if (true === file_exists($target['backup'])) {
-                    $output->writeln(r('<comment>{target}: Legacy source already renamed to {backup}. Skipping.</comment>', [
+                    $output->writeln(r('<comment>{target}: Legacy source db already renamed to {backup}. Skipping.</comment>', [
                         'target' => $target['name'],
                         'backup' => $target['backup'],
                     ]));
-                    continue;
                 }
-
-                $output->writeln(r('<comment>{target}: No legacy source found at {source}. Skipping.</comment>', [
-                    'target' => $target['name'],
-                    'source' => $target['source'],
-                ]));
                 continue;
             }
 
@@ -254,10 +248,6 @@ final class LegacyCommand extends Command
     {
         foreach ($targets as $target) {
             if (false === file_exists($target['backup'])) {
-                $output->writeln(r('<comment>{target}: No legacy backup found at {backup}. Skipping.</comment>', [
-                    'target' => $target['name'],
-                    'backup' => $target['backup'],
-                ]));
                 continue;
             }
 

--- a/src/Commands/Events/DispatchCommand.php
+++ b/src/Commands/Events/DispatchCommand.php
@@ -8,11 +8,16 @@ use App\Command;
 use App\Libs\Attributes\Route\Cli;
 use App\Libs\Config;
 use App\Libs\Events\DataEvent;
+use App\Libs\Extends\ProxyHandler;
 use App\Libs\Options;
 use App\Model\Events\Event;
 use App\Model\Events\EventsRepository;
 use App\Model\Events\EventsTable;
 use App\Model\Events\EventStatus as Status;
+use Monolog\Handler\HandlerInterface;
+use Monolog\Level;
+use Monolog\Logger as MonologLogger;
+use Monolog\LogRecord;
 use Psr\EventDispatcher\EventDispatcherInterface as iDispatcher;
 use Psr\Log\LoggerInterface as iLogger;
 use Psr\SimpleCache\CacheInterface as iCache;
@@ -66,6 +71,7 @@ final class DispatchCommand extends Command
         register_events();
 
         $debug = $input->getOption('debug') || Config::get('debug.enabled');
+        $visibleLevel = true === (bool) $input->getOption('debug') ? Level::Debug : $this->toLevel($output);
 
         if (null !== ($id = $input->getOption('id'))) {
             if (null === ($event = $this->repo->findById($id))) {
@@ -77,15 +83,15 @@ final class DispatchCommand extends Command
                 $event->logs = [];
             }
 
-            $this->runEvent($event, debug: $debug);
+            $this->runEvent($event, visibleLevel: $visibleLevel, debug: $debug);
 
             return self::SUCCESS;
         }
 
-        return $this->runEvents(debug: $debug);
+        return $this->runEvents(visibleLevel: $visibleLevel, debug: $debug);
     }
 
-    protected function runEvents(bool $debug = false): int
+    protected function runEvents(Level $visibleLevel, bool $debug = false): int
     {
         $repo = $this->repo
             ->setSort(EventsTable::COLUMN_CREATED_AT)
@@ -143,17 +149,21 @@ final class DispatchCommand extends Command
                 continue;
             }
 
-            $this->runEvent($event);
+            $this->runEvent($event, visibleLevel: $visibleLevel, debug: $debug);
         }
 
         return self::SUCCESS;
     }
 
-    private function runEvent(Event $event, bool $debug = false): void
+    private function runEvent(Event $event, Level $visibleLevel, bool $debug = false): void
     {
+        $capturedRecords = [];
+        $capturedHandlers = null;
+
         try {
-            $message = "Dispatching Event: '{event}' queued at '{date}'.";
+            $message = "[event:{id}] Dispatching Event: '{event}' queued at '{date}'.";
             $log_data = [
+                'id' => $event->id,
                 'event' => $event->event,
                 'date' => make_date($event->created_at),
             ];
@@ -163,9 +173,6 @@ final class DispatchCommand extends Command
             if (count($event->event_data) > 0) {
                 $log_data['data'] = $event->event_data;
             }
-
-            $this->logger->info($message, $log_data);
-
             $event->status = Status::RUNNING;
             $event->updated_at = (string) make_date();
             $event->attempts += 1;
@@ -174,8 +181,15 @@ final class DispatchCommand extends Command
             }
             $this->repo->save($event);
 
+            $logCount = count($event->logs);
             $ref = new DataEvent($event);
-            $this->dispatcher->dispatch($ref, $event->event);
+            $capturedHandlers = $this->captureLogger($capturedRecords);
+
+            try {
+                $this->dispatcher->dispatch($ref, $event->event);
+            } finally {
+                $this->restoreLogger($capturedHandlers);
+            }
 
             if (Status::RUNNING !== $ref->getStatus()) {
                 $event->status = $ref->getStatus();
@@ -184,10 +198,20 @@ final class DispatchCommand extends Command
             }
 
             $event->updated_at = (string) make_date();
+
+            if ($this->isVisible(array_slice($event->logs, $logCount), $visibleLevel)) {
+                $this->logger->notice($message, $log_data);
+            }
+
+            $this->replayRecords($capturedHandlers, $capturedRecords);
+
             $event->logs[] = r("Event '{event}' was dispatched.", ['event' => $event->event]);
 
             $this->repo->save($event);
         } catch (Throwable $e) {
+            $this->restoreLogger($capturedHandlers);
+            $this->replayRecords($capturedHandlers, $capturedRecords);
+
             $errorLog = r("Failed to dispatch event: '{event}'. {error}", [
                 'event' => ag($event, 'event'),
                 'error' => $e->getMessage(),
@@ -199,7 +223,110 @@ final class DispatchCommand extends Command
             $event->updated_at = (string) make_date();
             $this->repo->save($event);
 
-            $this->logger->error($errorLog, ['trace' => $e->getTrace()]);
+            $this->logger->error('[event:{id}] {message}', [
+                'id' => $event->id,
+                'message' => $errorLog,
+                'trace' => $e->getTrace(),
+            ]);
+        }
+    }
+
+    private function captureLogger(array &$records): ?array
+    {
+        if (false === $this->logger instanceof MonologLogger) {
+            return null;
+        }
+
+        $handlers = $this->logger->getHandlers();
+        $this->logger->setHandlers([
+            ProxyHandler::create(static function (string $_message, mixed $record) use (&$records): void {
+                if ($record instanceof LogRecord) {
+                    $records[] = $record;
+                }
+            }, Level::Debug),
+        ]);
+
+        return $handlers;
+    }
+
+    private function restoreLogger(?array $handlers): void
+    {
+        if (null === $handlers || false === $this->logger instanceof MonologLogger) {
+            return;
+        }
+
+        $this->logger->setHandlers($handlers);
+    }
+
+    private function replayRecords(?array $handlers, array $records): void
+    {
+        if (null === $handlers) {
+            return;
+        }
+
+        foreach ($records as $record) {
+            if (false === $record instanceof LogRecord) {
+                continue;
+            }
+
+            foreach ($handlers as $handler) {
+                if (false === $handler instanceof HandlerInterface) {
+                    continue;
+                }
+
+                if (true === $handler->handle($record)) {
+                    break;
+                }
+            }
+        }
+    }
+
+    private function toLevel(OutputInterface $output): Level
+    {
+        return match ($output->getVerbosity()) {
+            OutputInterface::VERBOSITY_QUIET => Level::Error,
+            OutputInterface::VERBOSITY_NORMAL => Level::Warning,
+            OutputInterface::VERBOSITY_VERBOSE => Level::Notice,
+            OutputInterface::VERBOSITY_VERY_VERBOSE => Level::Info,
+            default => Level::Debug,
+        };
+    }
+
+    private function isVisible(array $logs, Level $visibleLevel): bool
+    {
+        $count = 0;
+
+        foreach ($logs as $log) {
+            $level = $this->eventLevel($log);
+
+            if (null === $level) {
+                continue;
+            }
+
+            if ($level->value >= $visibleLevel->value) {
+                $count++;
+            }
+        }
+
+        return $count > 0;
+    }
+
+    private function eventLevel(mixed $log): ?Level
+    {
+        if (false === is_string($log)) {
+            return null;
+        }
+
+        $levelRegex = '/^(?:\[[^\]]+]\s*)?(?:[a-z0-9_.-]+\.)?(?<level>EMERGENCY|ALERT|CRITICAL|ERROR|WARNING|NOTICE|INFO|DEBUG):\s*/i';
+
+        if (1 !== preg_match($levelRegex, trim($log), $matches)) {
+            return null;
+        }
+
+        try {
+            return MonologLogger::toMonologLevel(strtoupper($matches['level']));
+        } catch (Throwable) {
+            return null;
         }
     }
 

--- a/src/Libs/Database/PDO/PDOAdapter.php
+++ b/src/Libs/Database/PDO/PDOAdapter.php
@@ -587,7 +587,17 @@ final class PDOAdapter implements iDB
         $this->db->transactional(static function (DBLayer $db) {
             /** @noinspection SqlResolve */
             $tables = $db->query(
-                'SELECT name FROM sqlite_master WHERE "type" = "table" AND "name" NOT LIKE "sqlite_%"',
+                'SELECT
+                    "name"
+                FROM
+                    sqlite_master
+                WHERE
+                    "type" = "table"
+                AND
+                    "name" NOT LIKE "sqlite_%"
+                AND
+                    "name" NOT LIKE "migration_%"
+                    ',
             );
 
             foreach ($tables->fetchAll(PDO::FETCH_COLUMN) as $table) {

--- a/src/Libs/Mappers/Import/DirectMapper.php
+++ b/src/Libs/Mappers/Import/DirectMapper.php
@@ -426,7 +426,7 @@ class DirectMapper implements ImportInterface
                 Message::increment("{$entity->via}.{$local->type}.failed");
                 $this->logger->error(
                     ...lw(
-                        message: "{mapper}: [T] Exception '{error.kind}' was thrown unhandled during '{user}@{backend}' - '{title}' handle tainted. {error.message} at '{error.file}:{error.line}'.",
+                        message: "{mapper}: [T] Exception '{error.kind}' was thrown unhandled during '{user}@{backend}' - '{title}' metadata-only handling. {error.message} at '{error.file}:{error.line}'.",
                         context: [
                             'user' => $this->userContext->name ?? 'main',
                             'mapper' => after_last(self::class, '\\'),
@@ -467,7 +467,7 @@ class DirectMapper implements ImportInterface
             $reasons = [];
 
             if (true === $entity->isTainted()) {
-                $reasons[] = 'event marked as tainted';
+                $reasons[] = 'metadata-only event';
             }
 
             if (count($reasons) < 1) {
@@ -475,7 +475,7 @@ class DirectMapper implements ImportInterface
             }
 
             $this->logger->notice(
-                "{mapper}: [T] '{user}@{backend}' item '#{id}: {title}' is marked as '{state}' vs local '{local_state}', However due to the following reason '{reasons}' it was not considered as valid state.",
+                "{mapper}: [T] '{user}@{backend}' item '#{id}: {title}' reported '{state}' vs local '{local_state}', but the state change was ignored due to '{reasons}'.",
                 [
                     'user' => $this->userContext->name ?? 'main',
                     'mapper' => after_last(self::class, '\\'),
@@ -713,7 +713,7 @@ class DirectMapper implements ImportInterface
             }
 
             $this->logger->notice(
-                "[CODE:DM001] {mapper}: [O] '{user}@{backend}' item '#{id}: {title}' [R: {state}] date '{remote_date}' is older than backend last sync date '{local_date}' [L: {local_state}]. Marking the item as tainted and re-processing. Check FAQ.",
+                "[CODE:DM001] {mapper}: [O] '{user}@{backend}' item '#{id}: {title}' [R: {state}] date '{remote_date}' is older than backend last sync date '{local_date}' [L: {local_state}]. Queueing item for re-processing. Check FAQ.",
                 [
                     'user' => $this->userContext->name ?? 'main',
                     'mapper' => after_last(self::class, '\\'),
@@ -834,11 +834,11 @@ class DirectMapper implements ImportInterface
             $hasDate = $entity->updated === ag($local->getMetadata($entity->via), iState::COLUMN_META_DATA_PLAYED_AT);
 
             if (false === $hasMeta) {
-                $message .= ' No metadata. Marking the item as tainted and re-processing.';
+                $message .= ' No metadata. Queueing item for re-processing.';
             }
 
             if (true === $hasMeta && true === $hasDate) {
-                $message .= ' db.metadata.played_at is equal to entity.updated. Marking the item as tainted and re-processing.';
+                $message .= ' db.metadata.played_at matches entity.updated. Queueing item for re-processing.';
             }
 
             $this->logger->warning($message, [

--- a/src/Libs/Mappers/Import/MemoryMapper.php
+++ b/src/Libs/Mappers/Import/MemoryMapper.php
@@ -290,10 +290,10 @@ class MemoryMapper implements ImportInterface
             $reasons = [];
 
             if (true === $entity->isTainted()) {
-                $reasons[] = 'event marked as tainted';
+                $reasons[] = 'metadata-only event';
             }
             if (true === (bool) ag($opts, Options::IMPORT_METADATA_ONLY)) {
-                $reasons[] = 'mapper is in metadata only mode';
+                $reasons[] = 'mapper is in metadata-only mode';
             }
 
             if (count($reasons) < 1) {
@@ -301,7 +301,7 @@ class MemoryMapper implements ImportInterface
             }
 
             $this->logger->notice(
-                "{mapper}: [T] Item '{user}@{backend}' - '#{id}: {title}' is marked as '{state}' vs local '{local_state}', However due to the following reasons '{reasons}' it was not considered as valid state.",
+                "{mapper}: [T] Item '{user}@{backend}' - '#{id}: {title}' reported '{state}' vs local '{local_state}', but the state change was ignored due to '{reasons}'.",
                 [
                     'user' => $this->userContext->name ?? 'main',
                     'mapper' => after_last(self::class, '\\'),
@@ -548,9 +548,9 @@ class MemoryMapper implements ImportInterface
             $hasDate = $entity->updated === ag($cloned->getMetadata($entity->via), iState::COLUMN_META_DATA_PLAYED_AT);
 
             if (false === $hasMeta) {
-                $message .= ' No metadata. Marking the item as tainted and re-processing.';
+                $message .= ' No metadata. Queueing item for re-processing.';
             } elseif (true === $hasDate) {
-                $message .= ' db.metadata.played_at is equal to entity.updated. Marking the item as tainted and re-processing.';
+                $message .= ' db.metadata.played_at matches entity.updated. Queueing item for re-processing.';
             }
 
             $this->logger->warning($message, [

--- a/src/Listeners/ProcessWebhookEvent.php
+++ b/src/Listeners/ProcessWebhookEvent.php
@@ -486,10 +486,10 @@ final class ProcessWebhookEvent
             $lastSync = make_date($lastSync);
         }
 
-        ($this->writer)(Level::Notice, r("Processing '{user}@{backend}' {tainted} request '{title}'. {data}", [
+        ($this->writer)(Level::Notice, r("{prefix}Processing '{user}@{backend}' request '{title}'. {data}", [
             'backend' => $entity->via,
             'title' => $entity->getName(),
-            'tainted' => $entity->isTainted() ? 'tainted' : 'untainted',
+            'prefix' => true === $entity->isTainted() ? '[T] ' : '',
             'lastSync' => $lastSync,
             'user' => $userContext->name,
             'data' => array_to_string([

--- a/tests/API/Logs/IndexTest.php
+++ b/tests/API/Logs/IndexTest.php
@@ -11,16 +11,16 @@ final class IndexTest extends TestCase
 {
     public function test_formatLog_no_whitelist(): void
     {
-        $line = "[2026-04-27T10:17:56+03:00] NOTICE: Processing 'main@office_emby' - '#123: IppSec' item.";
+        $line = "[2026-04-27T10:17:56+03:00] NOTICE: Processing 'main@emby_main' - '#123: IppSec' item.";
 
         $parsed = Index::formatLog($line);
 
         $this->assertSame('123', $parsed['item_id'], 'Log formatter should extract history item ids from structured messages.');
         $this->assertSame('main', $parsed['user'], 'Log formatter should expose the user even when no whitelist is provided.');
-        $this->assertSame('office_emby', $parsed['backend'], 'Log formatter should expose the backend even when no whitelist is provided.');
+        $this->assertSame('emby_main', $parsed['backend'], 'Log formatter should expose the backend even when no whitelist is provided.');
         $this->assertSame('2026-04-27T10:17:56+03:00', $parsed['date'], 'Log formatter should preserve the bracketed timestamp.');
         $this->assertSame(
-            "NOTICE: Processing 'main@office_emby' - '#123: IppSec' item.",
+            "NOTICE: Processing 'main@emby_main' - '#123: IppSec' item.",
             $parsed['text'],
             'Log formatter should strip the timestamp prefix from the display text.'
         );
@@ -35,5 +35,17 @@ final class IndexTest extends TestCase
         $this->assertNull($parsed['item_id'], 'Stringified payloads should not invent item ids.');
         $this->assertNull($parsed['user'], 'Stringified payloads should not invent users.');
         $this->assertNull($parsed['backend'], 'Stringified payloads should not invent backends.');
+    }
+
+    public function test_event_marker(): void
+    {
+        $eventId = '550e8400-e29b-41d4-a716-446655440000';
+        $line = "[2026-04-27T10:17:56+03:00] NOTICE: [event:{$eventId}] Dispatching Event: 'on_push' queued at '2026-05-17T08:25:02+03:00'.";
+
+        $parsed = Index::formatLog($line);
+
+        $this->assertSame($eventId, $parsed['event_id']);
+        $this->assertSame('notice', $parsed['level']);
+        $this->assertSame("NOTICE: Dispatching Event: 'on_push' queued at '2026-05-17T08:25:02+03:00'.", $parsed['text']);
     }
 }

--- a/tests/Commands/Events/DispatchCommandTest.php
+++ b/tests/Commands/Events/DispatchCommandTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands\Events;
+
+use App\Commands\Events\DispatchCommand;
+use App\Libs\Events\DataEvent;
+use App\Libs\Extends\LogMessageProcessor;
+use App\Libs\TestCase;
+use App\Model\Events\Event;
+use App\Model\Events\EventsRepository;
+use Monolog\Handler\TestHandler;
+use Monolog\Level;
+use Monolog\Logger;
+use Psr\Log\LoggerInterface as iLogger;
+use Psr\SimpleCache\CacheInterface as iCache;
+use ReflectionMethod;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+final class DispatchCommandTest extends TestCase
+{
+    public function test_visible_logs(): void
+    {
+        $method = new ReflectionMethod(DispatchCommand::class, 'isVisible');
+        $command = $this->makeCommand();
+
+        self::assertTrue($method->invoke(
+            $command,
+            [
+                'INFO: hidden',
+                'NOTICE: visible',
+                '[2026-04-27T10:17:56+03:00] WARNING: visible',
+                'plain text',
+            ],
+            Level::Notice,
+        ));
+
+        self::assertTrue($method->invoke(
+            $command,
+            [
+                'INFO: visible',
+                'NOTICE: visible',
+                'WARNING: visible',
+                'event.DEBUG: hidden',
+            ],
+            Level::Info,
+        ));
+
+        self::assertFalse($method->invoke($command, ['INFO: hidden'], Level::Warning));
+    }
+
+    public function test_orders_marker(): void
+    {
+        $handler = new TestHandler(Level::Debug);
+        $logger = new Logger('test', [$handler], [new LogMessageProcessor()]);
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener('on_push', static function (DataEvent $event) use ($logger): void {
+            $event->addLog('NOTICE: listener visible');
+            $logger->notice('Listener visible.');
+        });
+
+        $repo = $this->createMock(EventsRepository::class);
+        $repo->expects(self::exactly(2))->method('save')->willReturn('event-id');
+
+        $event = new Event([]);
+        $event->id = '550e8400-e29b-41d4-a716-446655440000';
+        $event->event = 'on_push';
+        $event->created_at = make_date('2026-05-17T08:25:02+00:00');
+
+        $method = new ReflectionMethod(DispatchCommand::class, 'runEvent');
+        $method->invoke(
+            new DispatchCommand(
+                $dispatcher,
+                $repo,
+                $this->createStub(iCache::class),
+                $logger,
+            ),
+            $event,
+            Level::Notice,
+        );
+
+        $records = $handler->getRecords();
+        self::assertSame(
+            "[event:550e8400-e29b-41d4-a716-446655440000] Dispatching Event: 'on_push' queued at '2026-05-17T08:25:02+00:00'.",
+            $records[0]->message,
+        );
+        self::assertSame('Listener visible.', $records[1]->message);
+    }
+
+    private function makeCommand(): DispatchCommand
+    {
+        return new DispatchCommand(
+            new EventDispatcher(),
+            $this->createStub(EventsRepository::class),
+            $this->createStub(iCache::class),
+            $this->createStub(iLogger::class),
+        );
+    }
+}

--- a/tests/Database/PDOAdapterTest.php
+++ b/tests/Database/PDOAdapterTest.php
@@ -610,6 +610,20 @@ class PDOAdapterTest extends TestCase
         $this->assertSame(1, $inserted->id, 'Reset should also clear the sqlite autoincrement sequence.');
     }
 
+    public function test_reset_keeps_migration_metadata(): void
+    {
+        $this->seedEntities();
+
+        $this->assertTrue($this->db->reset(), 'Reset should succeed for a migrated sqlite database.');
+
+        $pdo = $this->db->getDBLayer()->getBackend();
+        $migrations = new PackageMigrationFactory();
+
+        self::assertTrue($migrations->isMigrated($pdo), 'Reset should preserve package migration state.');
+        self::assertSame('1', (string) $pdo->query('SELECT COUNT(*) FROM migration_version')?->fetchColumn());
+        self::assertSame('0', (string) $pdo->query('SELECT COUNT(*) FROM migration_lock')?->fetchColumn());
+    }
+
     public function test_transaction()
     {
         $this->db->getDBLayer()->transactional(function () {


### PR DESCRIPTION
This pull request introduces several improvements and enhancements to log viewing and event navigation in the frontend, along with some clarifications and minor corrections in documentation and backend log parsing. The most significant changes are the addition of contextual links to log entries, allowing users to quickly navigate to related events, history, or backend details, and the ability to open detailed event views in a modal. Additionally, log parsing on the backend has been improved to extract more metadata, and documentation has been updated for clarity.

**Frontend Enhancements:**

* Added a new vue component, which provides a popover menu with contextual links (event, history, backend) for each log entry that has related metadata. This replaces the previous single "View" button and makes navigation more flexible and user-friendly. 
* Introduced the ability to open an event's detailed view in a modal dialog from log entries, both on the main index and log file pages. 
* Clarified the meaning of "tainted" items and updated the description of how conflicts are handled between local and backend play states.
* Fixed reset operations also resetting migrations tables.