### PR TITLE
Feat: add flag to force replace metadata

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -127,6 +127,36 @@ This will push your local watch state to the backend and ensure both are in sync
 
 ----
 
+# How to force a backend metadata refresh?
+
+By default, `state:import` is conservative, if a backend stops reporting a metadata field, WatchState keeps
+the locally stored value instead of assuming the missing field should be removed. This avoids accidental data loss from
+partial or inconsistent backend API responses.
+
+If you know want a specific backend to be authoritative, run import with `--force-metadata-change`.
+This makes the imported backend replace its own local metadata block with exactly what the backend reports.
+
+For example, to make `plex_main` authoritative for metadata and progress:
+
+```bash
+bin/console state:import --select-backend plex_main --force-full --force-metadata-change
+```
+
+When this flag is used:
+
+* Metadata keys omitted by the selected backend are removed from local db.
+* If the selected backend reports a different progress value, that exact value is propagated to export-enabled backends.
+
+> [!WARNING]
+> Use `--select-backend` with this flag unless you intentionally want all imported backends to compete. If you import
+> multiple backends with `--force-metadata-change`, the final result depends on backend processing order and the last
+> backend that updates an item can win.
+
+This flag does not make import ignore every play-state guard. If you also need to ignore the last import timestamp and
+scan the full backend, combine it with `--force-full`.
+
+----
+
 # My New Backend Watch State Is Not Being Updated?
 
 This issue is most likely caused by a **date mismatch**. When exporting watch state, the system compares the date of the

--- a/FAQ.md
+++ b/FAQ.md
@@ -133,13 +133,18 @@ By default, `state:import` is conservative, if a backend stops reporting a metad
 the locally stored value instead of assuming the missing field should be removed. This avoids accidental data loss from
 partial or inconsistent backend API responses.
 
-If you know want a specific backend to be authoritative, run import with `--force-metadata-change`.
+If you want a specific backend to be authoritative, run import with `--force-replace-metadata`.
 This makes the imported backend replace its own local metadata block with exactly what the backend reports.
+
+This is flag is a bit different from `--always-update-metadata`:
+
+* `--always-update-metadata` updates metadata by merging backend data into the existing local metadata.
+* `--force-replace-metadata` replaces the selected backend metadata block, so omitted keys are removed locally.
 
 For example, to make `plex_main` authoritative for metadata and progress:
 
 ```bash
-bin/console state:import --select-backend plex_main --force-full --force-metadata-change
+$ bin/console state:import -vv --force-full --force-replace-metadata -s plex_main 
 ```
 
 When this flag is used:
@@ -149,11 +154,11 @@ When this flag is used:
 
 > [!WARNING]
 > Use `--select-backend` with this flag unless you intentionally want all imported backends to compete. If you import
-> multiple backends with `--force-metadata-change`, the final result depends on backend processing order and the last
+> multiple backends with `--force-replace-metadata`, the final result depends on backend processing order and the last
 > backend that updates an item can win.
 
 This flag does not make import ignore every play-state guard. If you also need to ignore the last import timestamp and
-scan the full backend, combine it with `--force-full`.
+scan the full backend, combine it with `-f, --force-full`.
 
 ----
 

--- a/src/Backends/Emby/Action/Progress.php
+++ b/src/Backends/Emby/Action/Progress.php
@@ -108,7 +108,7 @@ class Progress
             }
 
             $metadata = $entity->getMetadata($context->backendName);
-            $forceChange = true === (bool) ag($context->options, Options::FORCE_METADATA_CHANGE, false);
+            $forceChange = true === (bool) ag($context->options, Options::FORCE_REPLACE_METADATA, false);
             $hasProgress = ag_exists($context->options, Options::STATE_PROGRESS_VALUE);
             $progressValue = true === $hasProgress
                 ? (int) ag($context->options, Options::STATE_PROGRESS_VALUE, 0)

--- a/src/Backends/Emby/Action/Progress.php
+++ b/src/Backends/Emby/Action/Progress.php
@@ -108,6 +108,11 @@ class Progress
             }
 
             $metadata = $entity->getMetadata($context->backendName);
+            $forceChange = true === (bool) ag($context->options, Options::FORCE_METADATA_CHANGE, false);
+            $hasProgress = ag_exists($context->options, Options::STATE_PROGRESS_VALUE);
+            $progressValue = true === $hasProgress
+                ? (int) ag($context->options, Options::STATE_PROGRESS_VALUE, 0)
+                : $entity->getPlayProgress();
 
             $logContext = [
                 'action' => $this->action,
@@ -118,7 +123,7 @@ class Progress
                     'id' => $entity->id,
                     'type' => $entity->type,
                     'title' => $entity->getName(),
-                    'progress' => format_duration($entity->getPlayProgress()),
+                    'progress' => format_duration($progressValue),
                 ],
             ];
 
@@ -248,17 +253,25 @@ class Progress
                     message: "{action}: Updating '{client}: {user}@{backend}' {item.type} '{item.title}' watch progress to '{progress}'.",
                     context: [
                         ...$logContext,
-                        'progress' => format_duration($entity->getPlayProgress()),
+                        'progress' => format_duration($progressValue),
                         // -- convert secs to ms for emby to understand it.
-                        'time' => floor($entity->getPlayProgress() * 1_00_00),
+                        'time' => floor($progressValue * 1_00_00),
                     ],
                 );
 
                 if (false === (bool) ag($context->options, Options::DRY_RUN, false)) {
                     $requestContext = [
                         ...$logContext,
-                        'progress' => format_duration($entity->getPlayProgress()),
+                        'progress' => format_duration($progressValue),
                     ];
+
+                    $json = [
+                        'PlaybackPositionTicks' => (string) floor($progressValue * 1_00_00),
+                    ];
+
+                    if (false === ($forceChange && true === $hasProgress && $progressValue < 1)) {
+                        $json['LastPlayedDate'] = make_date($senderDate)->format(Date::ATOM);
+                    }
 
                     $queue->add(
                         new Request(
@@ -268,10 +281,7 @@ class Progress
                                 'headers' => [
                                     'Content-Type' => 'application/json',
                                 ],
-                                'json' => [
-                                    'PlaybackPositionTicks' => (string) floor($entity->getPlayProgress() * 1_00_00),
-                                    'LastPlayedDate' => make_date($senderDate)->format(Date::ATOM),
-                                ],
+                                'json' => $json,
                             ]),
                             success: function (ResponseInterface $response) use ($requestContext): array {
                                 $statusCode = $response->getStatusCode();

--- a/src/Backends/Jellyfin/Action/Import.php
+++ b/src/Backends/Jellyfin/Action/Import.php
@@ -961,6 +961,7 @@ class Import
                 Options::IMPORT_METADATA_ONLY => true === (bool) ag($context->options, Options::IMPORT_METADATA_ONLY),
                 Options::DISABLE_MARK_UNPLAYED => true === (bool) ag($context->options, Options::DISABLE_MARK_UNPLAYED),
                 Options::FORCE_FULL => true === (bool) ag($context->options, Options::FORCE_FULL),
+                Options::FORCE_METADATA_CHANGE => true === (bool) ag($context->options, Options::FORCE_METADATA_CHANGE),
             ];
 
             $mapper->add(entity: $entity, opts: $opts);

--- a/src/Backends/Jellyfin/Action/Import.php
+++ b/src/Backends/Jellyfin/Action/Import.php
@@ -961,7 +961,7 @@ class Import
                 Options::IMPORT_METADATA_ONLY => true === (bool) ag($context->options, Options::IMPORT_METADATA_ONLY),
                 Options::DISABLE_MARK_UNPLAYED => true === (bool) ag($context->options, Options::DISABLE_MARK_UNPLAYED),
                 Options::FORCE_FULL => true === (bool) ag($context->options, Options::FORCE_FULL),
-                Options::FORCE_METADATA_CHANGE => true === (bool) ag($context->options, Options::FORCE_METADATA_CHANGE),
+                Options::FORCE_REPLACE_METADATA => true === (bool) ag($context->options, Options::FORCE_REPLACE_METADATA),
             ];
 
             $mapper->add(entity: $entity, opts: $opts);

--- a/src/Backends/Jellyfin/Action/Progress.php
+++ b/src/Backends/Jellyfin/Action/Progress.php
@@ -135,7 +135,7 @@ class Progress
             }
 
             $metadata = $entity->getMetadata($context->backendName);
-            $forceChange = true === (bool) ag($context->options, Options::FORCE_METADATA_CHANGE, false);
+            $forceChange = true === (bool) ag($context->options, Options::FORCE_REPLACE_METADATA, false);
             $hasProgress = ag_exists($context->options, Options::STATE_PROGRESS_VALUE);
             $progressValue = true === $hasProgress
                 ? (int) ag($context->options, Options::STATE_PROGRESS_VALUE, 0)

--- a/src/Backends/Jellyfin/Action/Progress.php
+++ b/src/Backends/Jellyfin/Action/Progress.php
@@ -135,6 +135,11 @@ class Progress
             }
 
             $metadata = $entity->getMetadata($context->backendName);
+            $forceChange = true === (bool) ag($context->options, Options::FORCE_METADATA_CHANGE, false);
+            $hasProgress = ag_exists($context->options, Options::STATE_PROGRESS_VALUE);
+            $progressValue = true === $hasProgress
+                ? (int) ag($context->options, Options::STATE_PROGRESS_VALUE, 0)
+                : $entity->getPlayProgress();
 
             $logContext = [
                 'action' => $this->action,
@@ -145,7 +150,7 @@ class Progress
                     'id' => $entity->id,
                     'type' => $entity->type,
                     'title' => $entity->getName(),
-                    'progress' => format_duration($entity->getPlayProgress()),
+                    'progress' => format_duration($progressValue),
                 ],
             ];
 
@@ -271,21 +276,25 @@ class Progress
                     message: "{action}: Updating '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' watch progress to '{progress}'.",
                     context: [
                         ...$logContext,
-                        'progress' => $entity->hasPlayProgress()
-                            ? format_duration(
-                                $entity->getPlayProgress(),
-                            )
-                            : '0:0:0',
+                        'progress' => format_duration($progressValue),
                         // -- convert secs to ms for jellyfin/emby to understand it.
-                        'time' => floor($entity->getPlayProgress() * 1_00_00),
+                        'time' => floor($progressValue * 1_00_00),
                     ],
                 );
 
                 if (false === (bool) ag($context->options, Options::DRY_RUN, false)) {
                     $requestContext = [
                         ...$logContext,
-                        'progress' => format_duration($entity->getPlayProgress()),
+                        'progress' => format_duration($progressValue),
                     ];
+
+                    $json = [
+                        'PlaybackPositionTicks' => (string) floor($progressValue * 1_00_00),
+                    ];
+
+                    if (false === ($forceChange && true === $hasProgress && $progressValue < 1)) {
+                        $json['LastPlayedDate'] = make_date($senderDate)->format(Date::ATOM);
+                    }
 
                     $queue->add(
                         new Request(
@@ -295,10 +304,7 @@ class Progress
                                 'headers' => [
                                     'Content-Type' => 'application/json',
                                 ],
-                                'json' => [
-                                    'PlaybackPositionTicks' => (string) floor($entity->getPlayProgress() * 1_00_00),
-                                    'LastPlayedDate' => make_date($senderDate)->format(Date::ATOM),
-                                ],
+                                'json' => $json,
                             ]),
                             success: function (ResponseInterface $response) use ($requestContext): array {
                                 $statusCode = $response->getStatusCode();

--- a/src/Backends/Plex/Action/Import.php
+++ b/src/Backends/Plex/Action/Import.php
@@ -962,6 +962,7 @@ class Import
                 Options::IMPORT_METADATA_ONLY => true === (bool) ag($context->options, Options::IMPORT_METADATA_ONLY),
                 Options::DISABLE_MARK_UNPLAYED => true === (bool) ag($context->options, Options::DISABLE_MARK_UNPLAYED),
                 Options::FORCE_FULL => true === (bool) ag($context->options, Options::FORCE_FULL),
+                Options::FORCE_METADATA_CHANGE => true === (bool) ag($context->options, Options::FORCE_METADATA_CHANGE),
             ]);
         } catch (Throwable $e) {
             $this->logger->error(

--- a/src/Backends/Plex/Action/Import.php
+++ b/src/Backends/Plex/Action/Import.php
@@ -962,7 +962,7 @@ class Import
                 Options::IMPORT_METADATA_ONLY => true === (bool) ag($context->options, Options::IMPORT_METADATA_ONLY),
                 Options::DISABLE_MARK_UNPLAYED => true === (bool) ag($context->options, Options::DISABLE_MARK_UNPLAYED),
                 Options::FORCE_FULL => true === (bool) ag($context->options, Options::FORCE_FULL),
-                Options::FORCE_METADATA_CHANGE => true === (bool) ag($context->options, Options::FORCE_METADATA_CHANGE),
+                Options::FORCE_REPLACE_METADATA => true === (bool) ag($context->options, Options::FORCE_REPLACE_METADATA),
             ]);
         } catch (Throwable $e) {
             $this->logger->error(

--- a/src/Backends/Plex/Action/Progress.php
+++ b/src/Backends/Plex/Action/Progress.php
@@ -117,6 +117,9 @@ class Progress
             }
 
             $metadata = $entity->getMetadata($context->backendName);
+            $progressValue = ag_exists($context->options, Options::STATE_PROGRESS_VALUE)
+                ? (int) ag($context->options, Options::STATE_PROGRESS_VALUE, 0)
+                : $entity->getPlayProgress();
 
             $logContext = [
                 'action' => $this->action,
@@ -127,7 +130,7 @@ class Progress
                     'id' => $entity->id,
                     'type' => $entity->type,
                     'title' => $entity->getName(),
-                    'progress' => format_duration($entity->getPlayProgress()),
+                    'progress' => format_duration($progressValue),
                 ],
             ];
 
@@ -256,7 +259,7 @@ class Progress
                             'key' => '/library/metadata/' . $logContext['remote']['id'],
                             'identifier' => 'com.plexapp.plugins.library',
                             'state' => 'stopped',
-                            'time' => $entity->getPlayProgress(),
+                            'time' => $progressValue,
                             // -- Without duration & client identifier plex ignore watch progress update.
                             'duration' => ag($remoteData, 'duration', 0),
                             'X-Plex-Client-Identifier' => $context->backendId,
@@ -269,15 +272,15 @@ class Progress
                     message: "{action}: Updating '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' watch progress to '{progress}'.",
                     context: [
                         ...$logContext,
-                        'progress' => format_duration($entity->getPlayProgress()),
-                        'time' => $entity->getPlayProgress(),
+                        'progress' => format_duration($progressValue),
+                        'time' => $progressValue,
                     ],
                 );
 
                 if (false === (bool) ag($context->options, Options::DRY_RUN, false)) {
                     $requestContext = [
                         ...$logContext,
-                        'progress' => format_duration($entity->getPlayProgress()),
+                        'progress' => format_duration($progressValue),
                     ];
 
                     $queue->add(

--- a/src/Commands/Events/DispatchCommand.php
+++ b/src/Commands/Events/DispatchCommand.php
@@ -61,6 +61,7 @@ final class DispatchCommand extends Command
             ->setName(self::ROUTE)
             ->addOption('id', 'i', InputOption::VALUE_REQUIRED, 'Force run this event.')
             ->addOption('reset', 'r', InputOption::VALUE_NONE, 'Reset event logs.')
+            ->addOption('limit', 'L', InputOption::VALUE_REQUIRED, 'How many events to run at per run.', 15)
             ->setDescription('Run queued events.');
     }
 
@@ -88,14 +89,15 @@ final class DispatchCommand extends Command
             return self::SUCCESS;
         }
 
-        return $this->runEvents(visibleLevel: $visibleLevel, debug: $debug);
+        return $this->runEvents(visibleLevel: $visibleLevel, limit: (int) $input->getOption('limit'), debug: $debug);
     }
 
-    protected function runEvents(Level $visibleLevel, bool $debug = false): int
+    protected function runEvents(Level $visibleLevel, int $limit, bool $debug = false): int
     {
         $repo = $this->repo
             ->setSort(EventsTable::COLUMN_CREATED_AT)
             ->setAscendingOrder()
+            ->setPerpage($limit)
             ->findAll([EventsTable::COLUMN_STATUS => Status::PENDING->value]);
 
         $events = [];

--- a/src/Commands/State/ImportCommand.php
+++ b/src/Commands/State/ImportCommand.php
@@ -79,7 +79,7 @@ class ImportCommand extends Command
                 'force-metadata-change',
                 'F',
                 InputOption::VALUE_NONE,
-                'Force imported backend metadata to replace locally stored backend metadata.',
+                'Replace existing metadata with data from backend even if there is no change.',
             )
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do not commit any changes.')
             ->addOption(

--- a/src/Commands/State/ImportCommand.php
+++ b/src/Commands/State/ImportCommand.php
@@ -75,6 +75,12 @@ class ImportCommand extends Command
             ->setName(self::ROUTE)
             ->setDescription('Import play state and metadata from backends.')
             ->addOption('force-full', 'f', InputOption::VALUE_NONE, 'Force full import. Ignore last sync date.')
+            ->addOption(
+                'force-metadata-change',
+                'F',
+                InputOption::VALUE_NONE,
+                'Force imported backend metadata to replace locally stored backend metadata.',
+            )
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do not commit any changes.')
             ->addOption(
                 'sync-requests',
@@ -180,6 +186,10 @@ class ImportCommand extends Command
 
         if ($input->getOption('always-update-metadata')) {
             $mapperOpts[Options::MAPPER_ALWAYS_UPDATE_META] = true;
+        }
+
+        if ($input->getOption('force-metadata-change')) {
+            $mapperOpts[Options::FORCE_METADATA_CHANGE] = true;
         }
 
         if (false === ($syncRequests = $input->getOption('sync-requests'))) {
@@ -365,6 +375,10 @@ class ImportCommand extends Command
                 if (true === $input->getOption('metadata-only')) {
                     $opts[Options::IMPORT_METADATA_ONLY] = true;
                     $metadata = true;
+                }
+
+                if (true === $input->getOption('force-metadata-change')) {
+                    $opts[Options::FORCE_METADATA_CHANGE] = true;
                 }
 
                 if ($input->getOption('trace')) {

--- a/src/Commands/State/ImportCommand.php
+++ b/src/Commands/State/ImportCommand.php
@@ -76,7 +76,7 @@ class ImportCommand extends Command
             ->setDescription('Import play state and metadata from backends.')
             ->addOption('force-full', 'f', InputOption::VALUE_NONE, 'Force full import. Ignore last sync date.')
             ->addOption(
-                'force-metadata-change',
+                'force-replace-metadata',
                 'F',
                 InputOption::VALUE_NONE,
                 'Replace existing metadata with data from backend even if there is no change.',
@@ -188,8 +188,8 @@ class ImportCommand extends Command
             $mapperOpts[Options::MAPPER_ALWAYS_UPDATE_META] = true;
         }
 
-        if ($input->getOption('force-metadata-change')) {
-            $mapperOpts[Options::FORCE_METADATA_CHANGE] = true;
+        if ($input->getOption('force-replace-metadata')) {
+            $mapperOpts[Options::FORCE_REPLACE_METADATA] = true;
         }
 
         if (false === ($syncRequests = $input->getOption('sync-requests'))) {
@@ -377,8 +377,8 @@ class ImportCommand extends Command
                     $metadata = true;
                 }
 
-                if (true === $input->getOption('force-metadata-change')) {
-                    $opts[Options::FORCE_METADATA_CHANGE] = true;
+                if (true === $input->getOption('force-replace-metadata')) {
+                    $opts[Options::FORCE_REPLACE_METADATA] = true;
                 }
 
                 if ($input->getOption('trace')) {

--- a/src/Libs/Mappers/Import/DirectMapper.php
+++ b/src/Libs/Mappers/Import/DirectMapper.php
@@ -354,25 +354,33 @@ class DirectMapper implements ImportInterface
         $inDryRunMode = $this->inDryRunMode();
         $writer = ag($opts, Options::LOG_TO_WRITER, null);
         $keys = [iState::COLUMN_META_DATA];
+        $cloned = clone $local;
 
         $progressChange = $this->shouldProgressUpdate($local, $entity, $opts);
+        $forceChange = $this->shouldForceChange($local, $entity, $opts);
 
-        if (true === $progressChange || true === (clone $local)->apply($entity, fields: $keys)->isChanged($keys)) {
+        if (true === $progressChange || true === $forceChange || true === (clone $local)->apply($entity, fields: $keys)->isChanged($keys)) {
             try {
                 $local = $local->apply(
                     entity: $entity,
                     fields: array_merge($keys, [iState::COLUMN_EXTRA]),
                 );
+                if (true === $forceChange) {
+                    $local = $this->applyMetaChange($local, $entity);
+                }
 
-                $changes = $local->diff(fields: $keys);
+                $changes = true === $forceChange ? $this->getMetaChanges($cloned, $entity) : $local->diff(fields: $keys);
 
-                if (true === $progressChange || count($changes) >= 1) {
+                if (true === $progressChange || true === $forceChange || count($changes) >= 1) {
                     $_keys = array_merge($keys, [iState::COLUMN_EXTRA]);
                     if (true === $progressChange) {
                         $_keys[] = iState::COLUMN_VIA;
                     }
 
                     $local = $local->apply($entity, fields: $_keys);
+                    if (true === $forceChange) {
+                        $local = $this->applyMetaChange($local, $entity);
+                    }
 
                     $changeLog = $changes;
                     if (true === $progressChange) {
@@ -404,6 +412,11 @@ class DirectMapper implements ImportInterface
                             'tainted' => 'untainted',
                             'id' => ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '??'),
                         ]);
+                        if (true === (bool) ag($opts, Options::FORCE_METADATA_CHANGE, false)) {
+                            $local = $local
+                                ->setContext(Options::FORCE_METADATA_CHANGE, true)
+                                ->setContext(Options::STATE_PROGRESS_VALUE, $this->getProgressValue($entity));
+                        }
                         $this->progressItems[$itemId] = $local;
                         if (null !== ($onProgressUpdate = ag($opts, Options::STATE_PROGRESS_EVENT, null))) {
                             $onProgressUpdate($local);
@@ -584,27 +597,39 @@ class DirectMapper implements ImportInterface
         }
 
         $progressChange = $this->shouldProgressUpdate($local, $entity, $opts);
+        $forceChange = $this->shouldForceChange($local, $entity, $opts);
 
         $updateMeta = true === (bool) ag($this->options, Options::MAPPER_ALWAYS_UPDATE_META);
         $hasMeta = count($cloned->getMetadata($entity->via)) >= 1;
 
         // -- this sometimes leads to never ending updates as data from backends conflicts.
-        if (false === $hasMeta || true === $progressChange || true === $updateMeta) {
-            if (false === $hasMeta || $progressChange || (clone $cloned)->apply($entity, $keys)->isChanged($keys)) {
+        if (false === $hasMeta || true === $progressChange || true === $forceChange || true === $updateMeta) {
+            if (
+                false === $hasMeta
+                || $progressChange
+                || true === $forceChange
+                || (clone $cloned)->apply($entity, $keys)->isChanged($keys)
+            ) {
                 try {
                     $local = $local->apply(
                         entity: $entity,
                         fields: array_merge($keys, [iState::COLUMN_EXTRA]),
                     );
+                    if (true === $forceChange) {
+                        $local = $this->applyMetaChange($local, $entity);
+                    }
 
-                    $changes = $local->diff(fields: $keys);
+                    $changes = true === $forceChange ? $this->getMetaChanges($cloned, $entity) : $local->diff(fields: $keys);
 
-                    if (true === $progressChange || false === $hasMeta || count($changes) >= 1) {
+                    if (true === $progressChange || true === $forceChange || false === $hasMeta || count($changes) >= 1) {
                         $_keys = array_merge($keys, [iState::COLUMN_EXTRA]);
                         if (true === $progressChange) {
                             $_keys[] = iState::COLUMN_VIA;
                         }
                         $local = $local->apply($entity, fields: $_keys);
+                        if (true === $forceChange) {
+                            $local = $this->applyMetaChange($local, $entity);
+                        }
 
                         $changeLog = $changes;
                         if (true === $progressChange) {
@@ -635,6 +660,11 @@ class DirectMapper implements ImportInterface
                                 'tainted' => 'untainted',
                                 'id' => ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '??'),
                             ]);
+                            if (true === (bool) ag($opts, Options::FORCE_METADATA_CHANGE, false)) {
+                                $local = $local
+                                    ->setContext(Options::FORCE_METADATA_CHANGE, true)
+                                    ->setContext(Options::STATE_PROGRESS_VALUE, $this->getProgressValue($entity));
+                            }
                             $this->progressItems[$itemId] = $local;
                             if (null !== ($onProgressUpdate = ag($opts, Options::STATE_PROGRESS_EVENT, null))) {
                                 $onProgressUpdate($local);
@@ -768,6 +798,12 @@ class DirectMapper implements ImportInterface
             $entity = $entity->setContext(Options::FORCE_FULL, true);
         }
 
+        if (true === (bool) ag($opts, Options::FORCE_METADATA_CHANGE, false)) {
+            $entity = $entity
+                ->setContext(Options::FORCE_METADATA_CHANGE, true)
+                ->setContext(Options::STATE_PROGRESS_VALUE, $this->getProgressValue($entity));
+        }
+
         if (!$entity->hasGuids() && !$entity->hasRelativeGuid()) {
             $this->logger->warning(
                 "{mapper}: [A] Ignoring '{user}@{backend}' - '{title}'. No valid/supported external ids.",
@@ -874,6 +910,7 @@ class DirectMapper implements ImportInterface
         $cloned = clone $local;
 
         $progressChange = $this->shouldProgressUpdate($local, $entity, $opts);
+        $forceChange = $this->shouldForceChange($local, $entity, $opts);
         $keys = $opts['diff_keys'] ?? $this->getDefaultDiffKeys();
 
         $shouldMark = $cloned->shouldMarkAsUnplayed($entity, $this->userContext);
@@ -883,7 +920,11 @@ class DirectMapper implements ImportInterface
         }
 
         $local = $local->apply(entity: $entity, fields: $_keys);
-        $changedKeys = $local->diff(fields: $keys);
+        if (true === $forceChange) {
+            $local = $this->applyMetaChange($local, $entity);
+        }
+
+        $changedKeys = true === $forceChange ? $this->getMetaChanges($cloned, $entity) : $local->diff(fields: $keys);
 
         if (false === $progressChange && false === $shouldMark && count($changedKeys) < 1) {
             $msg = "{mapper}: [U] Ignoring '{user}@{backend}' - '#{id}: {title}'. Metadata & play state are identical.";
@@ -926,7 +967,7 @@ class DirectMapper implements ImportInterface
                 }
             }
 
-            $changes = $local->diff(fields: $_keys);
+            $changes = true === $forceChange ? $this->getMetaChanges($cloned, $entity) : $local->diff(fields: $_keys);
             $pointerChanges = $local->diff(fields: array_keys($this->pointerChangeKeys));
             if (true === $this->hasPointerChanges($pointerChanges)) {
                 $this->removePointers($cloned)->addPointers($local, $local->id);
@@ -968,6 +1009,11 @@ class DirectMapper implements ImportInterface
                         'tainted' => 'untainted',
                         'id' => ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '??'),
                     ]);
+                    if (true === (bool) ag($opts, Options::FORCE_METADATA_CHANGE, false)) {
+                        $local = $local
+                            ->setContext(Options::FORCE_METADATA_CHANGE, true)
+                            ->setContext(Options::STATE_PROGRESS_VALUE, $this->getProgressValue($entity));
+                    }
                     $this->progressItems[$itemId] = $local;
                     if (null !== ($onProgressUpdate = ag($opts, Options::STATE_PROGRESS_EVENT, null))) {
                         $onProgressUpdate($local);
@@ -1066,12 +1112,24 @@ class DirectMapper implements ImportInterface
                 }
 
                 foreach ($this->progressItems as $entity) {
-                    $opts[EventsTable::COLUMN_REFERENCE] = r($name, [
+                    $_opts = $opts;
+                    $_opts[EventsTable::COLUMN_REFERENCE] = r($name, [
                         'type' => $entity->type,
                         'backend' => $entity->via,
                         'id' => ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '??'),
                     ]);
-                    queue_event(ProcessProgressEvent::NAME, [iState::COLUMN_ID => $entity->id], $opts);
+
+                    if (true === (bool) $entity->getContext(Options::FORCE_METADATA_CHANGE, false)) {
+                        $_opts[EventsTable::COLUMN_OPTIONS] = array_replace_recursive(
+                            (array) ag($_opts, EventsTable::COLUMN_OPTIONS, []),
+                            [
+                                Options::FORCE_METADATA_CHANGE => true,
+                                Options::STATE_PROGRESS_VALUE => $entity->getContext(Options::STATE_PROGRESS_VALUE, 0),
+                            ],
+                        );
+                    }
+
+                    queue_event(ProcessProgressEvent::NAME, [iState::COLUMN_ID => $entity->id], $_opts);
                 }
             } catch (CacheInvalidArgumentException $e) {
                 $this->logger->error(
@@ -1374,6 +1432,13 @@ class DirectMapper implements ImportInterface
             return false;
         }
 
+        if (
+            true === (bool) ag($opts, Options::FORCE_METADATA_CHANGE, false)
+            && $this->getProgressValue($old, $new->via) !== $this->getProgressValue($new)
+        ) {
+            return true;
+        }
+
         $newPlayProgress = (int) ag($new->getMetadata($new->via), iState::COLUMN_META_DATA_PROGRESS);
         $oldPlayProgress = (int) ag($old->getMetadata($new->via), iState::COLUMN_META_DATA_PROGRESS);
         $playChanged = $newPlayProgress > ($oldPlayProgress + 10);
@@ -1388,6 +1453,48 @@ class DirectMapper implements ImportInterface
         }
 
         return $playChanged;
+    }
+
+    private function shouldForceChange(iState $old, iState $new, array $opts = []): bool
+    {
+        if (true !== (bool) ag($opts, Options::FORCE_METADATA_CHANGE, false)) {
+            return false;
+        }
+
+        return $old->getMetadata($new->via) !== $new->getMetadata($new->via);
+    }
+
+    private function applyMetaChange(iState $local, iState $entity): iState
+    {
+        $metadata = $local->getMetadata();
+        $metadata[$entity->via] = $entity->getMetadata($entity->via);
+        $local->metadata = $metadata;
+
+        return $local;
+    }
+
+    private function getMetaChanges(iState $old, iState $new): array
+    {
+        $oldMetadata = $old->getMetadata($new->via);
+        $newMetadata = $new->getMetadata($new->via);
+
+        if ($oldMetadata === $newMetadata) {
+            return [];
+        }
+
+        return [
+            iState::COLUMN_META_DATA => [
+                $new->via => [
+                    'old' => $oldMetadata,
+                    'new' => $newMetadata,
+                ],
+            ],
+        ];
+    }
+
+    private function getProgressValue(iState $entity, ?string $via = null): int
+    {
+        return (int) ag($entity->getMetadata($via ?? $entity->via), iState::COLUMN_META_DATA_PROGRESS, 0);
     }
 
     /**

--- a/src/Libs/Mappers/Import/DirectMapper.php
+++ b/src/Libs/Mappers/Import/DirectMapper.php
@@ -412,9 +412,9 @@ class DirectMapper implements ImportInterface
                             'tainted' => 'untainted',
                             'id' => ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '??'),
                         ]);
-                        if (true === (bool) ag($opts, Options::FORCE_METADATA_CHANGE, false)) {
+                        if (true === (bool) ag($opts, Options::FORCE_REPLACE_METADATA, false)) {
                             $local = $local
-                                ->setContext(Options::FORCE_METADATA_CHANGE, true)
+                                ->setContext(Options::FORCE_REPLACE_METADATA, true)
                                 ->setContext(Options::STATE_PROGRESS_VALUE, $this->getProgressValue($entity));
                         }
                         $this->progressItems[$itemId] = $local;
@@ -660,9 +660,9 @@ class DirectMapper implements ImportInterface
                                 'tainted' => 'untainted',
                                 'id' => ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '??'),
                             ]);
-                            if (true === (bool) ag($opts, Options::FORCE_METADATA_CHANGE, false)) {
+                            if (true === (bool) ag($opts, Options::FORCE_REPLACE_METADATA, false)) {
                                 $local = $local
-                                    ->setContext(Options::FORCE_METADATA_CHANGE, true)
+                                    ->setContext(Options::FORCE_REPLACE_METADATA, true)
                                     ->setContext(Options::STATE_PROGRESS_VALUE, $this->getProgressValue($entity));
                             }
                             $this->progressItems[$itemId] = $local;
@@ -798,9 +798,9 @@ class DirectMapper implements ImportInterface
             $entity = $entity->setContext(Options::FORCE_FULL, true);
         }
 
-        if (true === (bool) ag($opts, Options::FORCE_METADATA_CHANGE, false)) {
+        if (true === (bool) ag($opts, Options::FORCE_REPLACE_METADATA, false)) {
             $entity = $entity
-                ->setContext(Options::FORCE_METADATA_CHANGE, true)
+                ->setContext(Options::FORCE_REPLACE_METADATA, true)
                 ->setContext(Options::STATE_PROGRESS_VALUE, $this->getProgressValue($entity));
         }
 
@@ -1009,9 +1009,9 @@ class DirectMapper implements ImportInterface
                         'tainted' => 'untainted',
                         'id' => ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '??'),
                     ]);
-                    if (true === (bool) ag($opts, Options::FORCE_METADATA_CHANGE, false)) {
+                    if (true === (bool) ag($opts, Options::FORCE_REPLACE_METADATA, false)) {
                         $local = $local
-                            ->setContext(Options::FORCE_METADATA_CHANGE, true)
+                            ->setContext(Options::FORCE_REPLACE_METADATA, true)
                             ->setContext(Options::STATE_PROGRESS_VALUE, $this->getProgressValue($entity));
                     }
                     $this->progressItems[$itemId] = $local;
@@ -1119,11 +1119,11 @@ class DirectMapper implements ImportInterface
                         'id' => ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '??'),
                     ]);
 
-                    if (true === (bool) $entity->getContext(Options::FORCE_METADATA_CHANGE, false)) {
+                    if (true === (bool) $entity->getContext(Options::FORCE_REPLACE_METADATA, false)) {
                         $_opts[EventsTable::COLUMN_OPTIONS] = array_replace_recursive(
                             (array) ag($_opts, EventsTable::COLUMN_OPTIONS, []),
                             [
-                                Options::FORCE_METADATA_CHANGE => true,
+                                Options::FORCE_REPLACE_METADATA => true,
                                 Options::STATE_PROGRESS_VALUE => $entity->getContext(Options::STATE_PROGRESS_VALUE, 0),
                             ],
                         );
@@ -1433,7 +1433,7 @@ class DirectMapper implements ImportInterface
         }
 
         if (
-            true === (bool) ag($opts, Options::FORCE_METADATA_CHANGE, false)
+            true === (bool) ag($opts, Options::FORCE_REPLACE_METADATA, false)
             && $this->getProgressValue($old, $new->via) !== $this->getProgressValue($new)
         ) {
             return true;
@@ -1457,7 +1457,7 @@ class DirectMapper implements ImportInterface
 
     private function shouldForceChange(iState $old, iState $new, array $opts = []): bool
     {
-        if (true !== (bool) ag($opts, Options::FORCE_METADATA_CHANGE, false)) {
+        if (true !== (bool) ag($opts, Options::FORCE_REPLACE_METADATA, false)) {
             return false;
         }
 

--- a/src/Libs/Options.php
+++ b/src/Libs/Options.php
@@ -15,7 +15,7 @@ final class Options
     public const string NO_CACHE = 'NO_CACHE';
     public const string CACHE_TTL = 'CACHE_TTL';
     public const string FORCE_FULL = 'FORCE_FULL';
-    public const string FORCE_METADATA_CHANGE = 'FORCE_METADATA_CHANGE';
+    public const string FORCE_REPLACE_METADATA = 'FORCE_REPLACE_METADATA';
     public const string DEBUG_TRACE = 'DEBUG_TRACE';
     public const string IGNORE_DATE = 'IGNORE_DATE';
     public const string EXPORT_ALLOWED_TIME_DIFF = 'EXPORT_TIME_DIFF';

--- a/src/Libs/Options.php
+++ b/src/Libs/Options.php
@@ -15,6 +15,7 @@ final class Options
     public const string NO_CACHE = 'NO_CACHE';
     public const string CACHE_TTL = 'CACHE_TTL';
     public const string FORCE_FULL = 'FORCE_FULL';
+    public const string FORCE_METADATA_CHANGE = 'FORCE_METADATA_CHANGE';
     public const string DEBUG_TRACE = 'DEBUG_TRACE';
     public const string IGNORE_DATE = 'IGNORE_DATE';
     public const string EXPORT_ALLOWED_TIME_DIFF = 'EXPORT_TIME_DIFF';
@@ -26,6 +27,7 @@ final class Options
     public const string LIBRARY_SEGMENT = 'LIBRARY_SEGMENT';
     public const string STATE_UPDATE_EVENT = 'STATE_UPDATE_EVENT';
     public const string STATE_PROGRESS_EVENT = 'STATE_PROGRESS_EVENT';
+    public const string STATE_PROGRESS_VALUE = 'STATE_PROGRESS_VALUE';
     public const string LOG_TO_WRITER = 'LOG_TO_WRITER';
     public const string DUMP_PAYLOAD = 'DUMP_PAYLOAD';
     public const string ADMIN_TOKEN = 'ADMIN_TOKEN';

--- a/src/Listeners/ProcessProgressEvent.php
+++ b/src/Listeners/ProcessProgressEvent.php
@@ -71,7 +71,7 @@ final readonly class ProcessProgressEvent
         }
 
         $options = $event->getOptions();
-        $forceMetadataChange = true === (bool) ag($options, Options::FORCE_METADATA_CHANGE, false);
+        $forceMetadataChange = true === (bool) ag($options, Options::FORCE_REPLACE_METADATA, false);
         $hasProgressValue = ag_exists($options, Options::STATE_PROGRESS_VALUE);
 
         if (null === ($item = $userContext->db->get(Container::get(iState::class)::fromArray($event->getData())))) {
@@ -184,7 +184,7 @@ final readonly class ProcessProgressEvent
                 }
 
                 if (true === $forceMetadataChange) {
-                    $opts[Options::FORCE_METADATA_CHANGE] = true;
+                    $opts[Options::FORCE_REPLACE_METADATA] = true;
                 }
 
                 if (true === $hasProgressValue) {

--- a/src/Listeners/ProcessProgressEvent.php
+++ b/src/Listeners/ProcessProgressEvent.php
@@ -71,6 +71,8 @@ final readonly class ProcessProgressEvent
         }
 
         $options = $event->getOptions();
+        $forceMetadataChange = true === (bool) ag($options, Options::FORCE_METADATA_CHANGE, false);
+        $hasProgressValue = ag_exists($options, Options::STATE_PROGRESS_VALUE);
 
         if (null === ($item = $userContext->db->get(Container::get(iState::class)::fromArray($event->getData())))) {
             $writer(Level::Error, "'{user}' item '{id}' is not referenced locally yet.", [
@@ -104,7 +106,7 @@ final readonly class ProcessProgressEvent
             }
         }
 
-        if (false === $item->hasPlayProgress()) {
+        if (false === $hasProgressValue && false === $item->hasPlayProgress()) {
             $writer(Level::Info, "'{user}' item '#{id}: {title}' has no watch progress to export.", [
                 'id' => $item->id,
                 'title' => $item->title,
@@ -113,7 +115,10 @@ final readonly class ProcessProgressEvent
             return $event;
         }
 
-        $progress = format_duration($item->getPlayProgress());
+        $progressValue = true === $hasProgressValue
+            ? (int) ag($options, Options::STATE_PROGRESS_VALUE, 0)
+            : $item->getPlayProgress();
+        $progress = format_duration($progressValue);
 
         $list = [];
 
@@ -176,6 +181,14 @@ final readonly class ProcessProgressEvent
 
                 if (ag($options, Options::DEBUG_TRACE)) {
                     $opts[Options::DEBUG_TRACE] = true;
+                }
+
+                if (true === $forceMetadataChange) {
+                    $opts[Options::FORCE_METADATA_CHANGE] = true;
+                }
+
+                if (true === $hasProgressValue) {
+                    $opts[Options::STATE_PROGRESS_VALUE] = $progressValue;
                 }
 
                 $backend['options'] = $opts;

--- a/tests/Backends/MediaBrowser/ProgressQueueTest.php
+++ b/tests/Backends/MediaBrowser/ProgressQueueTest.php
@@ -100,7 +100,7 @@ class ProgressQueueTest extends MediaBrowserTestCase
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass, $metaClass, $sessionsClass]) {
             $context = $this->makeContext($clientName, [
                 Options::IGNORE_DATE => true,
-                Options::FORCE_METADATA_CHANGE => true,
+                Options::FORCE_REPLACE_METADATA => true,
                 Options::STATE_PROGRESS_VALUE => 0,
             ]);
             $cache = new Psr16Cache(new ArrayAdapter());
@@ -168,7 +168,7 @@ class ProgressQueueTest extends MediaBrowserTestCase
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass, $metaClass, $sessionsClass]) {
             $context = $this->makeContext($clientName, [
                 Options::IGNORE_DATE => true,
-                Options::FORCE_METADATA_CHANGE => true,
+                Options::FORCE_REPLACE_METADATA => true,
                 Options::STATE_PROGRESS_VALUE => 30000,
             ]);
             $cache = new Psr16Cache(new ArrayAdapter());

--- a/tests/Backends/MediaBrowser/ProgressQueueTest.php
+++ b/tests/Backends/MediaBrowser/ProgressQueueTest.php
@@ -95,6 +95,142 @@ class ProgressQueueTest extends MediaBrowserTestCase
         }
     }
 
+    public function test_progress_force_reset(): void
+    {
+        foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass, $metaClass, $sessionsClass]) {
+            $context = $this->makeContext($clientName, [
+                Options::IGNORE_DATE => true,
+                Options::FORCE_METADATA_CHANGE => true,
+                Options::STATE_PROGRESS_VALUE => 0,
+            ]);
+            $cache = new Psr16Cache(new ArrayAdapter());
+
+            Container::add($sessionsClass, fn() => new class() {
+                public function __invoke(): Response
+                {
+                    return new Response(status: true, response: ['sessions' => []]);
+                }
+            });
+
+            $metaResponse = new MockResponse(
+                json_encode($this->fixture('metadata')),
+                ['http_code' => 200],
+            );
+            $metaHttp = new HttpClient(new MockHttpClient($metaResponse));
+            Container::add($metaClass, fn() => new $metaClass($metaHttp, $this->logger, $cache));
+
+            $http = new HttpClient(new MockHttpClient(new MockResponse('ok', ['http_code' => 200])));
+
+            $entity = StateEntity::fromArray([
+                iState::COLUMN_ID => 10,
+                iState::COLUMN_TYPE => iState::TYPE_MOVIE,
+                iState::COLUMN_UPDATED => 2000,
+                iState::COLUMN_WATCHED => 0,
+                iState::COLUMN_VIA => 'Other',
+                iState::COLUMN_TITLE => 'Test Movie',
+                iState::COLUMN_META_DATA => [
+                    $context->backendName => [
+                        iState::COLUMN_ID => 'item-1',
+                        iState::COLUMN_TYPE => iState::TYPE_MOVIE,
+                        iState::COLUMN_WATCHED => '0',
+                        iState::COLUMN_TITLE => 'Test Movie',
+                    ],
+                    'Other' => [
+                        iState::COLUMN_WATCHED => '0',
+                    ],
+                ],
+                iState::COLUMN_EXTRA => [
+                    $context->backendName => [
+                        iState::COLUMN_EXTRA_DATE => '2024-01-02T00:00:00Z',
+                    ],
+                    'Other' => [
+                        iState::COLUMN_EXTRA_DATE => '2024-01-01T00:00:00Z',
+                    ],
+                ],
+            ]);
+
+            $queue = new QueueRequests();
+            $action = new $actionClass($http, $this->logger);
+            $guid = (new $guidClass($this->logger))->withContext($context);
+            $result = $action($context, $guid, [$entity], $queue);
+
+            $this->assertTrue($result->isSuccessful());
+            $this->assertSame(1, $queue->count());
+
+            $request = $queue->getQueue()[0];
+            $this->assertSame('0', ag($request->options, 'json.PlaybackPositionTicks'));
+            $this->assertFalse(ag_exists(ag($request->options, 'json', []), 'LastPlayedDate'));
+        }
+    }
+
+    public function test_progress_force_value(): void
+    {
+        foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass, $metaClass, $sessionsClass]) {
+            $context = $this->makeContext($clientName, [
+                Options::IGNORE_DATE => true,
+                Options::FORCE_METADATA_CHANGE => true,
+                Options::STATE_PROGRESS_VALUE => 30000,
+            ]);
+            $cache = new Psr16Cache(new ArrayAdapter());
+
+            Container::add($sessionsClass, fn() => new class() {
+                public function __invoke(): Response
+                {
+                    return new Response(status: true, response: ['sessions' => []]);
+                }
+            });
+
+            $metaResponse = new MockResponse(
+                json_encode($this->fixture('metadata')),
+                ['http_code' => 200],
+            );
+            $metaHttp = new HttpClient(new MockHttpClient($metaResponse));
+            Container::add($metaClass, fn() => new $metaClass($metaHttp, $this->logger, $cache));
+
+            $http = new HttpClient(new MockHttpClient(new MockResponse('ok', ['http_code' => 200])));
+
+            $entity = StateEntity::fromArray([
+                iState::COLUMN_ID => 10,
+                iState::COLUMN_TYPE => iState::TYPE_MOVIE,
+                iState::COLUMN_UPDATED => 2000,
+                iState::COLUMN_WATCHED => 0,
+                iState::COLUMN_VIA => 'Other',
+                iState::COLUMN_TITLE => 'Test Movie',
+                iState::COLUMN_META_DATA => [
+                    $context->backendName => [
+                        iState::COLUMN_ID => 'item-1',
+                        iState::COLUMN_TYPE => iState::TYPE_MOVIE,
+                        iState::COLUMN_WATCHED => '0',
+                        iState::COLUMN_TITLE => 'Test Movie',
+                    ],
+                    'Other' => [
+                        iState::COLUMN_WATCHED => '0',
+                    ],
+                ],
+                iState::COLUMN_EXTRA => [
+                    $context->backendName => [
+                        iState::COLUMN_EXTRA_DATE => '2024-01-02T00:00:00Z',
+                    ],
+                    'Other' => [
+                        iState::COLUMN_EXTRA_DATE => '2024-01-01T00:00:00Z',
+                    ],
+                ],
+            ]);
+
+            $queue = new QueueRequests();
+            $action = new $actionClass($http, $this->logger);
+            $guid = (new $guidClass($this->logger))->withContext($context);
+            $result = $action($context, $guid, [$entity], $queue);
+
+            $this->assertTrue($result->isSuccessful());
+            $this->assertSame(1, $queue->count());
+
+            $request = $queue->getQueue()[0];
+            $this->assertSame('300000000', ag($request->options, 'json.PlaybackPositionTicks'));
+            $this->assertTrue(ag_exists(ag($request->options, 'json', []), 'LastPlayedDate'));
+        }
+    }
+
     private function provideBackends(): array
     {
         return [

--- a/tests/Mappers/Import/DirectMapperTest.php
+++ b/tests/Mappers/Import/DirectMapperTest.php
@@ -225,4 +225,150 @@ class DirectMapperTest extends MapperAbstract
         $result = $this->mapper->get($updateMovie);
         $this->assertSame(0, $result->watched, 'Item should be marked as unwatched');
     }
+
+    public function test_force_metadata_change(): void
+    {
+        $this->testMovie[iState::COLUMN_WATCHED] = 0;
+        $this->testMovie[iState::COLUMN_META_DATA][$this->testMovie[iState::COLUMN_VIA]][iState::COLUMN_WATCHED] = 0;
+        $this->testMovie[iState::COLUMN_META_DATA]['test_jellyfin'] = [
+            iState::COLUMN_ID => 777,
+            iState::COLUMN_TYPE => iState::TYPE_MOVIE,
+            iState::COLUMN_WATCHED => 0,
+            iState::COLUMN_META_DATA_PROGRESS => 65000,
+        ];
+
+        $testMovie = new StateEntity($this->testMovie);
+        $this->mapper->add($testMovie);
+        $this->mapper->commit();
+        $this->mapper->reset()->loadData();
+
+        $updatedMovie = clone $testMovie;
+        $metadata = $updatedMovie->getMetadata();
+        unset($metadata[$updatedMovie->via][iState::COLUMN_META_DATA_PROGRESS]);
+        unset($metadata[$updatedMovie->via][iState::COLUMN_YEAR]);
+        $updatedMovie->metadata = $metadata;
+
+        $progressEventCalled = false;
+        $progressValue = null;
+        $progressCallback = function (iState $entity) use (&$progressEventCalled, &$progressValue) {
+            $progressEventCalled = true;
+            $progressValue = $entity->getContext(Options::STATE_PROGRESS_VALUE);
+        };
+
+        $this->mapper->add($updatedMovie, [
+            Options::FORCE_METADATA_CHANGE => true,
+            Options::STATE_PROGRESS_EVENT => $progressCallback,
+        ]);
+        $this->mapper->commit();
+
+        $this->assertTrue($progressEventCalled, 'Progress reset should queue progress event');
+        $this->assertSame(0, $progressValue, 'Progress reset should export zero progress');
+
+        $this->mapper->reset()->loadData();
+        $stored = $this->mapper->get($updatedMovie);
+        $storedMetadata = $stored->getMetadata($updatedMovie->via);
+
+        $this->assertArrayNotHasKey(iState::COLUMN_META_DATA_PROGRESS, $storedMetadata);
+        $this->assertArrayNotHasKey(iState::COLUMN_YEAR, $storedMetadata);
+        $this->assertSame(65000, ag($stored->getMetadata('test_jellyfin'), iState::COLUMN_META_DATA_PROGRESS));
+    }
+
+    public function test_force_progress_change(): void
+    {
+        $this->testMovie[iState::COLUMN_WATCHED] = 0;
+        $this->testMovie[iState::COLUMN_META_DATA][$this->testMovie[iState::COLUMN_VIA]][iState::COLUMN_WATCHED] = 0;
+
+        $testMovie = new StateEntity($this->testMovie);
+        $this->mapper->add($testMovie);
+        $this->mapper->commit();
+        $this->mapper->reset()->loadData();
+
+        $updatedMovie = clone $testMovie;
+        $metadata = $updatedMovie->getMetadata();
+        $metadata[$updatedMovie->via][iState::COLUMN_META_DATA_PROGRESS] = 50000;
+        $updatedMovie->metadata = $metadata;
+
+        $progressEventCalled = false;
+        $progressValue = null;
+        $progressCallback = function (iState $entity) use (&$progressEventCalled, &$progressValue) {
+            $progressEventCalled = true;
+            $progressValue = $entity->getContext(Options::STATE_PROGRESS_VALUE);
+        };
+
+        $this->mapper->add($updatedMovie, [
+            Options::FORCE_METADATA_CHANGE => true,
+            Options::STATE_PROGRESS_EVENT => $progressCallback,
+        ]);
+        $this->mapper->commit();
+
+        $this->assertTrue($progressEventCalled, 'Forced progress change should queue progress event');
+        $this->assertSame(50000, $progressValue, 'Forced progress change should export source progress');
+
+        $this->mapper->reset()->loadData();
+        $stored = $this->mapper->get($updatedMovie);
+
+        $this->assertSame(50000, ag($stored->getMetadata($updatedMovie->via), iState::COLUMN_META_DATA_PROGRESS));
+    }
+
+    public function test_force_progress_same(): void
+    {
+        $this->testMovie[iState::COLUMN_WATCHED] = 0;
+        $this->testMovie[iState::COLUMN_META_DATA][$this->testMovie[iState::COLUMN_VIA]][iState::COLUMN_WATCHED] = 0;
+        $this->testMovie[iState::COLUMN_META_DATA][$this->testMovie[iState::COLUMN_VIA]][iState::COLUMN_META_DATA_PROGRESS] = 0;
+
+        $testMovie = new StateEntity($this->testMovie);
+        $this->mapper->add($testMovie);
+        $this->mapper->commit();
+        $this->mapper->reset()->loadData();
+
+        $updatedMovie = clone $testMovie;
+        $metadata = $updatedMovie->getMetadata();
+        unset($metadata[$updatedMovie->via][iState::COLUMN_YEAR]);
+        $updatedMovie->metadata = $metadata;
+
+        $progressEventCalled = false;
+        $progressCallback = function () use (&$progressEventCalled) {
+            $progressEventCalled = true;
+        };
+
+        $this->mapper->add($updatedMovie, [
+            Options::FORCE_METADATA_CHANGE => true,
+            Options::STATE_PROGRESS_EVENT => $progressCallback,
+        ]);
+        $this->mapper->commit();
+
+        $this->assertFalse($progressEventCalled, 'Unchanged zero progress should not queue progress event');
+
+        $this->mapper->reset()->loadData();
+        $stored = $this->mapper->get($updatedMovie);
+
+        $this->assertArrayNotHasKey(iState::COLUMN_YEAR, $stored->getMetadata($updatedMovie->via));
+    }
+
+    public function test_no_force_metadata_change(): void
+    {
+        $this->testMovie[iState::COLUMN_WATCHED] = 0;
+        $this->testMovie[iState::COLUMN_META_DATA][$this->testMovie[iState::COLUMN_VIA]][iState::COLUMN_WATCHED] = 0;
+
+        $testMovie = new StateEntity($this->testMovie);
+        $this->mapper->add($testMovie);
+        $this->mapper->commit();
+        $this->mapper->reset()->loadData();
+
+        $updatedMovie = clone $testMovie;
+        $metadata = $updatedMovie->getMetadata();
+        unset($metadata[$updatedMovie->via][iState::COLUMN_META_DATA_PROGRESS]);
+        unset($metadata[$updatedMovie->via][iState::COLUMN_YEAR]);
+        $updatedMovie->metadata = $metadata;
+
+        $this->mapper->add($updatedMovie);
+        $this->mapper->commit();
+
+        $this->mapper->reset()->loadData();
+        $stored = $this->mapper->get($updatedMovie);
+        $storedMetadata = $stored->getMetadata($updatedMovie->via);
+
+        $this->assertArrayHasKey(iState::COLUMN_META_DATA_PROGRESS, $storedMetadata);
+        $this->assertArrayHasKey(iState::COLUMN_YEAR, $storedMetadata);
+    }
 }

--- a/tests/Mappers/Import/DirectMapperTest.php
+++ b/tests/Mappers/Import/DirectMapperTest.php
@@ -256,7 +256,7 @@ class DirectMapperTest extends MapperAbstract
         };
 
         $this->mapper->add($updatedMovie, [
-            Options::FORCE_METADATA_CHANGE => true,
+            Options::FORCE_REPLACE_METADATA => true,
             Options::STATE_PROGRESS_EVENT => $progressCallback,
         ]);
         $this->mapper->commit();
@@ -296,7 +296,7 @@ class DirectMapperTest extends MapperAbstract
         };
 
         $this->mapper->add($updatedMovie, [
-            Options::FORCE_METADATA_CHANGE => true,
+            Options::FORCE_REPLACE_METADATA => true,
             Options::STATE_PROGRESS_EVENT => $progressCallback,
         ]);
         $this->mapper->commit();
@@ -332,7 +332,7 @@ class DirectMapperTest extends MapperAbstract
         };
 
         $this->mapper->add($updatedMovie, [
-            Options::FORCE_METADATA_CHANGE => true,
+            Options::FORCE_REPLACE_METADATA => true,
             Options::STATE_PROGRESS_EVENT => $progressCallback,
         ]);
         $this->mapper->commit();


### PR DESCRIPTION
* Added a `-F, --force-replace-metadata` option to the `state:import` command, allowing users to replace local metadata with backend values, removing omitted keys and making the selected backend authoritative for metadata and progress. See #828 
* Updated the `DirectMapper` to handle forced metadata replacement.
* Added a `-L, --limit` option to `Events:DispatchCommand` allowing users to control how many events are processed per run. See #829
