### PR TITLE
Refactor: use JSONL as log format and normalize log messages.

### DIFF
--- a/API.md
+++ b/API.md
@@ -1587,7 +1587,7 @@ Lists log, webhook dump, and debug files under WatchState's temp directories.
 ```json
 [
   {
-    "filename": "access.20260328.log",
+    "filename": "access.20260328.jsonl",
     "type": "access",
     "date": "20260328",
     "size": 12345,
@@ -1599,7 +1599,7 @@ Lists log, webhook dump, and debug files under WatchState's temp directories.
 ---
 
 #### GET /v1/api/logs/recent
-Returns the most recent lines from today's `.log` files.
+Returns the most recent raw lines from today's `.jsonl` log files.
 
 **Query**:
 - `limit` (optional) - Defaults to `50`.
@@ -1608,20 +1608,13 @@ Returns the most recent lines from today's `.log` files.
 ```json
 [
   {
-    "filename": "access.20260328.log",
+    "filename": "access.20260328.jsonl",
     "type": "access",
     "date": "20260328",
     "size": 12345,
     "modified": "2026-03-28T12:00:00+00:00",
     "lines": [
-      {
-        "id": "...",
-        "item_id": "101",
-        "user": "main",
-        "backend": "plex_main",
-        "date": "2026-03-28T12:00:00+00:00",
-        "text": "Queuing main@plex_main request ..."
-      }
+      "{\"id\":\"...\",\"datetime\":\"2026-03-28T12:00:00+00:00\",\"level\":\"info\",\"logger\":\"access\",\"message\":\"Queuing main@plex_main request ...\"}"
     ]
   }
 ]
@@ -1631,7 +1624,7 @@ Returns the most recent lines from today's `.log` files.
 - `500 Internal Server Error` if the log path is not configured.
 
 **Notes**:
-- Only today's `.log` files are returned, not older logs or JSON dump files.
+- Only today's `.jsonl` log files are returned, not older logs or JSON dump files.
 
 ---
 
@@ -1649,20 +1642,13 @@ Reads, downloads, streams, or deletes a single log, debug, or webhook file.
 **Normal GET Response**:
 ```json
 {
-  "filename": "access.20260328.log",
+  "filename": "access.20260328.jsonl",
   "offset": 100,
   "next": 200,
   "max": 500,
   "type": "log",
   "lines": [
-    {
-      "id": "...",
-      "item_id": null,
-      "user": "main",
-      "backend": "plex_main",
-      "date": "2026-03-28T12:00:00+00:00",
-      "text": "Some log line"
-    }
+    "{\"id\":\"...\",\"datetime\":\"2026-03-28T12:00:00+00:00\",\"level\":\"info\",\"logger\":\"access\",\"message\":\"Some log line\"}"
   ]
 }
 ```
@@ -1670,7 +1656,7 @@ Reads, downloads, streams, or deletes a single log, debug, or webhook file.
 **Stream Response**:
 - `Content-Type: text/event-stream; charset=UTF-8`
 - Emits:
-  - `data` events containing JSON formatted log lines
+  - `data` events containing `{"data":"<raw line>"}` payloads
   - `ping` keepalive events
 
 **DELETE Response**:

--- a/composer.lock
+++ b/composer.lock
@@ -1376,16 +1376,16 @@
     },
     {
       "name": "symfony/cache",
-      "version": "v8.0.10",
+      "version": "v8.0.12",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/cache.git",
-        "reference": "8ff96cde73684bfa32b702f5cff1eb83b1fac429"
+        "reference": "11dc0681506ff07ca80bfb4cbf84c601c3cf04f7"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/cache/zipball/8ff96cde73684bfa32b702f5cff1eb83b1fac429",
-        "reference": "8ff96cde73684bfa32b702f5cff1eb83b1fac429",
+        "url": "https://api.github.com/repos/symfony/cache/zipball/11dc0681506ff07ca80bfb4cbf84c601c3cf04f7",
+        "reference": "11dc0681506ff07ca80bfb4cbf84c601c3cf04f7",
         "shasum": ""
       },
       "require": {
@@ -1451,7 +1451,7 @@
         "psr6"
       ],
       "support": {
-        "source": "https://github.com/symfony/cache/tree/v8.0.10"
+        "source": "https://github.com/symfony/cache/tree/v8.0.12"
       },
       "funding": [
         {
@@ -1471,7 +1471,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2026-05-05T08:24:00+00:00"
+      "time": "2026-05-20T07:22:03+00:00"
     },
     {
       "name": "symfony/cache-contracts",
@@ -1555,16 +1555,16 @@
     },
     {
       "name": "symfony/console",
-      "version": "v8.0.9",
+      "version": "v8.0.11",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/console.git",
-        "reference": "7113778e2e91f4709cb3194a75dfa9c0d028d94d"
+        "reference": "3156577f46a38aa1b9323aad223de7a9cd426782"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/console/zipball/7113778e2e91f4709cb3194a75dfa9c0d028d94d",
-        "reference": "7113778e2e91f4709cb3194a75dfa9c0d028d94d",
+        "url": "https://api.github.com/repos/symfony/console/zipball/3156577f46a38aa1b9323aad223de7a9cd426782",
+        "reference": "3156577f46a38aa1b9323aad223de7a9cd426782",
         "shasum": ""
       },
       "require": {
@@ -1621,7 +1621,7 @@
         "terminal"
       ],
       "support": {
-        "source": "https://github.com/symfony/console/tree/v8.0.9"
+        "source": "https://github.com/symfony/console/tree/v8.0.11"
       },
       "funding": [
         {
@@ -1641,7 +1641,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2026-04-29T15:02:55+00:00"
+      "time": "2026-05-13T12:07:53+00:00"
     },
     {
       "name": "symfony/deprecation-contracts",
@@ -2224,16 +2224,16 @@
     },
     {
       "name": "symfony/process",
-      "version": "v8.0.8",
+      "version": "v8.0.11",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/process.git",
-        "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc"
+        "reference": "26d89e459f037d2873300605d0a07e7a8ef84db0"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/process/zipball/cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
-        "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
+        "url": "https://api.github.com/repos/symfony/process/zipball/26d89e459f037d2873300605d0a07e7a8ef84db0",
+        "reference": "26d89e459f037d2873300605d0a07e7a8ef84db0",
         "shasum": ""
       },
       "require": {
@@ -2265,7 +2265,7 @@
       "description": "Executes commands in sub-processes",
       "homepage": "https://symfony.com",
       "support": {
-        "source": "https://github.com/symfony/process/tree/v8.0.8"
+        "source": "https://github.com/symfony/process/tree/v8.0.11"
       },
       "funding": [
         {
@@ -2285,7 +2285,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2026-03-30T15:14:47+00:00"
+      "time": "2026-05-11T16:56:32+00:00"
     },
     {
       "name": "symfony/service-contracts",
@@ -2376,16 +2376,16 @@
     },
     {
       "name": "symfony/string",
-      "version": "v8.0.8",
+      "version": "v8.0.11",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/string.git",
-        "reference": "ae9488f874d7603f9d2dfbf120203882b645d963"
+        "reference": "39be2ad058a3c0bd558edca23e65f009865d75ff"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/string/zipball/ae9488f874d7603f9d2dfbf120203882b645d963",
-        "reference": "ae9488f874d7603f9d2dfbf120203882b645d963",
+        "url": "https://api.github.com/repos/symfony/string/zipball/39be2ad058a3c0bd558edca23e65f009865d75ff",
+        "reference": "39be2ad058a3c0bd558edca23e65f009865d75ff",
         "shasum": ""
       },
       "require": {
@@ -2442,7 +2442,7 @@
         "utf8"
       ],
       "support": {
-        "source": "https://github.com/symfony/string/tree/v8.0.8"
+        "source": "https://github.com/symfony/string/tree/v8.0.11"
       },
       "funding": [
         {
@@ -2462,7 +2462,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2026-03-30T15:14:47+00:00"
+      "time": "2026-05-13T12:07:53+00:00"
     },
     {
       "name": "symfony/uid",
@@ -2624,16 +2624,16 @@
     },
     {
       "name": "symfony/yaml",
-      "version": "v8.0.10",
+      "version": "v8.0.12",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/yaml.git",
-        "reference": "aa9ee60c41d9b20a2468c41ff0a32e2a7405ac05"
+        "reference": "2a36f4b8405d41fa31799b06874dbd45c1b16c30"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/yaml/zipball/aa9ee60c41d9b20a2468c41ff0a32e2a7405ac05",
-        "reference": "aa9ee60c41d9b20a2468c41ff0a32e2a7405ac05",
+        "url": "https://api.github.com/repos/symfony/yaml/zipball/2a36f4b8405d41fa31799b06874dbd45c1b16c30",
+        "reference": "2a36f4b8405d41fa31799b06874dbd45c1b16c30",
         "shasum": ""
       },
       "require": {
@@ -2675,7 +2675,7 @@
       "description": "Loads and dumps YAML files",
       "homepage": "https://symfony.com",
       "support": {
-        "source": "https://github.com/symfony/yaml/tree/v8.0.10"
+        "source": "https://github.com/symfony/yaml/tree/v8.0.12"
       },
       "funding": [
         {
@@ -2695,22 +2695,22 @@
           "type": "tidelift"
         }
       ],
-      "time": "2026-05-05T08:10:04+00:00"
+      "time": "2026-05-20T07:22:03+00:00"
     }
   ],
   "packages-dev": [
     {
       "name": "carthage-software/mago",
-      "version": "1.26.0",
+      "version": "1.28.0",
       "source": {
         "type": "git",
         "url": "https://github.com/carthage-software/mago.git",
-        "reference": "9ae2f7ad58ffeeaa2ff890e736a8658f8e397cdf"
+        "reference": "c3daa7199f83bd06c0077b997358c46e80a0bb06"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/carthage-software/mago/zipball/9ae2f7ad58ffeeaa2ff890e736a8658f8e397cdf",
-        "reference": "9ae2f7ad58ffeeaa2ff890e736a8658f8e397cdf",
+        "url": "https://api.github.com/repos/carthage-software/mago/zipball/c3daa7199f83bd06c0077b997358c46e80a0bb06",
+        "reference": "c3daa7199f83bd06c0077b997358c46e80a0bb06",
         "shasum": ""
       },
       "require": {
@@ -2725,9 +2725,12 @@
       "type": "library",
       "autoload": {
         "files": [
-          "composer/functions.php",
-          "composer/internal.php"
-        ]
+          "composer/src/functions.php",
+          "composer/src/internal.php"
+        ],
+        "psr-4": {
+          "Mago\\": "composer/src/"
+        }
       },
       "notification-url": "https://packagist.org/downloads/",
       "license": [
@@ -2745,7 +2748,7 @@
       ],
       "support": {
         "issues": "https://github.com/carthage-software/mago/issues",
-        "source": "https://github.com/carthage-software/mago/tree/1.26.0"
+        "source": "https://github.com/carthage-software/mago/tree/1.28.0"
       },
       "funding": [
         {
@@ -2753,7 +2756,7 @@
           "type": "github"
         }
       ],
-      "time": "2026-05-06T21:44:02+00:00"
+      "time": "2026-05-19T07:03:29+00:00"
     },
     {
       "name": "myclabs/deep-copy",
@@ -2993,16 +2996,16 @@
     },
     {
       "name": "phpunit/php-code-coverage",
-      "version": "14.1.8",
+      "version": "14.1.9",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-        "reference": "031856c28c060e1c1d1fc94d256e3ffbe4230c91"
+        "reference": "655533a65696bbc4231cd8027af150dadc40ec88"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/031856c28c060e1c1d1fc94d256e3ffbe4230c91",
-        "reference": "031856c28c060e1c1d1fc94d256e3ffbe4230c91",
+        "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/655533a65696bbc4231cd8027af150dadc40ec88",
+        "reference": "655533a65696bbc4231cd8027af150dadc40ec88",
         "shasum": ""
       },
       "require": {
@@ -3059,7 +3062,7 @@
       "support": {
         "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
         "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-        "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/14.1.8"
+        "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/14.1.9"
       },
       "funding": [
         {
@@ -3079,7 +3082,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2026-05-09T12:06:52+00:00"
+      "time": "2026-05-16T05:16:14+00:00"
     },
     {
       "name": "phpunit/php-file-iterator",
@@ -3376,16 +3379,16 @@
     },
     {
       "name": "phpunit/phpunit",
-      "version": "13.1.9",
+      "version": "13.1.10",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/phpunit.git",
-        "reference": "506033fd7d6855fea1e2973767d65844412b4574"
+        "reference": "38959098d3c10660a189afaa35a94290c1de67bb"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/506033fd7d6855fea1e2973767d65844412b4574",
-        "reference": "506033fd7d6855fea1e2973767d65844412b4574",
+        "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/38959098d3c10660a189afaa35a94290c1de67bb",
+        "reference": "38959098d3c10660a189afaa35a94290c1de67bb",
         "shasum": ""
       },
       "require": {
@@ -3405,8 +3408,8 @@
         "phpunit/php-text-template": "^6.0.0",
         "phpunit/php-timer": "^9.0.0",
         "sebastian/cli-parser": "^5.0.0",
-        "sebastian/comparator": "^8.1.2",
-        "sebastian/diff": "^8.1.0",
+        "sebastian/comparator": "^8.1.3",
+        "sebastian/diff": "^8.3.0",
         "sebastian/environment": "^9.3.0",
         "sebastian/exporter": "^8.0.2",
         "sebastian/git-state": "^1.0",
@@ -3455,7 +3458,7 @@
       "support": {
         "issues": "https://github.com/sebastianbergmann/phpunit/issues",
         "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-        "source": "https://github.com/sebastianbergmann/phpunit/tree/13.1.9"
+        "source": "https://github.com/sebastianbergmann/phpunit/tree/13.1.10"
       },
       "funding": [
         {
@@ -3463,7 +3466,7 @@
           "type": "other"
         }
       ],
-      "time": "2026-05-13T04:00:53+00:00"
+      "time": "2026-05-15T08:03:56+00:00"
     },
     {
       "name": "roave/security-advisories",
@@ -3471,12 +3474,12 @@
       "source": {
         "type": "git",
         "url": "https://github.com/Roave/SecurityAdvisories.git",
-        "reference": "ec0c867c22e5b8d392815d48e4cc9de37470e8c0"
+        "reference": "97022e308bdad1cbd320841c461437ba13fa64d5"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/ec0c867c22e5b8d392815d48e4cc9de37470e8c0",
-        "reference": "ec0c867c22e5b8d392815d48e4cc9de37470e8c0",
+        "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/97022e308bdad1cbd320841c461437ba13fa64d5",
+        "reference": "97022e308bdad1cbd320841c461437ba13fa64d5",
         "shasum": ""
       },
       "conflict": {
@@ -3591,13 +3594,13 @@
         "cesnet/simplesamlphp-module-proxystatistics": "<3.1",
         "chriskacerguis/codeigniter-restserver": "<=2.7.1",
         "chrome-php/chrome": "<1.14",
-        "ci4-cms-erp/ci4ms": "<=0.31.7",
+        "ci4-cms-erp/ci4ms": "<=0.31.8",
         "civicrm/civicrm-core": ">=4.2,<4.2.9|>=4.3,<4.3.3",
         "ckeditor/ckeditor": "<4.25",
         "clickstorm/cs-seo": ">=6,<6.8|>=7,<7.5|>=8,<8.4|>=9,<9.3",
         "co-stack/fal_sftp": "<0.2.6",
         "cockpit-hq/cockpit": "<2.14",
-        "code16/sharp": "<9.20",
+        "code16/sharp": "<9.22",
         "codeception/codeception": "<3.1.3|>=4,<4.1.22",
         "codeigniter/framework": "<3.1.10",
         "codeigniter4/framework": "<4.6.2",
@@ -3607,7 +3610,7 @@
         "codingms/modules": "<4.3.11|>=5,<5.7.4|>=6,<6.4.2|>=7,<7.5.5",
         "commerceteam/commerce": ">=0.9.6,<0.9.9",
         "components/jquery": ">=1.0.3,<3.5",
-        "composer/composer": "<2.2.27|>=2.3,<2.9.6",
+        "composer/composer": "<2.2.28|>=2.3,<2.9.8",
         "concrete5/concrete5": "<9.4.8",
         "concrete5/core": "<8.5.8|>=9,<9.1",
         "contao-components/mediaelement": ">=2.14.2,<2.21.1",
@@ -3617,7 +3620,7 @@
         "contao/core-bundle": "<4.13.57|>=5,<5.3.42|>=5.4,<5.6.5",
         "contao/listing-bundle": ">=3,<=3.5.30|>=4,<4.4.8",
         "contao/managed-edition": "<=1.5",
-        "coreshop/core-shop": "<4.1.9",
+        "coreshop/core-shop": "<4.1.9|==5",
         "corveda/phpsandbox": "<1.3.5",
         "cosenary/instagram": "<=2.3",
         "couleurcitron/tarteaucitron-wp": "<0.3",
@@ -3797,7 +3800,7 @@
         "georgringer/news": "<1.3.3",
         "geshi/geshi": "<=1.0.9.1",
         "getformwork/formwork": "<=2.3.3",
-        "getgrav/grav": "<2.0.0.0-beta4",
+        "getgrav/grav": "<=2.0.0.0-RC1",
         "getgrav/grav-plugin-api": "<1.0.0.0-beta15",
         "getgrav/grav-plugin-form": "<9.1",
         "getkirby/cms": "<4.9|>=5,<5.4",
@@ -4187,9 +4190,11 @@
         "scheb/two-factor-bundle": "<3.26|>=4,<4.11",
         "sensiolabs/connect": "<4.2.3",
         "serluck/phpwhois": "<=4.2.6",
-        "setasign/fpdi": "<2.6.4",
+        "setasign/fpdi": "<2.6.7",
         "sfroemken/url_redirect": "<=1.2.1",
         "sheng/yiicms": "<1.2.1",
+        "shopper/cart": "<2.8",
+        "shopper/framework": "<2.8",
         "shopware/core": "<6.6.10.15-dev|>=6.7,<6.7.8.1-dev",
         "shopware/platform": "<6.6.10.15-dev|>=6.7,<6.7.8.1-dev",
         "shopware/production": "<=6.3.5.2",
@@ -4221,6 +4226,7 @@
         "simplesamlphp/saml2": "<=4.16.15|>=5.0.0.0-alpha1,<=5.0.0.0-alpha19",
         "simplesamlphp/saml2-legacy": "<=4.16.15",
         "simplesamlphp/simplesamlphp": "<1.18.6",
+        "simplesamlphp/simplesamlphp-module-casserver": "<=7.0.2",
         "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
         "simplesamlphp/simplesamlphp-module-openid": "<1",
         "simplesamlphp/simplesamlphp-module-openidprovider": "<0.9",
@@ -4253,14 +4259,14 @@
         "starcitizentools/short-description": ">=4,<4.0.1",
         "starcitizentools/tabber-neue": ">=1.9.1,<2.7.2|>=3,<3.1.1",
         "starcitizenwiki/embedvideo": "<=4",
-        "statamic/cms": "<5.73.21|>=6,<6.15",
+        "statamic/cms": "<5.73.22|>=6,<6.18.1",
         "stormpath/sdk": "<9.9.99",
         "studio-42/elfinder": "<=2.1.67",
         "studiomitte/friendlycaptcha": "<0.1.4",
         "subhh/libconnect": "<7.0.8|>=8,<8.1",
         "sukohi/surpass": "<1",
         "sulu/form-bundle": ">=2,<2.5.3",
-        "sulu/sulu": "<2.6.22|>=3,<3.0.5",
+        "sulu/sulu": "<=2.6.22|>=3,<=3.0.5",
         "sumocoders/framework-user-bundle": "<1.4",
         "superbig/craft-audit": "<3.0.2",
         "svewap/a21glossary": "<=0.4.10",
@@ -4278,42 +4284,51 @@
         "symbiote/silverstripe-seed": "<6.0.3",
         "symbiote/silverstripe-versionedfiles": "<=2.0.3",
         "symfont/process": ">=0",
-        "symfony/cache": ">=3.1,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8",
+        "symfony/cache": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
         "symfony/dependency-injection": ">=2,<2.0.17|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+        "symfony/dom-crawler": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
         "symfony/error-handler": ">=4.4,<4.4.4|>=5,<5.0.4",
         "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.50|>=2.8,<2.8.49|>=3,<3.4.20|>=4,<4.0.15|>=4.1,<4.1.9|>=4.2,<4.2.1",
         "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7|>=5.3.14,<5.3.15|>=5.4.3,<5.4.4|>=6.0.3,<6.0.4",
+        "symfony/html-sanitizer": ">=6.1,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
         "symfony/http-client": ">=4.3,<5.4.47|>=6,<6.4.15|>=7,<7.1.8",
         "symfony/http-foundation": "<5.4.50|>=6,<6.4.29|>=7,<7.3.7",
-        "symfony/http-kernel": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.2.6",
+        "symfony/http-kernel": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.2.6|>=7.4,<7.4.12|>=8,<8.0.12",
         "symfony/intl": ">=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
+        "symfony/json-path": ">=7.3,<7.4.12|>=8,<8.0.12",
+        "symfony/lox24-notifier": ">=7.1,<7.4.12|>=8,<8.0.12",
+        "symfony/mailer": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+        "symfony/mailjet-mailer": ">=6.4,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+        "symfony/mailtrap-mailer": ">=7.2,<7.4.12|>=8,<8.0.12",
         "symfony/maker-bundle": ">=1.27,<1.29.2|>=1.30,<1.31.1",
-        "symfony/mime": ">=4.3,<4.3.8",
+        "symfony/mime": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+        "symfony/monolog-bridge": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
         "symfony/phpunit-bridge": ">=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
         "symfony/polyfill": ">=1,<1.10",
         "symfony/polyfill-php55": ">=1,<1.10",
         "symfony/process": "<5.4.51|>=6,<6.4.33|>=7,<7.1.7|>=7.3,<7.3.11|>=7.4,<7.4.5|>=8,<8.0.5",
         "symfony/proxy-manager-bridge": ">=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
-        "symfony/routing": ">=2,<2.0.19",
-        "symfony/runtime": ">=5.3,<5.4.46|>=6,<6.4.14|>=7,<7.1.7",
+        "symfony/routing": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
+        "symfony/runtime": ">=5.3,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
         "symfony/security": ">=2,<2.7.51|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.8",
         "symfony/security-bundle": ">=2,<4.4.50|>=5,<5.4.20|>=6,<6.0.20|>=6.1,<6.1.12|>=6.2,<6.4.10|>=7,<7.0.10|>=7.1,<7.1.3",
         "symfony/security-core": ">=2.4,<2.6.13|>=2.7,<2.7.9|>=2.7.30,<2.7.32|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.9",
         "symfony/security-csrf": ">=2.4,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
         "symfony/security-guard": ">=2.8,<3.4.48|>=4,<4.4.23|>=5,<5.2.8",
-        "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7|>=5.1,<5.2.8|>=5.3,<5.4.47|>=6,<6.4.15|>=7,<7.1.8",
+        "symfony/security-http": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
         "symfony/serializer": ">=2,<2.0.11|>=4.1,<4.4.35|>=5,<5.3.12",
-        "symfony/symfony": "<5.4.51|>=6,<6.4.33|>=7,<7.3.11|>=7.4,<7.4.5|>=8,<8.0.5",
+        "symfony/symfony": "<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
         "symfony/translation": ">=2,<2.0.17",
-        "symfony/twig-bridge": ">=2,<4.4.51|>=5,<5.4.31|>=6,<6.3.8",
+        "symfony/twig-bridge": ">=2,<4.4.51|>=5,<5.4.31|>=6,<6.3.8|>=6.4.24,<6.4.40",
+        "symfony/twilio-notifier": ">=6.4,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
         "symfony/ux-autocomplete": "<2.11.2",
         "symfony/ux-live-component": "<2.25.1",
         "symfony/ux-twig-component": "<2.25.1",
         "symfony/validator": "<5.4.43|>=6,<6.4.11|>=7,<7.1.4",
         "symfony/var-exporter": ">=4.2,<4.2.12|>=4.3,<4.3.8",
-        "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
+        "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4|>=7.2.9,<7.4.12|>=8,<8.0.12",
         "symfony/webhook": ">=6.3,<6.3.8",
-        "symfony/yaml": ">=2,<2.0.22|>=2.1,<2.1.7|>=2.2.0.0-beta1,<2.2.0.0-beta2",
+        "symfony/yaml": ">=2,<5.4.52|>=6,<6.4.40|>=7,<7.4.12|>=8,<8.0.12",
         "symphonycms/symphony-2": "<2.6.4",
         "t3/dce": "<0.11.5|>=2.2,<2.6.2",
         "t3g/svg-sanitizer": "<1.0.3",
@@ -4344,7 +4359,10 @@
         "truckersmp/phpwhois": "<=4.3.1",
         "ttskch/pagination-service-provider": "<1",
         "twbs/bootstrap": "<3.4.1|>=4,<4.3.1",
-        "twig/twig": "<3.11.2|>=3.12,<3.14.1|>=3.16,<3.19",
+        "twig/cssinliner-extra": ">=2.12,<3.26",
+        "twig/intl-extra": ">=2.12,<3.26",
+        "twig/markdown-extra": ">=2.12,<3.26",
+        "twig/twig": "<3.26",
         "typicms/core": "<16.1.7",
         "typo3/cms": "<9.5.29|>=10,<10.4.35|>=11,<11.5.23|>=12,<12.2",
         "typo3/cms-backend": "<4.1.14|>=4.2,<4.2.15|>=4.3,<4.3.7|>=4.4,<4.4.4|>=7,<=7.6.50|>=8,<=8.7.39|>=9,<9.5.55|>=10,<=10.4.54|>=11,<=11.5.48|>=12,<=12.4.40|>=13,<=13.4.22|>=14,<=14.0.1|==14.2",
@@ -4386,7 +4404,7 @@
         "uvdesk/core-framework": "<=1.1.1",
         "vanilla/safecurl": "<0.9.2",
         "verbb/comments": "<1.5.5",
-        "verbb/formie": "<=2.1.43",
+        "verbb/formie": "<2.2.20|>=3.0.0.0-beta1,<3.1.24",
         "verbb/image-resizer": "<2.0.9",
         "verbb/knock-knock": "<1.2.8",
         "verot/class.upload.php": "<=2.1.6",
@@ -4529,7 +4547,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2026-05-11T19:35:52+00:00"
+      "time": "2026-05-20T11:05:08+00:00"
     },
     {
       "name": "sebastian/cli-parser",
@@ -4602,27 +4620,27 @@
     },
     {
       "name": "sebastian/comparator",
-      "version": "8.1.2",
+      "version": "8.2.0",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/comparator.git",
-        "reference": "b3d09f4360ad97dcad8f82d1c047ad16ff38b7e1"
+        "reference": "ddacb462216a4f6d97e84bf08165b9074ddbafeb"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/b3d09f4360ad97dcad8f82d1c047ad16ff38b7e1",
-        "reference": "b3d09f4360ad97dcad8f82d1c047ad16ff38b7e1",
+        "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ddacb462216a4f6d97e84bf08165b9074ddbafeb",
+        "reference": "ddacb462216a4f6d97e84bf08165b9074ddbafeb",
         "shasum": ""
       },
       "require": {
         "ext-dom": "*",
         "ext-mbstring": "*",
         "php": ">=8.4",
-        "sebastian/diff": "^8.1",
-        "sebastian/exporter": "^8.0"
+        "sebastian/diff": "^8.3",
+        "sebastian/exporter": "^8.0.3"
       },
       "require-dev": {
-        "phpunit/phpunit": "^13.0"
+        "phpunit/phpunit": "^13.1.10"
       },
       "suggest": {
         "ext-bcmath": "For comparing BcMath\\Number objects"
@@ -4630,7 +4648,7 @@
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-main": "8.1-dev"
+          "dev-main": "8.2-dev"
         }
       },
       "autoload": {
@@ -4670,7 +4688,7 @@
       "support": {
         "issues": "https://github.com/sebastianbergmann/comparator/issues",
         "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-        "source": "https://github.com/sebastianbergmann/comparator/tree/8.1.2"
+        "source": "https://github.com/sebastianbergmann/comparator/tree/8.2.0"
       },
       "funding": [
         {
@@ -4690,7 +4708,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2026-04-14T08:24:42+00:00"
+      "time": "2026-05-20T11:55:37+00:00"
     },
     {
       "name": "sebastian/complexity",
@@ -4764,16 +4782,16 @@
     },
     {
       "name": "sebastian/diff",
-      "version": "8.1.0",
+      "version": "8.3.0",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/diff.git",
-        "reference": "9c957d730257f49c873f3761674559bd90098a7d"
+        "reference": "b36d33b6e796513de7cb7df053afb3f55eefcd47"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/9c957d730257f49c873f3761674559bd90098a7d",
-        "reference": "9c957d730257f49c873f3761674559bd90098a7d",
+        "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b36d33b6e796513de7cb7df053afb3f55eefcd47",
+        "reference": "b36d33b6e796513de7cb7df053afb3f55eefcd47",
         "shasum": ""
       },
       "require": {
@@ -4786,7 +4804,7 @@
       "type": "library",
       "extra": {
         "branch-alias": {
-          "dev-main": "8.1-dev"
+          "dev-main": "8.3-dev"
         }
       },
       "autoload": {
@@ -4819,7 +4837,7 @@
       "support": {
         "issues": "https://github.com/sebastianbergmann/diff/issues",
         "security": "https://github.com/sebastianbergmann/diff/security/policy",
-        "source": "https://github.com/sebastianbergmann/diff/tree/8.1.0"
+        "source": "https://github.com/sebastianbergmann/diff/tree/8.3.0"
       },
       "funding": [
         {
@@ -4839,7 +4857,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2026-04-05T12:02:33+00:00"
+      "time": "2026-05-15T04:58:09+00:00"
     },
     {
       "name": "sebastian/environment",
@@ -4919,16 +4937,16 @@
     },
     {
       "name": "sebastian/exporter",
-      "version": "8.0.2",
+      "version": "8.0.3",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/exporter.git",
-        "reference": "9cee180ebe62259e3ed48df2212d1fc8cfd971bb"
+        "reference": "9b54f1afabb977a097ef353600d41a372ccde617"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/9cee180ebe62259e3ed48df2212d1fc8cfd971bb",
-        "reference": "9cee180ebe62259e3ed48df2212d1fc8cfd971bb",
+        "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/9b54f1afabb977a097ef353600d41a372ccde617",
+        "reference": "9b54f1afabb977a097ef353600d41a372ccde617",
         "shasum": ""
       },
       "require": {
@@ -4937,7 +4955,7 @@
         "sebastian/recursion-context": "^8.0"
       },
       "require-dev": {
-        "phpunit/phpunit": "^13.0"
+        "phpunit/phpunit": "^13.1.10"
       },
       "type": "library",
       "extra": {
@@ -4985,7 +5003,7 @@
       "support": {
         "issues": "https://github.com/sebastianbergmann/exporter/issues",
         "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-        "source": "https://github.com/sebastianbergmann/exporter/tree/8.0.2"
+        "source": "https://github.com/sebastianbergmann/exporter/tree/8.0.3"
       },
       "funding": [
         {
@@ -5005,7 +5023,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2026-04-15T12:38:05+00:00"
+      "time": "2026-05-20T04:38:47+00:00"
     },
     {
       "name": "sebastian/git-state",
@@ -5152,24 +5170,24 @@
     },
     {
       "name": "sebastian/lines-of-code",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-        "reference": "4f21bb7768e1c997722ccc7efb1d6b5c11bfd471"
+        "reference": "d2cff273a90c79b0eb590baa682d4b5c318bdbb7"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/4f21bb7768e1c997722ccc7efb1d6b5c11bfd471",
-        "reference": "4f21bb7768e1c997722ccc7efb1d6b5c11bfd471",
+        "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d2cff273a90c79b0eb590baa682d4b5c318bdbb7",
+        "reference": "d2cff273a90c79b0eb590baa682d4b5c318bdbb7",
         "shasum": ""
       },
       "require": {
-        "nikic/php-parser": "^5.0",
+        "nikic/php-parser": "^5.7.0",
         "php": ">=8.4"
       },
       "require-dev": {
-        "phpunit/phpunit": "^13.0"
+        "phpunit/phpunit": "^13.1.10"
       },
       "type": "library",
       "extra": {
@@ -5198,7 +5216,7 @@
       "support": {
         "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
         "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-        "source": "https://github.com/sebastianbergmann/lines-of-code/tree/5.0.0"
+        "source": "https://github.com/sebastianbergmann/lines-of-code/tree/5.0.1"
       },
       "funding": [
         {
@@ -5218,7 +5236,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2026-02-06T04:45:54+00:00"
+      "time": "2026-05-19T16:23:37+00:00"
     },
     {
       "name": "sebastian/object-enumerator",
@@ -5436,23 +5454,23 @@
     },
     {
       "name": "sebastian/type",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/type.git",
-        "reference": "42412224607bd3931241bbd17f38e0f972f5a916"
+        "reference": "fee0309275847fefd7636167085e379c1dbf6990"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/42412224607bd3931241bbd17f38e0f972f5a916",
-        "reference": "42412224607bd3931241bbd17f38e0f972f5a916",
+        "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fee0309275847fefd7636167085e379c1dbf6990",
+        "reference": "fee0309275847fefd7636167085e379c1dbf6990",
         "shasum": ""
       },
       "require": {
         "php": ">=8.4"
       },
       "require-dev": {
-        "phpunit/phpunit": "^13.0"
+        "phpunit/phpunit": "^13.1.10"
       },
       "type": "library",
       "extra": {
@@ -5481,7 +5499,7 @@
       "support": {
         "issues": "https://github.com/sebastianbergmann/type/issues",
         "security": "https://github.com/sebastianbergmann/type/security/policy",
-        "source": "https://github.com/sebastianbergmann/type/tree/7.0.0"
+        "source": "https://github.com/sebastianbergmann/type/tree/7.0.1"
       },
       "funding": [
         {
@@ -5501,7 +5519,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2026-02-06T04:52:09+00:00"
+      "time": "2026-05-20T06:49:11+00:00"
     },
     {
       "name": "sebastian/version",

--- a/config/config.php
+++ b/config/config.php
@@ -229,7 +229,7 @@ return (function () {
         'file' => [
             'type' => 'stream',
             'enabled' => (bool) env('WS_LOGGER_FILE_ENABLE', true),
-            'level' => env('WS_LOGGER_FILE_LEVEL', Level::Warning),
+            'level' => env('WS_LOGGER_FILE_LEVEL', Level::Error),
             'filename' => ag($config, 'tmpDir') . '/logs/app.' . $logDateFormat . '.jsonl',
             'format' => 'jsonl',
         ],

--- a/config/config.php
+++ b/config/config.php
@@ -141,7 +141,7 @@ return (function () {
 
     $dbFile = ag($config, 'path') . '/db/' . PdoFactory::DB_FILE;
 
-    $config['api']['logfile'] = ag($config, 'tmpDir') . '/logs/access.' . $logDateFormat . '.log';
+    $config['api']['logfile'] = ag($config, 'tmpDir') . '/logs/access.' . $logDateFormat . '.jsonl';
 
     $isMemory = 'MEMORY' === env('WS_DB_MODE', 'WAL');
     $pragma = [
@@ -230,7 +230,8 @@ return (function () {
             'type' => 'stream',
             'enabled' => (bool) env('WS_LOGGER_FILE_ENABLE', true),
             'level' => env('WS_LOGGER_FILE_LEVEL', Level::Warning),
-            'filename' => ag($config, 'tmpDir') . '/logs/app.' . $logDateFormat . '.log',
+            'filename' => ag($config, 'tmpDir') . '/logs/app.' . $logDateFormat . '.jsonl',
+            'format' => 'jsonl',
         ],
         'stderr' => [
             'type' => 'stream',
@@ -340,7 +341,7 @@ return (function () {
     };
 
     $config['tasks'] = [
-        'logfile' => ag($config, 'tmpDir') . '/logs/task.' . $logDateFormat . '.log',
+        'logfile' => ag($config, 'tmpDir') . '/logs/task.' . $logDateFormat . '.jsonl',
         'list' => [
             ImportCommand::TASK_NAME => [
                 'command' => ImportCommand::ROUTE,
@@ -412,7 +413,7 @@ return (function () {
     ];
 
     $config['events'] = [
-        'logfile' => ag($config, 'tmpDir') . '/logs/events.' . $logDateFormat . '.log',
+        'logfile' => ag($config, 'tmpDir') . '/logs/events.' . $logDateFormat . '.jsonl',
         'listeners' => [
             'cache' => new DateInterval(env('WS_EVENTS_LISTENERS_CACHE', 'PT1M')),
             'file' => env('APP_EVENTS_FILE', function () use ($config): ?string {

--- a/config/env.spec.php
+++ b/config/env.spec.php
@@ -72,7 +72,7 @@ return (function () {
         [
             'key' => 'WS_LOGGER_FILE_ENABLE',
             'config' => 'logger.file.enabled',
-            'description' => 'Enable logging to app.(YYYYMMDD).log file.',
+            'description' => 'Enable logging to app.(YYYYMMDD).jsonl file.',
             'type' => 'bool',
         ],
         [

--- a/config/env.spec.php
+++ b/config/env.spec.php
@@ -303,6 +303,7 @@ return (function () {
             'config' => 'profiler.collector',
             'description' => 'The XHProf data collector URL to send the profiler data to.',
             'type' => 'string',
+            'mask' => true,
         ],
         [
             'key' => 'WS_PROFILER_SAVE',

--- a/frontend/app/components/BackendEditForm.vue
+++ b/frontend/app/components/BackendEditForm.vue
@@ -33,7 +33,7 @@
           <p>
             After saving shared backend changes like URL, API key, UUID, or import/export settings,
             go to <NuxtLink to="/identities" class="text-primary">Identities</NuxtLink> and use
-            <strong>Sync Backends</strong> to propagate those changes safely.
+            <strong>Sync Backends</strong> sync the changes.
           </p>
         </div>
       </template>

--- a/frontend/app/components/EventView.vue
+++ b/frontend/app/components/EventView.vue
@@ -391,6 +391,7 @@ import { useDialog } from '~/composables/useDialog';
 import type { EventsItem, GenericError, LogEntry } from '~/types';
 import {
   copyText,
+  api_error_message,
   getEventStatusClass,
   makeEventName,
   notification,
@@ -599,7 +600,11 @@ const loadContent = async (): Promise<void> => {
     }
 
     if (200 !== response.status) {
-      notification('error', 'Error', 'Errors viewItem request error.');
+      notification(
+        'error',
+        'Error',
+        `Errors viewItem request error. ${api_error_message(json, response)}`,
+      );
       return;
     }
 

--- a/frontend/app/components/EventView.vue
+++ b/frontend/app/components/EventView.vue
@@ -74,7 +74,7 @@
             size="sm"
             icon="i-lucide-copy"
             :disabled="isLoading"
-            @click="() => copyText(JSON.stringify(item, null, 2))"
+            @click="copyItem"
           >
             <span class="hidden sm:inline">Copy</span>
           </UButton>
@@ -182,7 +182,7 @@
               size="sm"
               icon="i-lucide-copy"
               class="absolute right-3 top-3"
-              @click="() => copyText(JSON.stringify(item.event_data, null, 2))"
+              @click="copyEventData"
             />
           </UTooltip>
         </div>
@@ -207,45 +207,106 @@
           </button>
         </template>
 
-        <div v-if="toggleLogs" class="relative">
-          <code
-            class="ws-terminal ws-terminal-panel ws-terminal-panel-lg"
-            :class="wrapLines ? 'ws-wrap-anywhere whitespace-pre-wrap' : 'whitespace-pre'"
-          >
-            <span
-              v-for="(logLine, index) in filteredRows"
-              :key="`${logLine.id}-${index}`"
-              class="block"
-              ><span
-                v-if="logLine?.date || hasLinks(logLine)"
-                class="mr-[1ch] inline-flex items-baseline whitespace-normal"
-              >
-                <template v-if="logLine?.date"
-                  >[<UTooltip :text="`${moment(logLine.date).format(TOOLTIP_DATE_FORMAT)}`">
-                    <span class="cursor-help">{{
-                      moment(logLine.date).format('HH:mm:ss')
-                    }}</span> </UTooltip
-                  >]</template
-                >
-                <span v-if="hasLinks(logLine)" :class="logLine?.date ? 'ml-[1ch]' : ''">
-                  <LogLineLinks :item="logLine" />
-                </span>
-              </span>
-              <span>{{ String(logLine.text).trim() }}</span>
+        <div v-if="toggleLogs" class="space-y-3">
+          <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-toned">
+            <span>
+              {{ filteredRows.length }} of {{ logRows.length }} line{{
+                1 === logRows.length ? '' : 's'
+              }}
+              {{ query ? 'visible' : 'loaded' }}
             </span>
-          </code>
-          <UTooltip text="Copy logs">
+
             <UButton
               color="neutral"
-              variant="soft"
-              size="sm"
+              variant="outline"
+              size="xs"
               icon="i-lucide-copy"
-              class="absolute right-3 top-3"
-              @click="
-                () => copyText(filteredRows.map((logLine) => formatLogLine(logLine)).join('\n'))
-              "
-            />
-          </UTooltip>
+              @click="copyLogs"
+            >
+              Copy logs
+            </UButton>
+          </div>
+
+          <div class="max-h-[60vh] overflow-auto border border-default bg-elevated/30 shadow-sm">
+            <template v-if="structuredRows.length > 0">
+              <article
+                v-for="(entry, index) in structuredRows"
+                :key="entry.key"
+                :class="structuredRowClass(index)"
+              >
+                <div
+                  :class="[
+                    'flex min-w-0 flex-1 items-start gap-[0.65rem] px-3 py-[0.65rem] leading-[1.6]',
+                    wrapLines ? 'w-full' : 'w-max min-w-full',
+                  ]"
+                >
+                  <p :class="structuredLineClass">
+                    <span
+                      class="inline-flex max-w-full flex-wrap items-center gap-x-2 gap-y-1 align-middle"
+                    >
+                      <UTooltip :text="lineTitle(entry.log)">
+                        <span class="inline cursor-pointer text-[11px] font-semibold text-toned">
+                          {{ timestampLabel(entry.log) }}
+                        </span>
+                      </UTooltip>
+
+                      <LogDetailsChip
+                        :item="entry.log"
+                        :open-details="openLogDetails"
+                        :open-event="openEvent"
+                      />
+
+                      <span
+                        :class="logLevelBadgeClass(entry.level)"
+                        @click="openLogDetails(entry.log)"
+                      >
+                        <UIcon :name="LOG_LEVEL_ICON[entry.level]" class="size-3" />
+                        {{ entry.level }}
+                      </span>
+
+                      <span
+                        v-if="entry.log.logger"
+                        :title="entry.log.logger"
+                        class="inline-block max-w-[46vw] truncate align-middle text-[11px] font-semibold text-toned sm:max-w-104"
+                      >
+                        [{{ entry.log.logger }}]
+                      </span>
+                    </span>
+
+                    <span class="ml-2">{{ logMessage(entry.log) }}</span>
+
+                    <span v-if="entry.log.exception_message" class="ml-1 text-error/90">
+                      : {{ entry.log.exception_message }}
+                    </span>
+                  </p>
+                </div>
+              </article>
+            </template>
+
+            <div
+              v-else
+              class="flex min-h-40 flex-col items-center justify-center gap-3 px-6 py-8 text-center"
+            >
+              <UIcon
+                :name="query ? 'i-lucide-filter-x' : 'i-lucide-circle-off'"
+                class="size-6 text-toned"
+              />
+
+              <div class="space-y-1">
+                <p class="text-sm font-medium text-default">
+                  {{ query ? 'No logs match this query' : 'No log lines available' }}
+                </p>
+
+                <p class="text-sm text-toned">
+                  {{
+                    query
+                      ? 'Adjust the filter to inspect more event output.'
+                      : 'This event has no visible log lines.'
+                  }}
+                </p>
+              </div>
+            </div>
+          </div>
         </div>
       </UCard>
 
@@ -282,21 +343,35 @@
               size="sm"
               icon="i-lucide-copy"
               class="absolute right-3 top-3"
-              @click="() => copyText(JSON.stringify(item.options, null, 2))"
+              @click="copyOptions"
             />
           </UTooltip>
         </div>
       </UCard>
     </template>
+
+    <UModal v-model:open="eventViewOpen" :title="eventViewTitle" :ui="eventViewModalUi">
+      <template #body>
+        <EventView
+          v-if="selectedEventId"
+          :id="selectedEventId"
+          @delete="(eventItem) => emit('delete', eventItem)"
+        />
+      </template>
+    </UModal>
+
+    <LogDetailsModal :log="selectedLog" v-model:open="detailsOpen" />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { createError, useHead } from '#app';
 import moment from 'moment';
 import { useStorage } from '@vueuse/core';
-import LogLineLinks from '~/components/LogLineLinks.vue';
+import EventView from '~/components/EventView.vue';
+import LogDetailsChip from '~/components/LogDetailsChip.vue';
+import LogDetailsModal from '~/components/LogDetailsModal.vue';
 import { useDialog } from '~/composables/useDialog';
 import type { EventsItem, GenericError, LogEntry } from '~/types';
 import {
@@ -308,6 +383,14 @@ import {
   request,
   TOOLTIP_DATE_FORMAT,
 } from '~/utils';
+import {
+  getLogLevel,
+  logMessageText,
+  logSearchText,
+  logTimestampLabel,
+  logTimestampTitle,
+  parseLogLines,
+} from '~/utils/logs';
 
 const emit = defineEmits<{
   closeOverlay: [];
@@ -326,11 +409,82 @@ const toggleLogs = useStorage<boolean>('events_toggle_logs', true);
 const toggleData = useStorage<boolean>('events_toggle_data', true);
 const toggleOptions = useStorage<boolean>('events_toggle_options', true);
 const wrapLines = useStorage<boolean>('logs_wrap_lines', false);
+const selectedEventId = ref<string | null>(null);
+const selectedLog = ref<LogEntry | null>(null);
+
+type LogLevel = 'debug' | 'info' | 'warning' | 'error';
+type StructuredLogRow = {
+  key: string;
+  log: LogEntry;
+  level: LogLevel;
+};
+
+const LOG_LEVEL_ICON: Record<LogLevel, string> = {
+  debug: 'i-lucide-terminal',
+  info: 'i-lucide-info',
+  warning: 'i-lucide-triangle-alert',
+  error: 'i-lucide-circle-x',
+};
 
 const cardUi = {
   header: 'p-4',
   body: 'px-4 pb-4 pt-0',
 };
+
+const eventViewModalUi = {
+  content: 'max-w-5xl',
+  body: 'p-4 sm:p-5',
+};
+
+const eventViewOpen = computed({
+  get: () => null !== selectedEventId.value,
+  set: (value: boolean) => {
+    if (false === value) {
+      selectedEventId.value = null;
+    }
+  },
+});
+
+const eventViewTitle = computed(() =>
+  null === selectedEventId.value ? 'Event' : `#${makeEventName(selectedEventId.value)}`,
+);
+
+const detailsOpen = computed({
+  get: () => null !== selectedLog.value,
+  set: (value: boolean) => {
+    if (false === value) {
+      selectedLog.value = null;
+    }
+  },
+});
+
+const dialog = useDialog();
+
+const logRows = computed<Array<LogEntry>>(() => parseLogLines(item.value.logs ?? []));
+
+const filteredRows = computed<Array<LogEntry>>(() => {
+  if (!query.value) {
+    return logRows.value;
+  }
+
+  const queryValue = query.value.toLowerCase();
+
+  return logRows.value.filter((logLine) => logSearchText(logLine).includes(queryValue));
+});
+
+const structuredRows = computed<Array<StructuredLogRow>>(() => {
+  return filteredRows.value.map((log, index) => ({
+    key: `${log.id}:${index}`,
+    log,
+    level: getLogLevel(log.level),
+  }));
+});
+
+const structuredLineClass = computed<Array<string>>(() => [
+  'flex-1',
+  wrapLines.value ? 'min-w-0 whitespace-pre-wrap wrap-break-word' : 'min-w-max whitespace-pre',
+  'text-default',
+]);
 
 watch(toggleFilter, () => {
   if (!toggleFilter.value) {
@@ -338,27 +492,42 @@ watch(toggleFilter, () => {
   }
 });
 
-const filteredRows = computed<Array<LogEntry>>(() => {
-  const rows = item.value.logs ?? [];
+watch(
+  () => props.id,
+  (value, oldValue) => {
+    if (!value || value === oldValue) {
+      return;
+    }
 
-  if (!query.value) {
-    return rows;
+    if (timer.value) {
+      clearInterval(timer.value);
+      timer.value = null;
+    }
+
+    selectedLog.value = null;
+    selectedEventId.value = null;
+    query.value = '';
+    void loadContent();
+  },
+);
+
+onMounted(async () => {
+  if (!props.id) {
+    throw createError({
+      statusCode: 404,
+      message: 'Error ID not provided.',
+    });
   }
 
-  const queryValue = query.value.toLowerCase();
-
-  return rows.filter((logLine) => logLine.text.toLowerCase().includes(queryValue));
+  await loadContent();
 });
 
-const formatLogLine = (logLine: LogEntry): string => {
-  const prefix = logLine.date ? `[${logLine.date}] ` : '';
-
-  return `${prefix}${String(logLine.text).trim()}`;
-};
-
-const hasLinks = (logLine: LogEntry): boolean => {
-  return Boolean(logLine.item_id || logLine.backend);
-};
+onUnmounted(() => {
+  if (timer.value) {
+    clearInterval(timer.value);
+    timer.value = null;
+  }
+});
 
 const getEventStatusColor = (status: number) => {
   const value = getEventStatusClass(status);
@@ -403,16 +572,6 @@ const getEventStatusIconClass = (status: number): string => {
   return 1 === status ? 'size-3.5 animate-spin' : 'size-3.5';
 };
 
-onMounted(async () => {
-  if (!props.id) {
-    throw createError({
-      statusCode: 404,
-      message: 'Error ID not provided.',
-    });
-  }
-  return await loadContent();
-});
-
 const loadContent = async (): Promise<void> => {
   try {
     isLoading.value = true;
@@ -436,7 +595,9 @@ const loadContent = async (): Promise<void> => {
 
     if (1 === json.status) {
       if (!timer.value) {
-        timer.value = setInterval(async () => await loadContent(), 5000);
+        timer.value = setInterval(() => {
+          void loadContent();
+        }, 5000);
       }
     } else if (timer.value) {
       clearInterval(timer.value);
@@ -458,7 +619,7 @@ const loadContent = async (): Promise<void> => {
 const deleteItem = async (): Promise<void> => emit('delete', item.value);
 
 const resetEvent = async (status: number = 0): Promise<void> => {
-  const { status: confirmStatus } = await useDialog().confirmDialog({
+  const { status: confirmStatus } = await dialog.confirmDialog({
     message: `Reset '${makeEventName(item.value.id)}'?`,
     confirmColor: 'warning',
   });
@@ -488,9 +649,77 @@ const resetEvent = async (status: number = 0): Promise<void> => {
     }
 
     item.value = json;
-  } catch (e: any) {
-    console.error(e);
-    notification('crit', 'Error', `Events view patch Request failure. ${e.message}`);
+  } catch (error: unknown) {
+    console.error(error);
+    notification(
+      'crit',
+      'Error',
+      `Events view patch Request failure. ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
+};
+
+const openEvent = (id: string): void => {
+  if (id === item.value.id) {
+    return;
+  }
+
+  selectedEventId.value = id;
+};
+
+const openLogDetails = (log: LogEntry): void => {
+  selectedLog.value = log;
+};
+
+const lineTitle = (logLine: LogEntry): string =>
+  logTimestampTitle(logLine.datetime ?? logLine.date);
+
+const timestampLabel = (logLine: LogEntry): string =>
+  logTimestampLabel(logLine.datetime ?? logLine.date);
+
+const logMessage = (logLine: LogEntry): string => logMessageText(logLine);
+
+const structuredRowClass = (index: number): Array<string> => {
+  const classes = [
+    'flex min-w-0 border-b border-default/40 bg-transparent transition-colors duration-150 last:border-b-0 hover:bg-elevated/70',
+  ];
+
+  if (index % 2 === 1) {
+    classes.push('bg-elevated/40');
+  }
+
+  return classes;
+};
+
+const logLevelBadgeClass = (level: LogLevel): Array<string> => [
+  'inline-flex cursor-pointer items-center gap-1.5 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide',
+  'debug' === level ? 'bg-muted/40 text-muted' : '',
+  'info' === level ? 'bg-info/10 text-info' : '',
+  'warning' === level ? 'bg-warning/10 text-warning' : '',
+  'error' === level ? 'bg-error/10 text-error' : '',
+];
+
+const copyItem = (): void => {
+  copyText(JSON.stringify(item.value, null, 2));
+};
+
+const copyEventData = (): void => {
+  if (!item.value.event_data) {
+    return;
+  }
+
+  copyText(JSON.stringify(item.value.event_data, null, 2));
+};
+
+const copyOptions = (): void => {
+  if (!item.value.options) {
+    return;
+  }
+
+  copyText(JSON.stringify(item.value.options, null, 2));
+};
+
+const copyLogs = (): void => {
+  copyText(filteredRows.value.map((logLine) => logLine.raw).join('\n'));
 };
 </script>

--- a/frontend/app/components/EventView.vue
+++ b/frontend/app/components/EventView.vue
@@ -67,18 +67,51 @@
           </UButton>
         </UTooltip>
 
-        <UTooltip text="Copy event.">
-          <UButton
-            color="neutral"
-            variant="outline"
-            size="sm"
-            icon="i-lucide-copy"
-            :disabled="isLoading"
-            @click="copyItem"
-          >
-            <span class="hidden sm:inline">Copy</span>
-          </UButton>
-        </UTooltip>
+        <Popover placement="bottom-end" trigger="click" :z-index="13000" :disabled="isLoading">
+          <template #trigger>
+            <UButton
+              color="neutral"
+              variant="outline"
+              size="sm"
+              icon="i-lucide-copy"
+              trailing-icon="i-lucide-chevron-down"
+              :disabled="isLoading"
+            >
+              <span class="hidden sm:inline">Copy</span>
+            </UButton>
+          </template>
+
+          <template #content="{ hide }">
+            <div class="w-52 space-y-1 p-1">
+              <button
+                type="button"
+                class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm text-default hover:bg-elevated hover:text-highlighted"
+                @click="copyEventId(hide)"
+              >
+                <UIcon name="i-lucide-hash" class="size-4 text-toned" />
+                <span>Copy ID</span>
+              </button>
+
+              <button
+                type="button"
+                class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm text-default hover:bg-elevated hover:text-highlighted"
+                @click="copyItem(hide)"
+              >
+                <UIcon name="i-lucide-copy" class="size-4 text-toned" />
+                <span>Copy Event</span>
+              </button>
+
+              <button
+                type="button"
+                class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm text-default hover:bg-elevated hover:text-highlighted"
+                @click="copyLogs(hide)"
+              >
+                <UIcon name="i-lucide-scroll-text" class="size-4 text-toned" />
+                <span>Copy Logs</span>
+              </button>
+            </div>
+          </template>
+        </Popover>
 
         <UTooltip text="Reload event data.">
           <UButton
@@ -208,25 +241,6 @@
         </template>
 
         <div v-if="toggleLogs" class="space-y-3">
-          <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-toned">
-            <span>
-              {{ filteredRows.length }} of {{ logRows.length }} line{{
-                1 === logRows.length ? '' : 's'
-              }}
-              {{ query ? 'visible' : 'loaded' }}
-            </span>
-
-            <UButton
-              color="neutral"
-              variant="outline"
-              size="xs"
-              icon="i-lucide-copy"
-              @click="copyLogs"
-            >
-              Copy logs
-            </UButton>
-          </div>
-
           <div class="max-h-[60vh] overflow-auto border border-default bg-elevated/30 shadow-sm">
             <template v-if="structuredRows.length > 0">
               <article
@@ -372,6 +386,7 @@ import { useStorage } from '@vueuse/core';
 import EventView from '~/components/EventView.vue';
 import LogDetailsChip from '~/components/LogDetailsChip.vue';
 import LogDetailsModal from '~/components/LogDetailsModal.vue';
+import Popover from '~/components/Popover.vue';
 import { useDialog } from '~/composables/useDialog';
 import type { EventsItem, GenericError, LogEntry } from '~/types';
 import {
@@ -385,6 +400,8 @@ import {
 } from '~/utils';
 import {
   getLogLevel,
+  LOG_LEVEL_ICON,
+  logLevelBadgeClass,
   logMessageText,
   logSearchText,
   logTimestampLabel,
@@ -412,18 +429,11 @@ const wrapLines = useStorage<boolean>('logs_wrap_lines', false);
 const selectedEventId = ref<string | null>(null);
 const selectedLog = ref<LogEntry | null>(null);
 
-type LogLevel = 'debug' | 'info' | 'warning' | 'error';
+type LogLevel = 'debug' | 'info' | 'notice' | 'warning' | 'error';
 type StructuredLogRow = {
   key: string;
   log: LogEntry;
   level: LogLevel;
-};
-
-const LOG_LEVEL_ICON: Record<LogLevel, string> = {
-  debug: 'i-lucide-terminal',
-  info: 'i-lucide-info',
-  warning: 'i-lucide-triangle-alert',
-  error: 'i-lucide-circle-x',
 };
 
 const cardUi = {
@@ -691,16 +701,14 @@ const structuredRowClass = (index: number): Array<string> => {
   return classes;
 };
 
-const logLevelBadgeClass = (level: LogLevel): Array<string> => [
-  'inline-flex cursor-pointer items-center gap-1.5 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide',
-  'debug' === level ? 'bg-muted/40 text-muted' : '',
-  'info' === level ? 'bg-info/10 text-info' : '',
-  'warning' === level ? 'bg-warning/10 text-warning' : '',
-  'error' === level ? 'bg-error/10 text-error' : '',
-];
+const copyEventId = (hide?: () => void): void => {
+  copyText(item.value.id);
+  hide?.();
+};
 
-const copyItem = (): void => {
+const copyItem = (hide?: () => void): void => {
   copyText(JSON.stringify(item.value, null, 2));
+  hide?.();
 };
 
 const copyEventData = (): void => {
@@ -719,7 +727,8 @@ const copyOptions = (): void => {
   copyText(JSON.stringify(item.value.options, null, 2));
 };
 
-const copyLogs = (): void => {
+const copyLogs = (hide?: () => void): void => {
   copyText(filteredRows.value.map((logLine) => logLine.raw).join('\n'));
+  hide?.();
 };
 </script>

--- a/frontend/app/components/LogDetailsChip.vue
+++ b/frontend/app/components/LogDetailsChip.vue
@@ -146,17 +146,6 @@ const menuItems = computed<Array<ActionItem>>(() => {
     });
   }
 
-  if (user) {
-    list.push({
-      key: `identity:${user}`,
-      label: `Use identity ${user}`,
-      icon: 'i-lucide-user-round',
-      action: async () => {
-        await switchIdentity(user);
-      },
-    });
-  }
-
   return list;
 });
 

--- a/frontend/app/components/LogDetailsChip.vue
+++ b/frontend/app/components/LogDetailsChip.vue
@@ -1,0 +1,194 @@
+<template>
+  <UTooltip v-if="menuItems.length < 1" text="View details">
+    <button
+      type="button"
+      class="inline-flex h-5 items-center gap-1 rounded px-1.5 text-[11px] font-medium text-primary transition hover:bg-primary/10 hover:text-primary"
+      @click="props.openDetails(props.item)"
+    >
+      <UIcon name="i-lucide-panel-right-open" class="size-3.5 shrink-0" />
+      <span>View</span>
+    </button>
+  </UTooltip>
+
+  <Popover
+    v-else
+    placement="bottom-start"
+    trigger="click"
+    :offset="6"
+    :show-arrow="false"
+    :z-index="13000"
+    popover-class="w-60"
+    content-class="p-1"
+  >
+    <template #trigger>
+      <UTooltip text="Extended view">
+        <button
+          type="button"
+          class="inline-flex h-5 items-center gap-1 rounded px-1.5 text-[11px] font-medium text-primary transition hover:bg-primary/10 hover:text-primary"
+        >
+          <UIcon name="i-lucide-panel-right-open" class="size-3.5 shrink-0" />
+          <span>View</span>
+        </button>
+      </UTooltip>
+    </template>
+
+    <template #content="{ hide }">
+      <div class="space-y-1">
+        <button
+          type="button"
+          class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-default hover:bg-elevated hover:text-highlighted"
+          @click="onOpenDetails(hide)"
+        >
+          <UIcon name="i-lucide-panel-right-open" class="size-4 shrink-0 text-toned" />
+          <span class="truncate">View details</span>
+        </button>
+
+        <button
+          v-for="entry in menuItems"
+          :key="entry.key"
+          type="button"
+          class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-default hover:bg-elevated hover:text-highlighted"
+          @click="void onSelect(entry, hide)"
+        >
+          <UIcon :name="entry.icon" class="size-4 shrink-0 text-toned" />
+          <span class="truncate">{{ entry.label }}</span>
+        </button>
+      </div>
+    </template>
+  </Popover>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useStorage } from '@vueuse/core';
+import Popover from '~/components/Popover.vue';
+import { useDialog } from '~/composables/useDialog';
+import type { LogEntry } from '~/types';
+import { goto_history_item, makeEventName } from '~/utils';
+import { navigateTo } from '#app';
+
+type ActionItem = {
+  key: string;
+  label: string;
+  icon: string;
+  action: () => Promise<void>;
+};
+
+const props = defineProps<{
+  item: LogEntry;
+  openDetails: (item: LogEntry) => void;
+  openEvent?: (id: string) => void;
+}>();
+
+const dialog = useDialog();
+const api_user = useStorage('api_user', 'main');
+
+const asString = (value: unknown): string | null => {
+  if ('string' === typeof value) {
+    return '' === value ? null : value;
+  }
+
+  if ('number' === typeof value || 'boolean' === typeof value) {
+    return String(value);
+  }
+
+  return null;
+};
+
+const menuItems = computed<Array<ActionItem>>(() => {
+  const list: Array<ActionItem> = [];
+  const user = asString(props.item.user);
+
+  if (itemId.value) {
+    list.push({
+      key: `item:${itemId.value}`,
+      label: `View item #${itemId.value}`,
+      icon: 'i-lucide-history',
+      action: async () => {
+        await goto_history_item({ item_id: itemId.value, user });
+      },
+    });
+  }
+
+  if (eventId.value) {
+    const currentEventId = eventId.value;
+
+    list.push({
+      key: `event:${currentEventId}`,
+      label: `View event #${makeEventName(currentEventId)}`,
+      icon: 'i-lucide-activity',
+      action: async () => {
+        if (props.openEvent) {
+          props.openEvent(currentEventId);
+          return;
+        }
+
+        await navigateTo({
+          path: '/events',
+          query: { view: currentEventId },
+        });
+      },
+    });
+  }
+
+  if (backend.value) {
+    list.push({
+      key: `backend:${backend.value}`,
+      label: `View backend ${backend.value}`,
+      icon: 'i-lucide-server',
+      action: async () => {
+        if (user && false === (await switchIdentity(user))) {
+          return;
+        }
+
+        await navigateTo(`/backend/${backend.value}`);
+      },
+    });
+  }
+
+  if (user) {
+    list.push({
+      key: `identity:${user}`,
+      label: `Use identity ${user}`,
+      icon: 'i-lucide-user-round',
+      action: async () => {
+        await switchIdentity(user);
+      },
+    });
+  }
+
+  return list;
+});
+
+const itemId = computed<string | null>(() => asString(props.item.item_id));
+const eventId = computed<string | null>(() => asString(props.item.event_id));
+const backend = computed<string | null>(() => asString(props.item.backend));
+
+const switchIdentity = async (identity: string): Promise<boolean> => {
+  if (identity === api_user.value) {
+    return true;
+  }
+
+  const { status } = await dialog.confirmDialog({
+    title: 'Switch Identity',
+    message: `This log is related to identity '${identity}'. You are currently using '${api_user.value}'. Do you want to switch to view it?`,
+  });
+
+  if (true !== status) {
+    return false;
+  }
+
+  api_user.value = identity;
+  return true;
+};
+
+const onOpenDetails = (hide: () => void): void => {
+  hide();
+  props.openDetails(props.item);
+};
+
+const onSelect = async (entry: ActionItem, hide: () => void): Promise<void> => {
+  hide();
+  await entry.action();
+};
+</script>

--- a/frontend/app/components/LogDetailsModal.vue
+++ b/frontend/app/components/LogDetailsModal.vue
@@ -82,27 +82,6 @@
           </div>
         </div>
 
-        <section v-if="log.exception" class="space-y-2">
-          <button
-            type="button"
-            class="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-toned hover:text-default"
-            @click="exceptionOpen = !exceptionOpen"
-          >
-            <UIcon
-              name="i-lucide-chevron-right"
-              :class="['size-4 transition-transform', exceptionOpen ? 'rotate-90' : '']"
-            />
-            <UIcon name="i-lucide-bug" class="size-4 text-error" />
-            Exception
-          </button>
-
-          <pre
-            v-if="exceptionOpen"
-            class="max-h-72 overflow-auto rounded-sm border border-error/30 bg-error/5 p-3 text-xs whitespace-pre-wrap text-error"
-            >{{ formatException(log.exception) }}</pre
-          >
-        </section>
-
         <section v-if="log.stack" class="space-y-2">
           <button
             type="button"
@@ -113,8 +92,8 @@
               name="i-lucide-chevron-right"
               :class="['size-4 transition-transform', stackOpen ? 'rotate-90' : '']"
             />
-            <UIcon name="i-lucide-layers" class="size-4 text-toned" />
-            Stack
+            <UIcon name="i-lucide-layers" class="size-4 text-error" />
+            Exception Stack
           </button>
 
           <pre
@@ -220,7 +199,6 @@ import Popover from '~/components/Popover.vue';
 import type { LogEntry } from '~/types';
 import { copyText } from '~/utils';
 import {
-  formatLogException,
   formatLogStack,
   getLogLevel,
   LOG_LEVEL_COLOR,
@@ -256,7 +234,6 @@ const modalOpen = computed({
 
 const selectedLogLevel = computed<LogLevel>(() => getLogLevel(props.log?.level));
 
-const exceptionOpen = useStorage<boolean>('logs_exception_open', false);
 const stackOpen = useStorage<boolean>('logs_stack_open', true);
 const fieldsOpen = useStorage<boolean>('logs_fields_open', true);
 const rawJsonOpen = useStorage<boolean>('logs_raw_json_open', false);
@@ -269,8 +246,6 @@ const logMessage = (item: LogEntry): string => logMessageText(item);
 const detailRows = (item: LogEntry) => logDetailRows(item);
 
 const fieldRows = (item: LogEntry) => logFieldRows(item);
-
-const formatException = (value: string | null | undefined): string => formatLogException(value);
 
 const formatStack = (value: string | null | undefined): string => formatLogStack(value);
 

--- a/frontend/app/components/LogDetailsModal.vue
+++ b/frontend/app/components/LogDetailsModal.vue
@@ -206,6 +206,8 @@ import {
   formatLogException,
   formatLogStack,
   getLogLevel,
+  LOG_LEVEL_COLOR,
+  LOG_LEVEL_ICON,
   logDetailRows,
   logFieldRows,
   logMessageText,
@@ -213,8 +215,7 @@ import {
   logTimestampTitle,
 } from '~/utils/logs';
 
-type LogLevel = 'debug' | 'info' | 'warning' | 'error';
-type LogLevelColor = 'neutral' | 'info' | 'warning' | 'error';
+type LogLevel = 'debug' | 'info' | 'notice' | 'warning' | 'error';
 
 const props = defineProps<{
   log: LogEntry | null;
@@ -224,20 +225,6 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'update:open', value: boolean): void;
 }>();
-
-const LOG_LEVEL_COLOR: Record<LogLevel, LogLevelColor> = {
-  debug: 'neutral',
-  info: 'info',
-  warning: 'warning',
-  error: 'error',
-};
-
-const LOG_LEVEL_ICON: Record<LogLevel, string> = {
-  debug: 'i-lucide-terminal',
-  info: 'i-lucide-info',
-  warning: 'i-lucide-triangle-alert',
-  error: 'i-lucide-circle-x',
-};
 
 const detailsModalUi = {
   content: 'max-w-5xl',

--- a/frontend/app/components/LogDetailsModal.vue
+++ b/frontend/app/components/LogDetailsModal.vue
@@ -29,25 +29,41 @@
           </div>
 
           <div class="flex shrink-0 flex-wrap justify-end gap-2">
-            <UButton
-              color="neutral"
-              variant="outline"
-              size="xs"
-              icon="i-lucide-copy"
-              @click="copyLogMessage(log)"
-            >
-              Message
-            </UButton>
+            <Popover placement="bottom-end" trigger="click">
+              <template #trigger>
+                <UButton
+                  color="neutral"
+                  variant="outline"
+                  size="xs"
+                  icon="i-lucide-copy"
+                  trailing-icon="i-lucide-chevron-down"
+                >
+                  Copy
+                </UButton>
+              </template>
 
-            <UButton
-              color="neutral"
-              variant="outline"
-              size="xs"
-              icon="i-lucide-braces"
-              @click="copyLogRaw(log)"
-            >
-              JSON
-            </UButton>
+              <template #content="{ hide }">
+                <div class="w-52 space-y-1 p-1">
+                  <button
+                    type="button"
+                    class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm text-default hover:bg-elevated hover:text-highlighted"
+                    @click="copyLogMessage(log, hide)"
+                  >
+                    <UIcon name="i-lucide-scroll-text" class="size-4 text-toned" />
+                    <span>Message</span>
+                  </button>
+
+                  <button
+                    type="button"
+                    class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm text-default hover:bg-elevated hover:text-highlighted"
+                    @click="copyLogRaw(log, hide)"
+                  >
+                    <UIcon name="i-lucide-braces" class="size-4 text-toned" />
+                    <span>RAW DATA</span>
+                  </button>
+                </div>
+              </template>
+            </Popover>
           </div>
 
           <div class="min-w-0 space-y-2 sm:col-span-2">
@@ -200,6 +216,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useStorage } from '@vueuse/core';
+import Popover from '~/components/Popover.vue';
 import type { LogEntry } from '~/types';
 import { copyText } from '~/utils';
 import {
@@ -208,6 +225,7 @@ import {
   getLogLevel,
   LOG_LEVEL_COLOR,
   LOG_LEVEL_ICON,
+  logClipboardLine,
   logDetailRows,
   logFieldRows,
   logMessageText,
@@ -258,11 +276,13 @@ const formatStack = (value: string | null | undefined): string => formatLogStack
 
 const logRawData = (item: LogEntry): string => logRaw(item);
 
-const copyLogMessage = (item: LogEntry): void => {
-  copyText(logMessage(item));
+const copyLogMessage = (item: LogEntry, hide?: () => void): void => {
+  copyText(logClipboardLine(item));
+  hide?.();
 };
 
-const copyLogRaw = (item: LogEntry): void => {
+const copyLogRaw = (item: LogEntry, hide?: () => void): void => {
   copyText(logRawData(item));
+  hide?.();
 };
 </script>

--- a/frontend/app/components/LogDetailsModal.vue
+++ b/frontend/app/components/LogDetailsModal.vue
@@ -1,0 +1,281 @@
+<template>
+  <UModal v-model:open="modalOpen" title="Log details" :ui="detailsModalUi">
+    <template #body>
+      <div v-if="log" class="space-y-5">
+        <div class="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+          <div class="flex min-w-0 flex-wrap items-center gap-2">
+            <UBadge
+              :color="LOG_LEVEL_COLOR[selectedLogLevel]"
+              variant="soft"
+              size="sm"
+              class="uppercase"
+            >
+              <UIcon :name="LOG_LEVEL_ICON[selectedLogLevel]" class="mr-1 size-3.5" />
+              {{ selectedLogLevel }}
+            </UBadge>
+
+            <UBadge
+              v-if="log.logger"
+              color="neutral"
+              variant="soft"
+              size="sm"
+              class="max-w-full min-w-0"
+              :title="log.logger"
+            >
+              <span class="min-w-0 max-w-full truncate">{{ log.logger }}</span>
+            </UBadge>
+
+            <span class="text-xs text-toned">{{ lineTitle(log) }}</span>
+          </div>
+
+          <div class="flex shrink-0 flex-wrap justify-end gap-2">
+            <UButton
+              color="neutral"
+              variant="outline"
+              size="xs"
+              icon="i-lucide-copy"
+              @click="copyLogMessage(log)"
+            >
+              Message
+            </UButton>
+
+            <UButton
+              color="neutral"
+              variant="outline"
+              size="xs"
+              icon="i-lucide-braces"
+              @click="copyLogRaw(log)"
+            >
+              JSON
+            </UButton>
+          </div>
+
+          <div class="min-w-0 space-y-2 sm:col-span-2">
+            <p class="wrap-break-word w-full font-mono text-sm text-default">
+              {{ logMessage(log) }}
+            </p>
+
+            <UAlert
+              v-if="log.exception_message"
+              color="error"
+              variant="soft"
+              icon="i-lucide-badge-alert"
+              :title="log.exception_message"
+              class="w-full"
+            />
+          </div>
+        </div>
+
+        <section v-if="log.exception" class="space-y-2">
+          <button
+            type="button"
+            class="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-toned hover:text-default"
+            @click="exceptionOpen = !exceptionOpen"
+          >
+            <UIcon
+              name="i-lucide-chevron-right"
+              :class="['size-4 transition-transform', exceptionOpen ? 'rotate-90' : '']"
+            />
+            <UIcon name="i-lucide-bug" class="size-4 text-error" />
+            Exception
+          </button>
+
+          <pre
+            v-if="exceptionOpen"
+            class="max-h-72 overflow-auto rounded-sm border border-error/30 bg-error/5 p-3 text-xs whitespace-pre-wrap text-error"
+            >{{ formatException(log.exception) }}</pre
+          >
+        </section>
+
+        <section v-if="log.stack" class="space-y-2">
+          <button
+            type="button"
+            class="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-toned hover:text-default"
+            @click="stackOpen = !stackOpen"
+          >
+            <UIcon
+              name="i-lucide-chevron-right"
+              :class="['size-4 transition-transform', stackOpen ? 'rotate-90' : '']"
+            />
+            <UIcon name="i-lucide-layers" class="size-4 text-toned" />
+            Stack
+          </button>
+
+          <pre
+            v-if="stackOpen"
+            class="max-h-72 overflow-auto rounded-sm border border-default bg-elevated/50 p-3 text-xs whitespace-pre-wrap text-default"
+            >{{ formatStack(log.stack) }}</pre
+          >
+        </section>
+
+        <section v-if="detailRows(log).length > 0" class="space-y-2">
+          <button
+            type="button"
+            class="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-toned hover:text-default"
+            @click="sourceOpen = !sourceOpen"
+          >
+            <UIcon
+              name="i-lucide-chevron-right"
+              :class="['size-4 transition-transform', sourceOpen ? 'rotate-90' : '']"
+            />
+            <UIcon name="i-lucide-file-code" class="size-4 text-info" />
+            Source
+          </button>
+
+          <dl v-if="sourceOpen" class="grid gap-2 sm:grid-cols-2">
+            <div
+              v-for="row in detailRows(log)"
+              :key="row.label"
+              class="rounded-sm border border-default bg-elevated/40 p-3"
+            >
+              <dt
+                class="inline-flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-toned"
+              >
+                <UIcon :name="row.icon" class="size-3.5" />
+                <span>{{ row.label }}</span>
+              </dt>
+
+              <dd class="mt-1 wrap-break-word font-mono text-xs text-default">{{ row.value }}</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section v-if="fieldRows(log).length > 0" class="space-y-2">
+          <button
+            type="button"
+            class="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-toned hover:text-default"
+            @click="fieldsOpen = !fieldsOpen"
+          >
+            <UIcon
+              name="i-lucide-chevron-right"
+              :class="['size-4 transition-transform', fieldsOpen ? 'rotate-90' : '']"
+            />
+            <UIcon name="i-lucide-tags" class="size-4 text-primary" />
+            Fields
+          </button>
+
+          <dl v-if="fieldsOpen" class="grid gap-2 sm:grid-cols-2">
+            <div
+              v-for="row in fieldRows(log)"
+              :key="row.label"
+              class="rounded-sm border border-default bg-elevated/40 p-3"
+            >
+              <dt
+                class="inline-flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-toned"
+              >
+                <UIcon :name="row.icon" class="size-3.5" />
+                <span>{{ row.label }}</span>
+              </dt>
+
+              <dd class="mt-1 wrap-break-word font-mono text-xs text-default">{{ row.value }}</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section class="space-y-2">
+          <button
+            type="button"
+            class="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-toned hover:text-default"
+            @click="rawJsonOpen = !rawJsonOpen"
+          >
+            <UIcon
+              name="i-lucide-chevron-right"
+              :class="['size-4 transition-transform', rawJsonOpen ? 'rotate-90' : '']"
+            />
+            <UIcon name="i-lucide-braces" class="size-4 text-toned" />
+            Raw data
+          </button>
+
+          <pre
+            v-if="rawJsonOpen"
+            class="max-h-96 overflow-auto rounded-sm border border-default bg-elevated/50 p-3 text-xs whitespace-pre-wrap text-default"
+            >{{ logRawData(log) }}</pre
+          >
+        </section>
+      </div>
+    </template>
+  </UModal>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useStorage } from '@vueuse/core';
+import type { LogEntry } from '~/types';
+import { copyText } from '~/utils';
+import {
+  formatLogException,
+  formatLogStack,
+  getLogLevel,
+  logDetailRows,
+  logFieldRows,
+  logMessageText,
+  logRaw,
+  logTimestampTitle,
+} from '~/utils/logs';
+
+type LogLevel = 'debug' | 'info' | 'warning' | 'error';
+type LogLevelColor = 'neutral' | 'info' | 'warning' | 'error';
+
+const props = defineProps<{
+  log: LogEntry | null;
+  open: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:open', value: boolean): void;
+}>();
+
+const LOG_LEVEL_COLOR: Record<LogLevel, LogLevelColor> = {
+  debug: 'neutral',
+  info: 'info',
+  warning: 'warning',
+  error: 'error',
+};
+
+const LOG_LEVEL_ICON: Record<LogLevel, string> = {
+  debug: 'i-lucide-terminal',
+  info: 'i-lucide-info',
+  warning: 'i-lucide-triangle-alert',
+  error: 'i-lucide-circle-x',
+};
+
+const detailsModalUi = {
+  content: 'max-w-5xl',
+  body: 'max-h-[75vh] overflow-y-auto',
+};
+
+const modalOpen = computed({
+  get: () => props.open,
+  set: (value: boolean) => emit('update:open', value),
+});
+
+const selectedLogLevel = computed<LogLevel>(() => getLogLevel(props.log?.level));
+
+const exceptionOpen = useStorage<boolean>('logs_exception_open', false);
+const stackOpen = useStorage<boolean>('logs_stack_open', true);
+const fieldsOpen = useStorage<boolean>('logs_fields_open', true);
+const rawJsonOpen = useStorage<boolean>('logs_raw_json_open', false);
+const sourceOpen = useStorage<boolean>('logs_source_open', true);
+
+const lineTitle = (item: LogEntry): string => logTimestampTitle(item.datetime ?? item.date);
+
+const logMessage = (item: LogEntry): string => logMessageText(item);
+
+const detailRows = (item: LogEntry) => logDetailRows(item);
+
+const fieldRows = (item: LogEntry) => logFieldRows(item);
+
+const formatException = (value: string | null | undefined): string => formatLogException(value);
+
+const formatStack = (value: string | null | undefined): string => formatLogStack(value);
+
+const logRawData = (item: LogEntry): string => logRaw(item);
+
+const copyLogMessage = (item: LogEntry): void => {
+  copyText(logMessage(item));
+};
+
+const copyLogRaw = (item: LogEntry): void => {
+  copyText(logRawData(item));
+};
+</script>

--- a/frontend/app/components/LogLineLinks.vue
+++ b/frontend/app/components/LogLineLinks.vue
@@ -1,6 +1,19 @@
 <template>
-  <span v-if="items.length > 0" class="inline-flex items-center align-middle">
+  <span v-if="items.length > 0" class="inline-flex max-w-full items-center gap-1 align-middle">
+    <button
+      v-for="entry in visibleItems"
+      :key="entry.key"
+      type="button"
+      :title="entry.label"
+      class="inline-flex h-5 items-center gap-1 rounded px-1.5 text-[11px] font-medium text-primary transition hover:bg-primary/10 hover:text-primary"
+      @click="void entry.action()"
+    >
+      <UIcon :name="entry.icon" class="size-3.5 shrink-0" />
+      <span v-if="!compact" class="truncate">{{ entry.shortLabel ?? entry.label }}</span>
+    </button>
+
     <Popover
+      v-if="!compact && overflowItems.length > 0"
       placement="bottom-start"
       trigger="click"
       :offset="6"
@@ -14,9 +27,9 @@
           color="neutral"
           variant="ghost"
           size="xs"
-          icon="i-lucide-link-2"
-          aria-label="Open related links"
-          title="Open related links"
+          icon="i-lucide-ellipsis"
+          aria-label="Open more related links"
+          title="Open more related links"
           class="h-5 cursor-pointer rounded px-1.5 text-primary hover:bg-primary/10 hover:text-primary"
           :ui="{
             base: 'min-h-0 min-w-0',
@@ -28,7 +41,7 @@
       <template #content="{ hide }">
         <div class="space-y-1">
           <button
-            v-for="entry in items"
+            v-for="entry in overflowItems"
             :key="entry.key"
             type="button"
             class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-default hover:bg-elevated hover:text-highlighted"
@@ -55,6 +68,7 @@ import { goto_history_item, makeEventName } from '~/utils';
 type LinkItem = {
   key: string;
   label: string;
+  shortLabel?: string;
   icon: string;
   action: () => Promise<void>;
 };
@@ -62,6 +76,7 @@ type LinkItem = {
 const props = defineProps<{
   item: Pick<LogEntry, 'item_id' | 'event_id' | 'user' | 'backend'>;
   openEvent?: (id: string) => void;
+  compact?: boolean;
 }>();
 
 const dialog = useDialog();
@@ -105,13 +120,22 @@ const switchIdentity = async (identity: string): Promise<boolean> => {
 const items = computed<Array<LinkItem>>(() => {
   const list: Array<LinkItem> = [];
 
-  if (eventId.value && props.openEvent) {
+  if (eventId.value) {
     list.push({
       key: `event:${eventId.value}`,
       label: `Event #${makeEventName(eventId.value)}`,
+      shortLabel: `#${makeEventName(eventId.value)}`,
       icon: 'i-lucide-activity',
       action: async () => {
-        props.openEvent?.(eventId.value as string);
+        if (props.openEvent) {
+          props.openEvent(eventId.value as string);
+          return;
+        }
+
+        await navigateTo({
+          path: '/events',
+          query: { view: eventId.value },
+        });
       },
     });
   }
@@ -120,6 +144,7 @@ const items = computed<Array<LinkItem>>(() => {
     list.push({
       key: `item:${itemId.value}`,
       label: `History #${itemId.value}`,
+      shortLabel: `#${itemId.value}`,
       icon: 'i-lucide-history',
       action: async () => {
         await goto_history_item({ item_id: itemId.value, user: user.value });
@@ -131,6 +156,7 @@ const items = computed<Array<LinkItem>>(() => {
     list.push({
       key: `backend:${backend.value}`,
       label: `Backend ${backend.value}`,
+      shortLabel: backend.value,
       icon: 'i-lucide-server',
       action: async () => {
         const identity = user.value;
@@ -143,7 +169,33 @@ const items = computed<Array<LinkItem>>(() => {
     });
   }
 
+  if (user.value) {
+    list.push({
+      key: `identity:${user.value}`,
+      label: `Use identity ${user.value}`,
+      shortLabel: user.value,
+      icon: 'i-lucide-user-round',
+      action: async () => {
+        await switchIdentity(user.value as string);
+      },
+    });
+  }
+
   return list;
+});
+
+const compact = computed<boolean>(() => true === props.compact);
+
+const visibleItems = computed<Array<LinkItem>>(() => {
+  return items.value.slice(0, compact.value ? 0 : items.value.length);
+});
+
+const overflowItems = computed<Array<LinkItem>>(() => {
+  if (!compact.value) {
+    return [];
+  }
+
+  return items.value.slice(3);
 });
 
 const onSelect = async (entry: LinkItem, hide: () => void): Promise<void> => {

--- a/frontend/app/components/LogLineLinks.vue
+++ b/frontend/app/components/LogLineLinks.vue
@@ -169,18 +169,6 @@ const items = computed<Array<LinkItem>>(() => {
     });
   }
 
-  if (user.value) {
-    list.push({
-      key: `identity:${user.value}`,
-      label: `Use identity ${user.value}`,
-      shortLabel: user.value,
-      icon: 'i-lucide-user-round',
-      action: async () => {
-        await switchIdentity(user.value as string);
-      },
-    });
-  }
-
   return list;
 });
 

--- a/frontend/app/components/PlaybackSelection.vue
+++ b/frontend/app/components/PlaybackSelection.vue
@@ -239,7 +239,15 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import Player from '~/components/Player.vue';
 import { useDialog } from '~/composables/useDialog';
 import type { PlayerSubtitleDeliveryMode, PlayerSubtitleTrack } from '~/types';
-import { basename, encodePath, notification, parse_api_response, request, ucFirst } from '~/utils';
+import {
+  api_error_message,
+  basename,
+  encodePath,
+  notification,
+  parse_api_response,
+  request,
+  ucFirst,
+} from '~/utils';
 
 type SelectItem = {
   label: string;
@@ -785,7 +793,7 @@ const loadContent = async (): Promise<void> => {
     }
 
     if ('error' in json) {
-      notification('error', 'Error', 'Failed to load item.');
+      notification('error', 'Error', `Failed to load item. ${api_error_message(json, response)}`);
       return;
     }
 
@@ -806,7 +814,7 @@ const loadContent = async (): Promise<void> => {
     updateHwAccel(video_codec.value);
   } catch (error: unknown) {
     console.error(error);
-    notification('error', 'Error', 'Failed to load item.');
+    notification('error', 'Error', `Failed to load item. ${String(error)}`);
   } finally {
     if (currentId === historyId.value && currentSession === sessionVersion.value) {
       isLoading.value = false;
@@ -839,7 +847,11 @@ const generateToken = async (): Promise<void> => {
     }
 
     if ('error' in json) {
-      notification('error', 'Token generation', 'Failed to generate token.');
+      notification(
+        'error',
+        'Token generation',
+        `Failed to generate token. ${api_error_message(json, response)}`,
+      );
       return;
     }
 
@@ -847,7 +859,7 @@ const generateToken = async (): Promise<void> => {
     playbackDirect.value = effectiveDirectPlay.value;
   } catch (error: unknown) {
     console.error(error);
-    notification('error', 'Error', 'Failed to generate token.');
+    notification('error', 'Error', `Failed to generate token. ${String(error)}`);
   } finally {
     if (currentId === historyId.value && currentSession === sessionVersion.value) {
       isGenerating.value = false;

--- a/frontend/app/components/Popover.vue
+++ b/frontend/app/components/Popover.vue
@@ -109,10 +109,12 @@ const popoverContent = computed(() => ({
 }));
 
 const popoverUi = computed(() => ({
-  content: props.popoverClass,
+  content: [`z-[${props.zIndex}]`, props.popoverClass].filter(Boolean).join(' '),
 }));
 
 const contentClass = computed(() => props.contentClass);
+
+const activeTrigger = resolvedTrigger;
 
 const show = () => {
   if (props.disabled) {
@@ -135,7 +137,4 @@ const toggle = () => {
 };
 
 watch(isOpen, (value) => emit(value ? 'show' : 'hide'));
-
-const activeTrigger = resolvedTrigger;
-const { showDelay, hideDelay, showArrow, disabled } = props;
 </script>

--- a/frontend/app/components/TaskScheduler.vue
+++ b/frontend/app/components/TaskScheduler.vue
@@ -43,10 +43,12 @@
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, ref } from 'vue';
 import { useDialog } from '~/composables/useDialog';
-import { notification, request } from '~/utils';
+import { api_error_message, notification, parse_api_response, request } from '~/utils';
+
+type SchedulerStatus = { status: boolean; message: string; restartable: boolean };
 
 const emit = defineEmits<{
-  (e: 'update', status: { status: boolean; message: string; restartable: boolean }): void;
+  (e: 'update', status: SchedulerStatus): void;
 }>();
 
 const props = withDefaults(
@@ -62,7 +64,7 @@ const props = withDefaults(
 let timer: ReturnType<typeof setTimeout> | null = null;
 const isLoading = ref<boolean>(false);
 const isRestarting = ref<boolean>(false);
-const status = ref<{ status: boolean; message: string; restartable: boolean }>({
+const status = ref<SchedulerStatus>({
   status: true,
   message: 'Loading...',
   restartable: false,
@@ -81,12 +83,22 @@ const loadContent = async (): Promise<void> => {
 
     isLoading.value = true;
     const response = await request('/system/scheduler');
-    const json = await response.json();
+
+    const json = await parse_api_response<SchedulerStatus>(response);
+    if ('error' in json) {
+      const message = api_error_message(json, response, 'Failed to load task scheduler status.');
+      status.value = { status: false, message, restartable: false };
+      emit('update', status.value);
+      notification('error', 'Error', message);
+      return;
+    }
+
     status.value = json;
     emit('update', json);
     timer = setTimeout(loadContent, 60000);
   } catch (e) {
     console.error(e);
+    notification('error', 'Error', `Failed to load task scheduler status. ${String(e)}`);
   } finally {
     isLoading.value = false;
   }
@@ -110,13 +122,18 @@ const restart = async (): Promise<void> => {
   try {
     isRestarting.value = true;
     const response = await request('/system/scheduler/restart', { method: 'POST' });
-    const json = await response.json();
+    const json = await parse_api_response<SchedulerStatus>(response);
 
-    notification(
-      200 === response.status ? 'success' : 'error',
-      '',
-      json.message ?? json.error?.message ?? '??',
-    );
+    if ('error' in json) {
+      notification(
+        'error',
+        'Error',
+        api_error_message(json, response, 'Failed to restart scheduler.'),
+      );
+      return;
+    }
+
+    notification(200 === response.status ? 'success' : 'error', '', json.message ?? '??');
 
     if (200 !== response.status) {
       return;
@@ -126,6 +143,7 @@ const restart = async (): Promise<void> => {
     emit('update', json);
   } catch (e) {
     console.error(e);
+    notification('error', 'Error', `Failed to restart scheduler. ${String(e)}`);
   } finally {
     isRestarting.value = false;
   }

--- a/frontend/app/composables/useBackendSetup.ts
+++ b/frontend/app/composables/useBackendSetup.ts
@@ -1,5 +1,5 @@
 import { computed, nextTick, onBeforeUnmount, ref, watch, type Ref } from 'vue';
-import { notification, parse_api_response, request, ucFirst } from '~/utils';
+import { api_error_message, notification, parse_api_response, request, ucFirst } from '~/utils';
 import type {
   Backend,
   BackendEditUser,
@@ -158,7 +158,7 @@ export const useBackendSetup = (backend: Ref<Backend>, setupOptions?: UseBackend
       const json = await parse_api_response<BackendUuidResponse>(response);
 
       if (!response.ok) {
-        notifyError('Failed to get the UUID from the backend.');
+        notifyError(api_error_message(json, response, 'Failed to get the UUID from the backend.'));
         return;
       }
 
@@ -239,11 +239,7 @@ export const useBackendSetup = (backend: Ref<Backend>, setupOptions?: UseBackend
       const json = await parse_api_response<Array<BackendEditUser>>(response);
 
       if (!response.ok) {
-        if ('error' in json) {
-          notifyError(`${json.error.code}: ${json.error.message}`);
-        } else {
-          notifyError('Failed to load users');
-        }
+        notifyError(api_error_message(json, response, 'Failed to load users'));
         return;
       }
 
@@ -327,11 +323,7 @@ export const useBackendSetup = (backend: Ref<Backend>, setupOptions?: UseBackend
       const json = await parse_api_response<Array<BackendServer>>(response);
 
       if (!response.ok) {
-        if ('error' in json) {
-          notifyError(`${json.error.code}: ${json.error.message}`);
-        } else {
-          notifyError('Failed to load servers');
-        }
+        notifyError(api_error_message(json, response, 'Failed to load servers'));
         return;
       }
 
@@ -368,11 +360,7 @@ export const useBackendSetup = (backend: Ref<Backend>, setupOptions?: UseBackend
       const json = await parse_api_response<PlexOAuthData>(response);
 
       if (!response.ok) {
-        if ('error' in json) {
-          notifyError(`${json.error.code}: ${json.error.message}`);
-        } else {
-          notifyError('Failed to generate Plex auth request');
-        }
+        notifyError(api_error_message(json, response, 'Failed to generate Plex auth request'));
         return;
       }
 
@@ -438,11 +426,7 @@ export const useBackendSetup = (backend: Ref<Backend>, setupOptions?: UseBackend
       const json = await parse_api_response<PlexOAuthTokenResponse>(response);
 
       if (!response.ok) {
-        if ('error' in json) {
-          notifyError(`${json.error.code}: ${json.error.message}`);
-        } else {
-          notifyError('Failed to check auth status');
-        }
+        notifyError(api_error_message(json, response, 'Failed to check auth status'));
         return;
       }
 

--- a/frontend/app/pages/backup.vue
+++ b/frontend/app/pages/backup.vue
@@ -400,6 +400,9 @@ const downloadFile = async (item: BackItemWithUI): Promise<void> => {
     URL.revokeObjectURL(fileURL);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unexpected error';
+    if (message.includes('aborted')) {
+      return;
+    }
     notification('error', 'Error', `Failed to download backup. ${message}`);
   } finally {
     item.isDownloading = false;

--- a/frontend/app/pages/backup.vue
+++ b/frontend/app/pages/backup.vue
@@ -254,6 +254,7 @@ import {
   humanFileSize,
   makeConsoleCommand,
   notification,
+  parse_api_error_message,
   parse_api_response,
   request,
   TOOLTIP_DATE_FORMAT,
@@ -377,6 +378,15 @@ const downloadFile = async (item: BackItemWithUI): Promise<void> => {
   try {
     const response = await request(`/system/backup/${item.filename}`);
 
+    if (!response.ok) {
+      notification(
+        'error',
+        'Error',
+        await parse_api_error_message(response, 'Failed to download backup.'),
+      );
+      return;
+    }
+
     if (pickerWindow.showSaveFilePicker) {
       if (!response.body) {
         notification('error', 'Error', 'No data returned from backup download request.');
@@ -436,7 +446,14 @@ const queueTask = async (): Promise<void> => {
         `Task backup has been ${is_queued ? 'removed from the queue' : 'queued'}.`,
       );
       queued.value = !is_queued;
+      return;
     }
+
+    notification(
+      'error',
+      'Error',
+      await parse_api_error_message(response, 'Failed to update backup task queue.'),
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unexpected error';
     notification('error', 'Error', `Request error. ${message}`);

--- a/frontend/app/pages/events.vue
+++ b/frontend/app/pages/events.vue
@@ -483,6 +483,7 @@ import { requireTopLevelPageShell } from '~/utils/topLevelNavigation';
 import {
   TOOLTIP_DATE_FORMAT,
   awaitElement,
+  api_error_message,
   makeEventName,
   notification,
   parse_api_response,
@@ -984,7 +985,11 @@ const resetEvent = async (item: EventsItem, status: number = 0): Promise<void> =
     }
 
     if (200 !== response.status) {
-      notification('error', 'Error', 'Events view patch Request error.');
+      notification(
+        'error',
+        'Error',
+        `Events view patch Request error. ${api_error_message(json, response)}`,
+      );
       return;
     }
 

--- a/frontend/app/pages/events.vue
+++ b/frontend/app/pages/events.vue
@@ -581,7 +581,7 @@ const showSearchPanel = ref<boolean>(
   }),
 );
 const search = ref<SearchState>(createSearchState(route.query));
-const quick_view = ref<string | null>(null);
+const quick_view = ref<string | null>(getRouteQueryValue(route.query.view, '') || null);
 const show_page_tips = useStorage<boolean>('show_page_tips', true);
 const deleteModalOpen = ref<boolean>(false);
 const deleteIncludePending = ref<boolean>(false);
@@ -778,6 +778,10 @@ const buildRouteQuery = (
     page: pageNumber,
   };
 
+  if (quick_view.value) {
+    historyQuery.view = quick_view.value;
+  }
+
   if (displayFilter.value) {
     historyQuery.filter = displayFilter.value;
   }
@@ -879,6 +883,7 @@ const handlePopState = async (): Promise<void> => {
   displayFilter.value = getRouteQueryValue(route.query.filter, '');
   showDisplayFilter.value = !!displayFilter.value;
   search.value = createSearchState(route.query);
+  quick_view.value = getRouteQueryValue(route.query.view, '') || null;
   showSearchPanel.value = ['status', 'event', 'reference', 'before', 'after'].some((key) => {
     const value = route.query[key];
     return Array.isArray(value) ? !!value[0] : !!value;
@@ -1073,6 +1078,35 @@ const confirmDeleteAll = async (): Promise<void> => {
 const toggleDisplayFilter = (): void => {
   showDisplayFilter.value = !showDisplayFilter.value;
 };
+
+watch(quick_view, (value: string | null) => {
+  const currentView = getRouteQueryValue(route.query.view, '') || null;
+
+  if (currentView === value) {
+    return;
+  }
+
+  void router.push({
+    path: '/events',
+    query: {
+      ...route.query,
+      view: value ?? undefined,
+    },
+  });
+});
+
+watch(
+  () => route.query.view,
+  (value) => {
+    const nextValue = getRouteQueryValue(value, '') || null;
+
+    if (nextValue === quick_view.value) {
+      return;
+    }
+
+    quick_view.value = nextValue;
+  },
+);
 
 watch(displayFilter, (value: string) => {
   if (!value) {

--- a/frontend/app/pages/identities/index.vue
+++ b/frontend/app/pages/identities/index.vue
@@ -407,7 +407,7 @@ const addIdentity = async (): Promise<void> => {
     });
     const result = await parse_api_response<GenericResponse>(response);
 
-    if ('error' in result) {
+    if (!response.ok && 'error' in result) {
       formError.value = result.error?.message || 'Failed to create identity';
       return;
     }

--- a/frontend/app/pages/identities/provision.vue
+++ b/frontend/app/pages/identities/provision.vue
@@ -488,7 +488,7 @@ import { NuxtLink } from '#components';
 import moment from 'moment';
 import draggable from 'vuedraggable';
 import { requireTopLevelPageShell } from '~/utils/topLevelNavigation';
-import { notification, parse_api_response, request } from '~/utils';
+import { notification, parse_api_error_message, parse_api_response, request } from '~/utils';
 import { useDialog } from '~/composables/useDialog';
 import type { GenericResponse } from '~/types';
 
@@ -624,20 +624,29 @@ const generateFile = async (): Promise<void> => {
     return;
   }
 
-  const response = request(`/system/yaml/${filename}`, {
-    method: 'POST',
-    headers: { Accept: 'text/yaml' },
-    body: JSON.stringify(data),
-  });
+  try {
+    const response = await request(`/system/yaml/${filename}`, {
+      method: 'POST',
+      headers: { Accept: 'text/yaml' },
+      body: JSON.stringify(data),
+    });
 
-  const pickerWindow = window as Window & {
-    showSaveFilePicker?: (options: FilePickerOptions) => Promise<FilePickerHandle>;
-  };
-  const showSaveFilePicker = pickerWindow.showSaveFilePicker;
+    if (!response.ok) {
+      notification(
+        'error',
+        'Error',
+        await parse_api_error_message(response, 'Failed to export mapper.'),
+      );
+      return;
+    }
 
-  if (showSaveFilePicker) {
-    response.then(async (res) => {
-      if (!res.body) {
+    const pickerWindow = window as Window & {
+      showSaveFilePicker?: (options: FilePickerOptions) => Promise<FilePickerHandle>;
+    };
+    const showSaveFilePicker = pickerWindow.showSaveFilePicker;
+
+    if (showSaveFilePicker) {
+      if (!response.body) {
         notification('error', 'Error', 'No data returned from export request.');
         return;
       }
@@ -645,19 +654,25 @@ const generateFile = async (): Promise<void> => {
       const handle = await showSaveFilePicker({
         suggestedName: `${filename}`,
       });
-      await res.body.pipeTo(await handle.createWritable());
-    });
-  }
+      await response.body.pipeTo(await handle.createWritable());
+      return;
+    }
 
-  response
-    .then((res) => res.blob())
-    .then((blob) => {
-      const fileURL = URL.createObjectURL(blob);
-      const fileLink = document.createElement('a');
-      fileLink.href = fileURL;
-      fileLink.download = `${filename}`;
-      fileLink.click();
-    });
+    const blob = await response.blob();
+    const fileURL = URL.createObjectURL(blob);
+    const fileLink = document.createElement('a');
+    fileLink.href = fileURL;
+    fileLink.download = `${filename}`;
+    fileLink.click();
+    URL.revokeObjectURL(fileURL);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unexpected error';
+    if (message.includes('aborted')) {
+      return;
+    }
+
+    notification('error', 'Error', `Failed to export mapper. ${message}`);
+  }
 };
 
 interface DragEvent {
@@ -832,14 +847,33 @@ const provisionIdentities = async (): Promise<void> => {
       }),
     });
 
-    const response = await parse_api_response<GenericResponse>(req);
+    const response = await parse_api_response<
+      GenericResponse & {
+        warning_count?: number;
+        warnings?: Array<{ identity?: string; backend?: string; message?: string }>;
+      }
+    >(req);
 
     if ('error' in response) {
       notification('error', 'Error', `${req.status}: ${response.error.message}`);
       return;
     }
 
-    notification('success', 'Success', response.info.message);
+    const warningCount = Number(response.warning_count ?? 0);
+    if (0 < warningCount) {
+      const warning = response.warnings?.[0];
+      const firstWarning = warning
+        ? ` First warning: ${warning.identity ?? 'unknown'}@${warning.backend ?? 'unknown'}: ${warning.message ?? 'No details.'}`
+        : '';
+      notification(
+        'warning',
+        'Warning',
+        `${response.info.message} Completed with ${warningCount} warning(s).${firstWarning}`,
+        10000,
+      );
+    } else {
+      notification('success', 'Success', response.info.message);
+    }
 
     if (false === dryRun.value) {
       await navigateTo('/identities');

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -251,8 +251,6 @@
                   </UTooltip>
                 </div>
               </div>
-
-              <p class="text-sm text-toned">Recent log stream from {{ log.filename }}</p>
             </div>
           </template>
 

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -257,33 +257,72 @@
           </template>
 
           <div class="space-y-3">
-            <div class="overflow-hidden border border-default bg-default/60">
-              <code
-                class="ws-terminal ws-terminal-panel ws-terminal-panel-dashboard"
-                :class="wrapLines ? 'ws-wrap-anywhere whitespace-pre-wrap' : 'whitespace-pre'"
-              >
-                <span
-                  v-for="(item, index) in log.lines"
-                  :key="`${log.filename}-${index}`"
-                  class="block"
-                  ><span
-                    v-if="item?.date || hasLinks(item)"
-                    class="mr-[1ch] inline-flex items-baseline whitespace-normal"
+            <div
+              class="overflow-auto border border-default bg-elevated/30 shadow-sm"
+              :style="miniLogStyle"
+              data-dashboard-log-scroll="1"
+            >
+              <template v-if="log.entries.length > 0">
+                <article
+                  v-for="(item, index) in log.entries"
+                  :key="`${log.filename}-${index}-${item.id}`"
+                  :class="structuredRowClass(index)"
+                >
+                  <div
+                    :class="[
+                      'flex min-w-0 flex-1 items-start gap-[0.65rem] px-3 py-[0.65rem] leading-[1.6]',
+                      wrapLines ? 'w-full' : 'w-max min-w-full',
+                    ]"
                   >
-                    <template v-if="item?.date"
-                      >[<UTooltip :text="`${moment(item.date).format(TOOLTIP_DATE_FORMAT)}`">
-                        <span class="cursor-help">{{
-                          moment(item.date).format('HH:mm:ss')
-                        }}</span> </UTooltip
-                      >]</template
-                    >
-                    <span v-if="hasLinks(item)" :class="item?.date ? 'ml-[1ch]' : ''">
-                      <LogLineLinks :item="item" :open-event="openEvent" />
-                    </span>
-                  </span>
-                  <span>{{ String(item.text).trim() }}</span>
-                </span>
-              </code>
+                    <p :class="structuredLineClass">
+                      <span
+                        class="inline-flex max-w-full flex-wrap items-center gap-x-2 gap-y-1 align-middle"
+                      >
+                        <UTooltip :text="lineTitle(item)">
+                          <span class="inline cursor-pointer text-[11px] font-semibold text-toned">
+                            {{ timestampLabel(item) }}
+                          </span>
+                        </UTooltip>
+
+                        <LogDetailsChip
+                          :item="item"
+                          :open-details="openLogDetails"
+                          :open-event="openEvent"
+                        />
+
+                        <span
+                          :class="logLevelBadgeClass(getLogLevel(item.level))"
+                          @click="openLogDetails(item)"
+                        >
+                          <UIcon :name="LOG_LEVEL_ICON[getLogLevel(item.level)]" class="size-3" />
+                          {{ getLogLevel(item.level) }}
+                        </span>
+
+                        <span
+                          v-if="item.logger"
+                          :title="item.logger"
+                          class="inline-block max-w-[46vw] truncate align-middle text-[11px] font-semibold text-toned sm:max-w-104"
+                        >
+                          [{{ item.logger }}]
+                        </span>
+                      </span>
+
+                      <span class="ml-2">{{ logMessage(item) }}</span>
+
+                      <span v-if="item.exception_message" class="ml-1 text-error/90">
+                        : {{ item.exception_message }}
+                      </span>
+                    </p>
+                  </div>
+                </article>
+              </template>
+
+              <div
+                v-else
+                class="flex min-h-28 items-center justify-center px-6 py-8 text-sm text-toned"
+              >
+                No log lines available.
+              </div>
             </div>
           </div>
         </UCard>
@@ -295,6 +334,8 @@
         <EventView v-if="selectedEventId" :id="selectedEventId" />
       </template>
     </UModal>
+
+    <LogDetailsModal :log="selectedLog" v-model:open="detailsOpen" />
   </div>
 </template>
 
@@ -306,7 +347,8 @@ import { NuxtLink } from '#components';
 import moment from 'moment';
 import EventView from '~/components/EventView.vue';
 import FloatingImage from '~/components/FloatingImage.vue';
-import LogLineLinks from '~/components/LogLineLinks.vue';
+import LogDetailsChip from '~/components/LogDetailsChip.vue';
+import LogDetailsModal from '~/components/LogDetailsModal.vue';
 import Popover from '~/components/Popover.vue';
 import DuplicateRecordList from '~/components/DuplicateRecordList.vue';
 import {
@@ -318,15 +360,17 @@ import {
   ucFirst,
   TOOLTIP_DATE_FORMAT,
 } from '~/utils';
-import type { HistoryItem, JsonObject, LogEntry } from '~/types';
+import {
+  getLogLevel,
+  logMessageText,
+  logTimestampLabel,
+  logTimestampTitle,
+  parseLogLines,
+} from '~/utils/logs';
+import type { HistoryItem, JsonObject, LogEntry, RecentLogFile } from '~/types';
 
-type IndexLogFile = {
-  type: string;
-  filename: string;
-  date: number;
-  size: number;
-  modified: string;
-  lines: Array<LogEntry>;
+type IndexLogFile = RecentLogFile & {
+  entries: Array<LogEntry>;
 };
 
 useHead({ title: 'Index' });
@@ -343,8 +387,18 @@ const reloadingLogs = ref<boolean>(false);
 const historyLoading = ref<boolean>(true);
 const logReloadInterval = ref<ReturnType<typeof setInterval> | null>(null);
 const selectedEventId = ref<string | null>(null);
+const selectedLog = ref<LogEntry | null>(null);
 const logReloadFrequency = 10000;
 let historyLoadToken = 0;
+
+type LogLevel = 'debug' | 'info' | 'warning' | 'error';
+
+const LOG_LEVEL_ICON: Record<LogLevel, string> = {
+  debug: 'i-lucide-terminal',
+  info: 'i-lucide-info',
+  warning: 'i-lucide-triangle-alert',
+  error: 'i-lucide-circle-x',
+};
 
 const eventViewModalUi = {
   content: 'max-w-5xl',
@@ -364,13 +418,59 @@ const eventViewTitle = computed(() =>
   null === selectedEventId.value ? 'Event' : `#${makeEventName(selectedEventId.value)}`,
 );
 
-const hasLinks = (item: LogEntry): boolean => {
-  return Boolean(item.item_id || item.event_id || item.backend);
-};
+const detailsOpen = computed({
+  get: () => null !== selectedLog.value,
+  set: (value: boolean) => {
+    if (false === value) {
+      selectedLog.value = null;
+    }
+  },
+});
 
 const openEvent = (id: string): void => {
   selectedEventId.value = id;
 };
+
+const openLogDetails = (item: LogEntry): void => {
+  selectedLog.value = item;
+};
+
+const lineTitle = (item: LogEntry): string => logTimestampTitle(item.datetime ?? item.date);
+
+const timestampLabel = (item: LogEntry): string => logTimestampLabel(item.datetime ?? item.date);
+
+const logMessage = (item: LogEntry): string => logMessageText(item);
+
+const structuredLineClass = computed<Array<string>>(() => [
+  'flex-1',
+  wrapLines.value ? 'min-w-0 whitespace-pre-wrap wrap-break-word' : 'min-w-max whitespace-pre',
+  'text-default',
+]);
+
+const miniLogStyle = {
+  minHeight: '12rem',
+  maxHeight: '26rem',
+} as const;
+
+const structuredRowClass = (index: number): Array<string> => {
+  const classes = [
+    'flex min-w-0 border-b border-default/40 bg-transparent transition-colors duration-150 last:border-b-0 hover:bg-elevated/70',
+  ];
+
+  if (index % 2 === 1) {
+    classes.push('bg-elevated/40');
+  }
+
+  return classes;
+};
+
+const logLevelBadgeClass = (level: LogLevel): Array<string> => [
+  'inline-flex cursor-pointer items-center gap-1.5 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide',
+  'debug' === level ? 'bg-muted/40 text-muted' : '',
+  'info' === level ? 'bg-info/10 text-info' : '',
+  'warning' === level ? 'bg-warning/10 text-warning' : '',
+  'error' === level ? 'bg-error/10 text-error' : '',
+];
 
 const duplicatePopoverTrigger = computed<'click' | 'hover'>(() =>
   'mobile' === breakpoints.active().value ? 'click' : 'hover',
@@ -492,12 +592,15 @@ const reloadLogs = async (): Promise<void> => {
       return;
     }
 
-    const logsResponse = await parse_api_response<Array<IndexLogFile>>(response);
+    const logsResponse = await parse_api_response<Array<RecentLogFile>>(response);
     if ('error' in logsResponse || 'index' !== route.name) {
       return;
     }
 
-    logs.value = logsResponse;
+    logs.value = logsResponse.map((item) => ({
+      ...item,
+      entries: parseLogLines(item.lines),
+    }));
   } catch {
   } finally {
     reloadingLogs.value = false;
@@ -541,7 +644,7 @@ onMounted(async () => {
 });
 
 onUpdated(() => {
-  document.querySelectorAll('.ws-terminal-panel-dashboard').forEach((element) => {
+  document.querySelectorAll('[data-dashboard-log-scroll="1"]').forEach((element) => {
     element.scrollTop = element.scrollHeight;
   });
 });

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -362,6 +362,8 @@ import {
 } from '~/utils';
 import {
   getLogLevel,
+  LOG_LEVEL_ICON,
+  logLevelBadgeClass,
   logMessageText,
   logTimestampLabel,
   logTimestampTitle,
@@ -390,15 +392,6 @@ const selectedEventId = ref<string | null>(null);
 const selectedLog = ref<LogEntry | null>(null);
 const logReloadFrequency = 10000;
 let historyLoadToken = 0;
-
-type LogLevel = 'debug' | 'info' | 'warning' | 'error';
-
-const LOG_LEVEL_ICON: Record<LogLevel, string> = {
-  debug: 'i-lucide-terminal',
-  info: 'i-lucide-info',
-  warning: 'i-lucide-triangle-alert',
-  error: 'i-lucide-circle-x',
-};
 
 const eventViewModalUi = {
   content: 'max-w-5xl',
@@ -463,14 +456,6 @@ const structuredRowClass = (index: number): Array<string> => {
 
   return classes;
 };
-
-const logLevelBadgeClass = (level: LogLevel): Array<string> => [
-  'inline-flex cursor-pointer items-center gap-1.5 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide',
-  'debug' === level ? 'bg-muted/40 text-muted' : '',
-  'info' === level ? 'bg-info/10 text-info' : '',
-  'warning' === level ? 'bg-warning/10 text-warning' : '',
-  'error' === level ? 'bg-error/10 text-error' : '',
-];
 
 const duplicatePopoverTrigger = computed<'click' | 'hover'>(() =>
   'mobile' === breakpoints.active().value ? 'click' : 'hover',

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -236,6 +236,19 @@
                     </UButton>
                   </UTooltip>
 
+                  <UTooltip text="Copy transformed log text.">
+                    <UButton
+                      color="neutral"
+                      variant="outline"
+                      size="sm"
+                      icon="i-lucide-copy"
+                      aria-label="Copy transformed log text"
+                      @click="copyLogEntries(log.entries)"
+                    >
+                      <span class="hidden sm:inline">Copy</span>
+                    </UButton>
+                  </UTooltip>
+
                   <UTooltip text="Fetch latest log entries.">
                     <UButton
                       color="neutral"
@@ -355,12 +368,14 @@ import {
   makeName,
   parse_api_response,
   request,
+  copyText,
   ucFirst,
   TOOLTIP_DATE_FORMAT,
 } from '~/utils';
 import {
   getLogLevel,
   LOG_LEVEL_ICON,
+  logClipboardText,
   logLevelBadgeClass,
   logMessageText,
   logTimestampLabel,
@@ -431,6 +446,10 @@ const lineTitle = (item: LogEntry): string => logTimestampTitle(item.datetime ??
 const timestampLabel = (item: LogEntry): string => logTimestampLabel(item.datetime ?? item.date);
 
 const logMessage = (item: LogEntry): string => logMessageText(item);
+
+const copyLogEntries = (entries: Array<LogEntry>): void => {
+  copyText(logClipboardText(entries));
+};
 
 const structuredLineClass = computed<Array<string>>(() => [
   'flex-1',

--- a/frontend/app/pages/logs/[filename].vue
+++ b/frontend/app/pages/logs/[filename].vue
@@ -34,7 +34,7 @@
           id="filter"
           v-model="query"
           type="search"
-          placeholder="Filter"
+          :placeholder="'log' === contentType ? 'Filter log entries' : 'Filter'"
           icon="i-lucide-filter"
           size="sm"
           class="w-full sm:w-72"
@@ -51,6 +51,23 @@
             <span class="hidden sm:inline">Filter</span>
           </UButton>
         </UTooltip>
+
+        <USelect
+          v-if="'log' === contentType"
+          v-model="selectedLevels"
+          :items="levelFilterItems"
+          value-key="value"
+          label-key="label"
+          multiple
+          size="sm"
+          icon="i-lucide-list-filter"
+          class="w-44 shrink-0 sm:w-48"
+          :ui="{ content: 'min-w-48' }"
+        >
+          <template #default>
+            {{ levelFilterLabel }}
+          </template>
+        </USelect>
 
         <UTooltip text="Delete logfile.">
           <UButton
@@ -128,42 +145,21 @@
     />
 
     <template v-else-if="!error">
-      <UAlert
-        v-if="'log' === contentType && reachedEnd && !query"
-        color="info"
-        variant="soft"
-        icon="i-lucide-triangle-alert"
-        title="End of file"
-        description="No more logs available for this file."
-      />
-
-      <UAlert
-        v-if="'log' === contentType && 0 === filterItems.length"
-        :color="query ? 'warning' : 'info'"
-        variant="soft"
-        :icon="query ? 'i-lucide-filter' : 'i-lucide-triangle-alert'"
-        :title="query ? 'No matching logs' : 'No logs available'"
-      >
-        <template #description>
-          <p class="text-sm text-default">
-            <template v-if="query"
-              >No logs match this query: <u>{{ query }}</u></template
-            >
-            <template v-else>No logs available.</template>
-          </p>
-        </template>
-      </UAlert>
-
-      <UCard
-        v-if="'json' === contentType || 0 < filterItems.length"
-        class="overflow-hidden border border-default/70 shadow-sm"
-        :ui="viewerCardUi"
-      >
-        <div v-if="'json' === contentType" ref="logContainer" class="logbox">
+      <UCard class="overflow-hidden border border-default/70 shadow-sm" :ui="viewerCardUi">
+        <div
+          v-if="'json' === contentType"
+          ref="logContainer"
+          class="logbox overflow-auto"
+          :style="logContainerStyle"
+        >
           <code
             id="logView"
             class="logline block"
-            :class="wrapLines ? 'whitespace-pre-wrap ws-wrap-anywhere' : 'whitespace-pre'"
+            :class="
+              wrapLines
+                ? 'min-w-0 whitespace-pre-wrap ws-wrap-anywhere'
+                : 'w-max min-w-full whitespace-pre'
+            "
           >
             {{ renderJson(rawLines) }}
           </code>
@@ -176,6 +172,34 @@
           @scroll.passive="handleScroll"
           :style="logContainerStyle"
         >
+          <div
+            v-if="reachedEnd && !hasActiveStructuredFilter"
+            class="flex justify-center border-b border-default/40 px-4 py-3"
+          >
+            <div
+              class="inline-flex items-center gap-1.5 rounded-full border border-warning/30 bg-warning/10 px-3 py-1 text-[11px] font-medium text-warning"
+            >
+              <UIcon name="i-lucide-triangle-alert" class="size-3.5 shrink-0" />
+              No older lines remain in this file.
+            </div>
+          </div>
+
+          <div
+            v-if="canLoadFilteredHistory"
+            class="flex justify-center border-b border-default/40 px-4 py-3"
+          >
+            <UButton
+              color="neutral"
+              variant="outline"
+              size="xs"
+              icon="i-lucide-history"
+              :loading="isLoading"
+              @click="loadContent(true)"
+            >
+              Load older lines into filter
+            </UButton>
+          </div>
+
           <template v-if="structuredRows.length > 0">
             <article
               v-for="(entry, index) in structuredRows"
@@ -236,21 +260,17 @@
             class="flex min-h-[55vh] flex-col items-center justify-center gap-3 px-6 py-8 text-center"
           >
             <UIcon
-              :name="query ? 'i-lucide-filter-x' : 'i-lucide-circle-off'"
+              :name="hasActiveStructuredFilter ? 'i-lucide-filter-x' : 'i-lucide-circle-off'"
               class="size-6 text-toned"
             />
 
             <div class="space-y-1">
               <p class="text-sm font-medium text-default">
-                {{ query ? 'No logs match this query' : 'No log lines available' }}
+                {{ emptyTitle }}
               </p>
 
               <p class="text-sm text-toned">
-                {{
-                  query
-                    ? 'Adjust the filter or load more lines.'
-                    : 'This file has no visible log lines yet.'
-                }}
+                {{ emptyDescription }}
               </p>
             </div>
           </div>
@@ -276,7 +296,6 @@ code {
 .logbox {
   background-color: #1f2229;
   min-width: 100%;
-  max-height: 73vh;
 }
 
 div.logbox pre {
@@ -303,6 +322,8 @@ import type { GenericResponse, LogEntry, LogResponse } from '~/types';
 import { copyText, makeEventName, notification, parse_api_response, request } from '~/utils';
 import {
   getLogLevel,
+  LOG_LEVEL_ICON,
+  logLevelBadgeClass,
   logMessageText,
   logSearchText,
   logTimestampLabel,
@@ -327,6 +348,13 @@ const data = ref<Array<LogEntry>>([]);
 const rawLines = ref<Array<string>>([]);
 const error = ref<string>('');
 const wrapLines = useStorage('logs_wrap_lines', false);
+const selectedLevels = useStorage<Array<LogLevel>>('logs_level_filter', [
+  'debug',
+  'info',
+  'notice',
+  'warning',
+  'error',
+]);
 const isDownloading = ref<boolean>(false);
 const isLoading = ref<boolean>(false);
 const toggleFilter = ref<boolean>(false);
@@ -341,20 +369,23 @@ const selectedEventId = ref<string | null>(null);
 const selectedLog = ref<LogEntry | null>(null);
 const isTodayLog = computed<boolean>(() => filename.includes(moment().format('YYYYMMDD')));
 
-type LogLevel = 'debug' | 'info' | 'warning' | 'error';
+type LogLevel = 'debug' | 'info' | 'notice' | 'warning' | 'error';
 
 type StructuredLogRow = {
   key: string;
   log: LogEntry;
   level: LogLevel;
+  isMatch: boolean;
+  isContext: boolean;
 };
 
-const LOG_LEVEL_ICON: Record<LogLevel, string> = {
-  debug: 'i-lucide-terminal',
-  info: 'i-lucide-info',
-  warning: 'i-lucide-triangle-alert',
-  error: 'i-lucide-circle-x',
+type LevelFilterItem = {
+  label: string;
+  value: LogLevel;
 };
+
+const LOG_LEVELS: Array<LogLevel> = ['debug', 'info', 'notice', 'warning', 'error'];
+const FILTER_CONTEXT_REGEX = /context:(\d+)/;
 
 const eventViewModalUi = {
   content: 'max-w-5xl',
@@ -416,23 +447,153 @@ const scrollLogContainerToBottom = (behavior: ScrollBehavior = 'auto'): void => 
 watch(toggleFilter, () => {
   if (!toggleFilter.value) {
     query.value = '';
+    scrollToBottom();
   }
 });
 
-const filterItems = computed<Array<LogEntry>>(() => {
-  if (!query.value) {
-    return data.value;
+const normalizedQuery = computed(() => query.value.trim().toLowerCase());
+const selectedLevelSet = computed(
+  () => new Set(LOG_LEVELS.filter((level) => selectedLevels.value.includes(level))),
+);
+const hasLevelFilter = computed(() => selectedLevelSet.value.size !== LOG_LEVELS.length);
+const filterContext = computed(() => {
+  const match = normalizedQuery.value.match(FILTER_CONTEXT_REGEX);
+  return match ? parseInt(match[1] ?? '0', 10) : 0;
+});
+const searchTerm = computed(() => normalizedQuery.value.replace(FILTER_CONTEXT_REGEX, '').trim());
+const hasTextFilter = computed(() => Boolean(searchTerm.value));
+const hasActiveStructuredFilter = computed(() => hasTextFilter.value || hasLevelFilter.value);
+const canLoadFilteredHistory = computed(
+  () =>
+    'log' === contentType.value &&
+    hasActiveStructuredFilter.value &&
+    !reachedEnd.value &&
+    data.value.length > 0,
+);
+const levelCounts = computed<Record<LogLevel, number>>(() => {
+  const counts: Record<LogLevel, number> = {
+    debug: 0,
+    info: 0,
+    notice: 0,
+    warning: 0,
+    error: 0,
+  };
+
+  data.value.forEach((item) => {
+    const level = getLogLevel(item.level);
+    counts[level] += 1;
+  });
+
+  return counts;
+});
+const levelFilterItems = computed<Array<LevelFilterItem>>(() =>
+  LOG_LEVELS.map((level) => ({
+    label: `${level.charAt(0).toUpperCase()}${level.slice(1)} (${levelCounts.value[level]})`,
+    value: level,
+  })),
+);
+const levelFilterLabel = computed(() => {
+  if (selectedLevelSet.value.size === LOG_LEVELS.length) {
+    return `All levels (${data.value.length})`;
   }
 
-  return data.value.filter((item) => logSearchText(item).includes(query.value.toLowerCase()));
+  if (selectedLevelSet.value.size === 0) {
+    return 'No levels selected';
+  }
+
+  return LOG_LEVELS.filter((level) => selectedLevelSet.value.has(level)).join(', ');
 });
 
 const structuredRows = computed<Array<StructuredLogRow>>(() => {
-  return filterItems.value.map((log, index) => ({
-    key: `${log.id}:${index}`,
-    log,
-    level: getLogLevel(log.level),
-  }));
+  if ('log' !== contentType.value) {
+    return [];
+  }
+
+  if (!hasActiveStructuredFilter.value) {
+    return data.value.map((log, index) => ({
+      key: `${log.id}:${index}`,
+      log,
+      level: getLogLevel(log.level),
+      isMatch: false,
+      isContext: false,
+    }));
+  }
+
+  const result: Array<StructuredLogRow> = [];
+  const visibleIndexes = new Set<number>();
+  const matchedIndexes = new Set<number>();
+
+  data.value.forEach((log, index) => {
+    if (!selectedLevelSet.value.has(getLogLevel(log.level))) {
+      return;
+    }
+
+    if (!hasTextFilter.value) {
+      visibleIndexes.add(index);
+      return;
+    }
+
+    if (logSearchText(log).includes(searchTerm.value)) {
+      matchedIndexes.add(index);
+
+      for (
+        let cursor = Math.max(0, index - filterContext.value);
+        cursor <= Math.min(data.value.length - 1, index + filterContext.value);
+        cursor++
+      ) {
+        visibleIndexes.add(cursor);
+      }
+    }
+  });
+
+  Array.from(visibleIndexes)
+    .sort((a, b) => a - b)
+    .forEach((index) => {
+      const log = data.value[index];
+      if (!log || !selectedLevelSet.value.has(getLogLevel(log.level))) {
+        return;
+      }
+
+      result.push({
+        key: `${log.id}:${index}`,
+        log,
+        level: getLogLevel(log.level),
+        isMatch: matchedIndexes.has(index),
+        isContext: !matchedIndexes.has(index),
+      });
+    });
+
+  return result;
+});
+
+const emptyTitle = computed(() => {
+  if ('json' === contentType.value) {
+    return 'No log lines available';
+  }
+
+  if (hasActiveStructuredFilter.value) {
+    return 'No logs match these filters';
+  }
+
+  if (!isLoading.value) {
+    return 'No log lines available';
+  }
+
+  return 'Loading logs...';
+});
+
+const emptyDescription = computed(() => {
+  if ('json' === contentType.value) {
+    return 'This file has no visible log lines yet.';
+  }
+
+  if (hasActiveStructuredFilter.value) {
+    return 'Adjust filters or load older lines into the current filter.';
+  }
+
+  return stream.value
+    ? 'Waiting for new stream output.'
+    : 'This file has no visible log lines yet.';
 });
 
 const openEvent = (id: string): void => {
@@ -443,7 +604,20 @@ const openLogDetails = (log: LogEntry): void => {
   selectedLog.value = log;
 };
 
-const loadContent = async (): Promise<void> => {
+const loadContent = async (force = false): Promise<void> => {
+  if (isLoading.value) {
+    return;
+  }
+
+  if (
+    'log' === contentType.value &&
+    hasActiveStructuredFilter.value &&
+    !force &&
+    data.value.length > 0
+  ) {
+    return;
+  }
+
   try {
     isLoading.value = true;
     const response = await request(`/log/${filename}?offset=${offset.value}`);
@@ -495,7 +669,11 @@ const loadContent = async (): Promise<void> => {
 };
 
 const handleScroll = (): void => {
-  if (!logContainer.value || query.value) {
+  if (!logContainer.value || 'json' === contentType.value) {
+    return;
+  }
+
+  if (hasActiveStructuredFilter.value) {
     return;
   }
 
@@ -687,6 +865,22 @@ const timestampLabel = (item: LogEntry): string => logTimestampLabel(item.dateti
 
 const logMessage = (item: LogEntry): string => logMessageText(item);
 
+const renderStructuredRowText = (entry: StructuredLogRow): string => {
+  const parts = [timestampLabel(entry.log), entry.level.toUpperCase()];
+
+  if (entry.log.logger) {
+    parts.push(`[${entry.log.logger}]`);
+  }
+
+  parts.push(logMessage(entry.log));
+
+  if (entry.log.exception_message) {
+    parts.push(`: ${entry.log.exception_message}`);
+  }
+
+  return parts.join(' ');
+};
+
 const structuredLineClass = computed<Array<string>>(() => [
   'flex-1',
   wrapLines.value ? 'min-w-0 whitespace-pre-wrap wrap-break-word' : 'min-w-max whitespace-pre',
@@ -698,20 +892,22 @@ const structuredRowClass = (_entry: StructuredLogRow, index: number): Array<stri
     'flex min-w-0 border-b border-default/40 bg-transparent transition-colors duration-150 last:border-b-0 hover:bg-elevated/70',
   ];
 
+  if (_entry.isMatch) {
+    classes.push('bg-warning/10');
+    return classes;
+  }
+
+  if (_entry.isContext) {
+    classes.push('bg-muted/30');
+    return classes;
+  }
+
   if (index % 2 === 1) {
     classes.push('bg-elevated/40');
   }
 
   return classes;
 };
-
-const logLevelBadgeClass = (level: LogLevel): Array<string> => [
-  'inline-flex cursor-pointer items-center gap-1.5 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide',
-  'debug' === level ? 'bg-muted/40 text-muted' : '',
-  'info' === level ? 'bg-info/10 text-info' : '',
-  'warning' === level ? 'bg-warning/10 text-warning' : '',
-  'error' === level ? 'bg-error/10 text-error' : '',
-];
 
 const renderJson = (lines: Array<string>): string => {
   try {
@@ -727,6 +923,6 @@ const copyData = (): void => {
     return;
   }
 
-  copyText(filterItems.value.map((item) => item.raw).join('\n'));
+  copyText(structuredRows.value.map((item) => renderStructuredRowText(item)).join('\n'));
 };
 </script>

--- a/frontend/app/pages/logs/[filename].vue
+++ b/frontend/app/pages/logs/[filename].vue
@@ -319,7 +319,14 @@ import LogDetailsModal from '~/components/LogDetailsModal.vue';
 import { useDialog } from '~/composables/useDialog';
 import { requireTopLevelPageShell } from '~/utils/topLevelNavigation';
 import type { GenericResponse, LogEntry, LogResponse } from '~/types';
-import { copyText, makeEventName, notification, parse_api_response, request } from '~/utils';
+import {
+  copyText,
+  makeEventName,
+  notification,
+  parse_api_error_message,
+  parse_api_response,
+  request,
+} from '~/utils';
 import {
   getLogLevel,
   LOG_LEVEL_ICON,
@@ -785,6 +792,16 @@ const downloadFile = async (): Promise<void> => {
 
   try {
     const response = await request(`/log/${filename}?download=1`);
+
+    if (!response.ok) {
+      notification(
+        'error',
+        'Error',
+        await parse_api_error_message(response, 'Failed to download log.'),
+      );
+      return;
+    }
+
     const pickerWindow = window as Window & {
       showSaveFilePicker?: (options: FilePickerOptions) => Promise<FilePickerHandle>;
     };

--- a/frontend/app/pages/logs/[filename].vue
+++ b/frontend/app/pages/logs/[filename].vue
@@ -323,6 +323,7 @@ import { copyText, makeEventName, notification, parse_api_response, request } fr
 import {
   getLogLevel,
   LOG_LEVEL_ICON,
+  logClipboardText,
   logLevelBadgeClass,
   logMessageText,
   logSearchText,
@@ -865,22 +866,6 @@ const timestampLabel = (item: LogEntry): string => logTimestampLabel(item.dateti
 
 const logMessage = (item: LogEntry): string => logMessageText(item);
 
-const renderStructuredRowText = (entry: StructuredLogRow): string => {
-  const parts = [timestampLabel(entry.log), entry.level.toUpperCase()];
-
-  if (entry.log.logger) {
-    parts.push(`[${entry.log.logger}]`);
-  }
-
-  parts.push(logMessage(entry.log));
-
-  if (entry.log.exception_message) {
-    parts.push(`: ${entry.log.exception_message}`);
-  }
-
-  return parts.join(' ');
-};
-
 const structuredLineClass = computed<Array<string>>(() => [
   'flex-1',
   wrapLines.value ? 'min-w-0 whitespace-pre-wrap wrap-break-word' : 'min-w-max whitespace-pre',
@@ -923,6 +908,6 @@ const copyData = (): void => {
     return;
   }
 
-  copyText(structuredRows.value.map((item) => renderStructuredRowText(item)).join('\n'));
+  copyText(logClipboardText(structuredRows.value.map((item) => item.log)));
 };
 </script>

--- a/frontend/app/pages/logs/[filename].vue
+++ b/frontend/app/pages/logs/[filename].vue
@@ -118,7 +118,7 @@
     </UAlert>
 
     <UAlert
-      v-else-if="isLoading && 0 === data.length"
+      v-else-if="isLoading && 0 === rawLines.length"
       color="info"
       variant="soft"
       icon="i-lucide-loader-circle"
@@ -165,34 +165,95 @@
             class="logline block"
             :class="wrapLines ? 'whitespace-pre-wrap ws-wrap-anywhere' : 'whitespace-pre'"
           >
-            {{ renderJson(data) }}
+            {{ renderJson(rawLines) }}
           </code>
         </div>
 
-        <div v-else ref="logContainer" class="logbox" @scroll.passive="handleScroll">
-          <code id="logView" class="logline block">
-            <span
-              v-for="item in filterItems"
-              :key="item.id"
-              :class="['log-entry block', wrapLines ? '' : 'whitespace-nowrap']"
-              ><span
-                v-if="item.date || hasLinks(item)"
-                class="mr-[1ch] inline-flex items-baseline whitespace-normal"
-              >
-                <template v-if="item.date"
-                  >[<span class="cursor-help" :title="item.date">{{ formatDate(item.date) }}</span
-                  >]</template
-                >
-                <span v-if="hasLinks(item)" :class="item.date ? 'ml-[1ch]' : ''">
-                  <LogLineLinks :item="item" :open-event="openEvent" />
-                </span>
-              </span>
-              <span
-                :class="wrapLines ? 'whitespace-pre-wrap ws-wrap-anywhere' : 'whitespace-pre'"
-                >{{ String(item.text).trimStart() }}</span
-              ></span
+        <div
+          v-else
+          ref="logContainer"
+          class="overflow-auto"
+          @scroll.passive="handleScroll"
+          :style="logContainerStyle"
+        >
+          <template v-if="structuredRows.length > 0">
+            <article
+              v-for="(entry, index) in structuredRows"
+              :key="entry.key"
+              :class="structuredRowClass(entry, index)"
             >
-          </code>
+              <div
+                :class="[
+                  'flex min-w-0 flex-1 items-start gap-[0.65rem] px-3 py-[0.65rem] leading-[1.6]',
+                  wrapLines ? 'w-full' : 'w-max min-w-full',
+                ]"
+              >
+                <p :class="structuredLineClass">
+                  <span
+                    class="inline-flex max-w-full flex-wrap items-center gap-x-2 gap-y-1 align-middle"
+                  >
+                    <UTooltip :text="lineTitle(entry.log)">
+                      <span class="inline cursor-pointer text-[11px] font-semibold text-toned">
+                        {{ timestampLabel(entry.log) }}
+                      </span>
+                    </UTooltip>
+
+                    <LogDetailsChip
+                      :item="entry.log"
+                      :open-details="openLogDetails"
+                      :open-event="openEvent"
+                    />
+
+                    <span
+                      :class="logLevelBadgeClass(entry.level)"
+                      @click="openLogDetails(entry.log)"
+                    >
+                      <UIcon :name="LOG_LEVEL_ICON[entry.level]" class="size-3" />
+                      {{ entry.level }}
+                    </span>
+
+                    <span
+                      v-if="entry.log.logger"
+                      :title="entry.log.logger"
+                      class="inline-block max-w-[46vw] truncate align-middle text-[11px] font-semibold text-toned sm:max-w-104"
+                    >
+                      [{{ entry.log.logger }}]
+                    </span>
+                  </span>
+
+                  <span class="ml-2">{{ logMessage(entry.log) }}</span>
+
+                  <span v-if="entry.log.exception_message" class="ml-1 text-error/90">
+                    : {{ entry.log.exception_message }}
+                  </span>
+                </p>
+              </div>
+            </article>
+          </template>
+
+          <div
+            v-else
+            class="flex min-h-[55vh] flex-col items-center justify-center gap-3 px-6 py-8 text-center"
+          >
+            <UIcon
+              :name="query ? 'i-lucide-filter-x' : 'i-lucide-circle-off'"
+              class="size-6 text-toned"
+            />
+
+            <div class="space-y-1">
+              <p class="text-sm font-medium text-default">
+                {{ query ? 'No logs match this query' : 'No log lines available' }}
+              </p>
+
+              <p class="text-sm text-toned">
+                {{
+                  query
+                    ? 'Adjust the filter or load more lines.'
+                    : 'This file has no visible log lines yet.'
+                }}
+              </p>
+            </div>
+          </div>
         </div>
       </UCard>
 
@@ -201,25 +262,13 @@
           <EventView v-if="selectedEventId" :id="selectedEventId" />
         </template>
       </UModal>
+
+      <LogDetailsModal :log="selectedLog" v-model:open="detailsOpen" />
     </template>
   </main>
 </template>
 
 <style scoped>
-#logView {
-  min-height: 72vh;
-  min-width: inherit;
-  max-width: 100%;
-}
-
-.log-entry:nth-child(even) {
-  color: #ffc9d4;
-}
-
-.log-entry:nth-child(odd) {
-  color: #e3c981;
-}
-
 code {
   background-color: unset;
 }
@@ -228,8 +277,6 @@ code {
   background-color: #1f2229;
   min-width: 100%;
   max-height: 73vh;
-  overflow-y: auto;
-  overflow-x: auto;
 }
 
 div.logbox pre {
@@ -237,10 +284,7 @@ div.logbox pre {
 }
 
 .logline {
-  word-break: break-all;
-  line-height: 2.3em;
-  padding: 1em;
-  color: #fff1b8;
+  line-height: 1.8em;
 }
 </style>
 
@@ -251,19 +295,21 @@ import { useStorage } from '@vueuse/core';
 import { fetchEventSource } from '@microsoft/fetch-event-source';
 import moment from 'moment';
 import EventView from '~/components/EventView.vue';
-import LogLineLinks from '~/components/LogLineLinks.vue';
+import LogDetailsChip from '~/components/LogDetailsChip.vue';
+import LogDetailsModal from '~/components/LogDetailsModal.vue';
 import { useDialog } from '~/composables/useDialog';
 import { requireTopLevelPageShell } from '~/utils/topLevelNavigation';
-import type { GenericResponse, LogEntry } from '~/types';
+import type { GenericResponse, LogEntry, LogResponse } from '~/types';
+import { copyText, makeEventName, notification, parse_api_response, request } from '~/utils';
 import {
-  copyText,
-  disableOpacity,
-  enableOpacity,
-  makeEventName,
-  notification,
-  parse_api_response,
-  request,
-} from '~/utils';
+  getLogLevel,
+  logMessageText,
+  logSearchText,
+  logTimestampLabel,
+  logTimestampTitle,
+  parseLogLine,
+  parseLogLines,
+} from '~/utils/logs';
 
 const router = useRouter();
 const route = useRoute();
@@ -278,6 +324,7 @@ useHead({ title: `Logs : ${filename}` });
 
 const query = ref<string>('');
 const data = ref<Array<LogEntry>>([]);
+const rawLines = ref<Array<string>>([]);
 const error = ref<string>('');
 const wrapLines = useStorage('logs_wrap_lines', false);
 const isDownloading = ref<boolean>(false);
@@ -291,12 +338,33 @@ const stream = ref<boolean>(false);
 const logContainer = ref<HTMLElement | null>(null);
 const streamController = ref<AbortController | null>(null);
 const selectedEventId = ref<string | null>(null);
+const selectedLog = ref<LogEntry | null>(null);
 const isTodayLog = computed<boolean>(() => filename.includes(moment().format('YYYYMMDD')));
+
+type LogLevel = 'debug' | 'info' | 'warning' | 'error';
+
+type StructuredLogRow = {
+  key: string;
+  log: LogEntry;
+  level: LogLevel;
+};
+
+const LOG_LEVEL_ICON: Record<LogLevel, string> = {
+  debug: 'i-lucide-terminal',
+  info: 'i-lucide-info',
+  warning: 'i-lucide-triangle-alert',
+  error: 'i-lucide-circle-x',
+};
 
 const eventViewModalUi = {
   content: 'max-w-5xl',
   body: 'p-4 sm:p-5',
 };
+
+const logContainerStyle = {
+  minHeight: '70vh',
+  maxHeight: '70vh',
+} as const;
 
 const eventViewOpen = computed({
   get: () => null !== selectedEventId.value,
@@ -310,6 +378,15 @@ const eventViewOpen = computed({
 const eventViewTitle = computed(() =>
   null === selectedEventId.value ? 'Event' : `#${makeEventName(selectedEventId.value)}`,
 );
+
+const detailsOpen = computed({
+  get: () => null !== selectedLog.value,
+  set: (value: boolean) => {
+    if (false === value) {
+      selectedLog.value = null;
+    }
+  },
+});
 
 let scrollTimeout: ReturnType<typeof setTimeout> | null = null;
 
@@ -347,29 +424,30 @@ const filterItems = computed<Array<LogEntry>>(() => {
     return data.value;
   }
 
-  return data.value.filter((item) => item.text.toLowerCase().includes(query.value.toLowerCase()));
+  return data.value.filter((item) => logSearchText(item).includes(query.value.toLowerCase()));
 });
 
-const hasLinks = (item: LogEntry): boolean => {
-  return Boolean(item.item_id || item.event_id || item.backend);
-};
+const structuredRows = computed<Array<StructuredLogRow>>(() => {
+  return filterItems.value.map((log, index) => ({
+    key: `${log.id}:${index}`,
+    log,
+    level: getLogLevel(log.level),
+  }));
+});
 
 const openEvent = (id: string): void => {
   selectedEventId.value = id;
+};
+
+const openLogDetails = (log: LogEntry): void => {
+  selectedLog.value = log;
 };
 
 const loadContent = async (): Promise<void> => {
   try {
     isLoading.value = true;
     const response = await request(`/log/${filename}?offset=${offset.value}`);
-    const json = await parse_api_response<{
-      filename: string;
-      offset: number;
-      next: number | null;
-      max: number;
-      type: 'log' | 'json';
-      lines: Array<LogEntry>;
-    }>(response);
+    const json = await parse_api_response<LogResponse>(response);
 
     if (200 !== response.status) {
       if ('error' in json) {
@@ -390,7 +468,11 @@ const loadContent = async (): Promise<void> => {
     contentType.value = json.type ?? 'log';
 
     if (0 < json.lines.length) {
-      data.value.unshift(...json.lines);
+      rawLines.value.unshift(...json.lines);
+
+      if ('log' === contentType.value) {
+        data.value.unshift(...parseLogLines(json.lines));
+      }
     }
 
     offset.value = json.next ?? offset.value;
@@ -444,7 +526,6 @@ const scrollToBottom = (): void => {
 
 onMounted(async () => {
   await loadContent();
-  await nextTick(() => disableOpacity());
 });
 
 onBeforeUnmount(() => closeStream());
@@ -455,7 +536,6 @@ onUnmounted(async () => {
     clearTimeout(scrollTimeout);
     scrollTimeout = null;
   }
-  await nextTick(() => enableOpacity());
 });
 
 const watchLog = (): void => {
@@ -473,25 +553,27 @@ const watchLog = (): void => {
         return;
       }
 
-      const lines = evt.data.split(/\n/g);
+      try {
+        const payload = JSON.parse(evt.data) as { data?: string };
+        const line = typeof payload.data === 'string' ? payload.data.trim() : '';
 
-      for (let index = 0; index < lines.length; index++) {
-        try {
-          const line = String(lines[index]);
-          if (!line.trim()) {
-            continue;
-          }
-
-          data.value.push(JSON.parse(line) as LogEntry);
-
-          await nextTick(() => {
-            if (autoScroll.value) {
-              scrollLogContainerToBottom('smooth');
-            }
-          });
-        } catch (streamError) {
-          console.error(streamError);
+        if (!line) {
+          return;
         }
+
+        rawLines.value.push(line);
+
+        if ('log' === contentType.value) {
+          data.value.push(parseLogLine(line));
+        }
+
+        await nextTick(() => {
+          if (autoScroll.value) {
+            scrollLogContainerToBottom('smooth');
+          }
+        });
+      } catch (streamError) {
+        console.error(streamError);
       }
     },
     onclose: () => {
@@ -551,6 +633,9 @@ const downloadFile = async (): Promise<void> => {
     URL.revokeObjectURL(fileURL);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    if (message.includes('aborted')) {
+      return;
+    }
     notification('error', 'Error', `Failed to download the file. ${message}`);
   } finally {
     isDownloading.value = false;
@@ -596,17 +681,52 @@ const deleteFile = async (): Promise<void> => {
   }
 };
 
-const formatDate = (dt: string): string => moment(dt).format('DD/MM HH:mm:ss');
+const lineTitle = (item: LogEntry): string => logTimestampTitle(item.datetime ?? item.date);
 
-const renderJson = (lines: Array<LogEntry>): string =>
-  JSON.stringify(JSON.parse(lines.map((entry) => entry.text).join('')), null, 4);
+const timestampLabel = (item: LogEntry): string => logTimestampLabel(item.datetime ?? item.date);
+
+const logMessage = (item: LogEntry): string => logMessageText(item);
+
+const structuredLineClass = computed<Array<string>>(() => [
+  'flex-1',
+  wrapLines.value ? 'min-w-0 whitespace-pre-wrap wrap-break-word' : 'min-w-max whitespace-pre',
+  'text-default',
+]);
+
+const structuredRowClass = (_entry: StructuredLogRow, index: number): Array<string> => {
+  const classes = [
+    'flex min-w-0 border-b border-default/40 bg-transparent transition-colors duration-150 last:border-b-0 hover:bg-elevated/70',
+  ];
+
+  if (index % 2 === 1) {
+    classes.push('bg-elevated/40');
+  }
+
+  return classes;
+};
+
+const logLevelBadgeClass = (level: LogLevel): Array<string> => [
+  'inline-flex cursor-pointer items-center gap-1.5 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide',
+  'debug' === level ? 'bg-muted/40 text-muted' : '',
+  'info' === level ? 'bg-info/10 text-info' : '',
+  'warning' === level ? 'bg-warning/10 text-warning' : '',
+  'error' === level ? 'bg-error/10 text-error' : '',
+];
+
+const renderJson = (lines: Array<string>): string => {
+  try {
+    return JSON.stringify(JSON.parse(lines.join('')), null, 4);
+  } catch {
+    return lines.join('\n');
+  }
+};
 
 const copyData = (): void => {
   if ('json' === contentType.value) {
-    copyText(renderJson(data.value));
+    copyText(renderJson(rawLines.value));
     return;
   }
 
-  copyText(filterItems.value.map((item) => item.text).join('\n'));
+  copyText(filterItems.value.map((item) => item.raw).join('\n'));
 };
 </script>

--- a/frontend/app/pages/tasks.vue
+++ b/frontend/app/pages/tasks.vue
@@ -354,6 +354,7 @@ import {
   makeEventName,
   makeConsoleCommand,
   notification,
+  parse_api_error_message,
   parse_api_response,
   request,
   TOOLTIP_DATE_FORMAT,
@@ -524,7 +525,14 @@ const queueTask = async (task: TaskItem): Promise<void> => {
           }),
         );
       }
+      return;
     }
+
+    notification(
+      'error',
+      'Error',
+      await parse_api_error_message(response, `Failed to update '${task.name}' queue.`),
+    );
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : 'Unexpected error';
     notification('error', 'Error', `Request error. ${message}`);

--- a/frontend/app/types/index.d.ts
+++ b/frontend/app/types/index.d.ts
@@ -228,10 +228,32 @@ export interface LogEntry {
   backend: string | null;
   /** Timestamp of the log entry */
   date: string | null;
+  /** Structured timestamp of the log entry */
+  datetime?: string | null;
   /** Parsed log level if available */
   level: string | null;
+  /** Structured logger/channel name */
+  logger?: string | null;
   /** The log message text */
   text: string;
+  /** Original structured message */
+  message?: string | null;
+  /** Structured flattened fields */
+  fields?: JsonObject;
+  /** Source metadata for structured logs */
+  source?: JsonObject;
+  /** Process metadata for structured logs */
+  process?: JsonObject;
+  /** Thread metadata for structured logs */
+  thread?: JsonObject;
+  /** Structured exception payload */
+  exception?: string | null;
+  /** Structured exception summary */
+  exception_message?: string | null;
+  /** Structured stack payload */
+  stack?: string | null;
+  /** Original raw line from the API */
+  raw: string;
 }
 
 /**
@@ -246,8 +268,18 @@ export interface LogResponse {
   next: number | null;
   /** Maximum number of lines in the file */
   max: number;
-  /** Array of log entries */
-  lines: Array<LogEntry>;
+  /** Content type of the file */
+  type: 'log' | 'json';
+  /** Raw lines returned by the API */
+  lines: Array<string>;
+}
+
+/**
+ * Recent log file response from /api/logs/recent endpoint.
+ */
+export interface RecentLogFile extends LogItem {
+  /** Raw log lines returned by the API */
+  lines: Array<string>;
 }
 
 /**
@@ -429,8 +461,8 @@ export interface EventsItem {
   updated_at?: string;
   /** Event data payload (optional) */
   event_data?: JsonObject;
-  /** Event logs array (optional) */
-  logs?: Array<LogEntry>;
+  /** Raw event log lines (optional) */
+  logs?: Array<string>;
   /** Event options (optional) */
   options?: JsonObject;
   /** Display toggle for event data (UI state) */

--- a/frontend/app/utils/index.ts
+++ b/frontend/app/utils/index.ts
@@ -569,6 +569,40 @@ const parse_api_response = async <T = JsonObject>(r: Response): Promise<T | Gene
   }
 };
 
+const is_api_error = (value: unknown): value is GenericError => {
+  if (null === value || 'object' !== typeof value || false === 'error' in value) {
+    return false;
+  }
+
+  const error = (value as { error?: unknown }).error;
+
+  return null !== error && 'object' === typeof error && 'message' in error;
+};
+
+const api_error_message = (
+  value: unknown,
+  response: Response | null = null,
+  fallback: string = 'Request failed',
+): string => {
+  if (is_api_error(value)) {
+    const message = String(value.error.message || fallback);
+    return `${value.error.code}: ${message}`;
+  }
+
+  if (null !== response) {
+    const message = response.statusText || fallback;
+    return `${response.status}: ${message}`;
+  }
+
+  return fallback;
+};
+
+const parse_api_error_message = async (
+  response: Response,
+  fallback: string = 'Request failed',
+): Promise<string> =>
+  api_error_message(await parse_api_response<JsonObject>(response), response, fallback);
+
 type HistoryLogItem = {
   item_id?: string | number | null;
   user?: string | null;
@@ -792,6 +826,9 @@ export {
   basename,
   encodePath,
   parse_api_response,
+  is_api_error,
+  api_error_message,
+  parse_api_error_message,
   goto_history_item,
   queue_event,
   syncOpacity,

--- a/frontend/app/utils/logs.ts
+++ b/frontend/app/utils/logs.ts
@@ -1,0 +1,549 @@
+import type { JsonObject, JsonValue, LogEntry } from '~/types';
+
+export type ParsedLogEntry = LogEntry;
+
+export type LogTone = 'neutral' | 'info' | 'warning' | 'error' | 'success';
+export type LogLevel = 'debug' | 'info' | 'warning' | 'error';
+
+export type LogDetailRow = {
+  label: string;
+  value: string;
+  icon: string;
+};
+
+export interface RawLogResponse {
+  filename: string;
+  offset: number;
+  next: number | null;
+  max: number;
+  type: 'log' | 'json';
+  lines: Array<string>;
+}
+
+export interface RawRecentLogFile {
+  filename: string;
+  type: string;
+  date: string;
+  size: number;
+  modified: string;
+  lines: Array<string>;
+}
+
+const LEVEL_REGEX =
+  /^(?:\[[^\]]+\]\s*)?(?:[a-z0-9_.-]+\.)?(?<level>EMERGENCY|ALERT|CRITICAL|ERROR|WARNING|NOTICE|INFO|DEBUG):\s*/i;
+const DATE_REGEX =
+  /^\[([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]+)?[+-][0-9]{2}:[0-9]{2})]/i;
+const EVENT_REGEX =
+  /\[event:(?<event_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})]\s*/i;
+const ITEM_REGEX = /'#(?<item_id>\d+):/;
+const IDENT_REGEX = /'((?<client>\w+):\s)?(?<user>\w+)@(?<backend>[\w-]+)'/i;
+let logSequence = 0;
+
+const hashText = (value: string): string => {
+  let hash = 0;
+
+  for (let index = 0; index < value.length; index++) {
+    hash = ((hash << 5) - hash + value.charCodeAt(index)) | 0;
+  }
+
+  return Math.abs(hash).toString(36);
+};
+
+const nextLogId = (prefix: string, seed: string): string => {
+  logSequence += 1;
+  return `${prefix}-${hashText(seed)}-${logSequence}`;
+};
+
+const isObject = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && false === Array.isArray(value);
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | null => {
+  return isObject(value) ? value : null;
+};
+
+const asString = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    const normalized = value.trim();
+    return '' === normalized ? null : normalized;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  return null;
+};
+
+const flattenInto = (target: JsonObject, source: Record<string, unknown>, prefix = ''): void => {
+  for (const [key, value] of Object.entries(source)) {
+    const path = '' === prefix ? key : `${prefix}.${key}`;
+
+    if (isObject(value)) {
+      flattenInto(target, value, path);
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      try {
+        target[path] = JSON.stringify(value) as JsonValue;
+      } catch {
+        target[path] = String(value);
+      }
+      continue;
+    }
+
+    if (
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean' ||
+      value === null
+    ) {
+      target[path] = value;
+      continue;
+    }
+
+    target[path] = String(value);
+  }
+};
+
+const emptyEntry = (raw: string): ParsedLogEntry => ({
+  id: nextLogId('log', raw),
+  item_id: null,
+  event_id: null,
+  user: null,
+  backend: null,
+  date: null,
+  datetime: null,
+  level: null,
+  logger: null,
+  text: raw,
+  message: null,
+  fields: {},
+  raw,
+});
+
+const parseJsonl = (line: string): ParsedLogEntry | null => {
+  let payload: unknown = null;
+
+  try {
+    payload = JSON.parse(line) as unknown;
+  } catch {
+    return null;
+  }
+
+  if (!isObject(payload)) {
+    return null;
+  }
+
+  const id = asString(payload.id);
+  const datetime = asString(payload.datetime);
+  const level = asString(payload.level)?.toLowerCase() ?? null;
+  const logger = asString(payload.logger) ?? asString(payload.channel);
+  const message = typeof payload.message === 'string' ? payload.message : null;
+
+  if (!id || !datetime || !level || !logger || null === message) {
+    return null;
+  }
+
+  const fieldsSource = asRecord(payload.fields) ?? {};
+  const fields: JsonObject = {};
+  flattenInto(fields, fieldsSource);
+
+  const itemId = asString(fields.item_id ?? fields['item.id'] ?? fields['attributes.item.id']);
+  const eventId = asString(fields.event_id ?? fields['event.id'] ?? fields['attributes.event.id']);
+  const user = asString(fields.user ?? fields['user.name'] ?? fields['attributes.user.name']);
+  const backend = asString(
+    fields.backend ?? fields['backend.name'] ?? fields['attributes.backend.name'] ?? fields.via,
+  );
+
+  return {
+    id,
+    item_id: itemId,
+    event_id: eventId,
+    user,
+    backend,
+    date: datetime,
+    datetime,
+    level,
+    logger,
+    text: message,
+    message,
+    fields,
+    source: (asRecord(payload.source) ?? undefined) as JsonObject | undefined,
+    process: (asRecord(payload.process) ?? undefined) as JsonObject | undefined,
+    thread: (asRecord(payload.thread) ?? undefined) as JsonObject | undefined,
+    exception: typeof payload.exception === 'string' ? payload.exception : null,
+    exception_message:
+      typeof payload.exception_message === 'string' ? payload.exception_message : null,
+    stack: typeof payload.stack === 'string' ? payload.stack : null,
+    raw: line,
+  };
+};
+
+const parseLegacy = (line: string): ParsedLogEntry => {
+  const dateMatch = DATE_REGEX.exec(line);
+  const eventMatch = EVENT_REGEX.exec(line);
+  const levelMatch = LEVEL_REGEX.exec(line);
+  const itemMatch = ITEM_REGEX.exec(line);
+  const identMatch = IDENT_REGEX.exec(line);
+
+  let text = dateMatch ? line.replace(DATE_REGEX, '').trim() : line;
+
+  if (eventMatch) {
+    text = text.replace(EVENT_REGEX, '').trim();
+  }
+
+  return {
+    id: nextLogId('legacy', line),
+    item_id: itemMatch?.groups?.item_id ?? null,
+    event_id: eventMatch?.groups?.event_id ?? null,
+    user: identMatch?.groups?.user ?? null,
+    backend: identMatch?.groups?.backend ?? null,
+    date: dateMatch?.[1] ?? null,
+    datetime: dateMatch?.[1] ?? null,
+    level: levelMatch?.groups?.level?.toLowerCase() ?? null,
+    logger: null,
+    text,
+    message: null,
+    fields: {},
+    raw: line,
+  };
+};
+
+const parseLogLine = (line: string): ParsedLogEntry => {
+  const normalized = line.trim();
+
+  if (!normalized) {
+    return emptyEntry('');
+  }
+
+  return parseJsonl(normalized) ?? parseLegacy(normalized);
+};
+
+const parseLogLines = (lines: Array<string>): Array<ParsedLogEntry> => {
+  return lines.map((line) => parseLogLine(line)).filter((entry) => '' !== entry.raw.trim());
+};
+
+const logMessageText = (entry: ParsedLogEntry): string => {
+  if (entry.message && entry.exception_message) {
+    return `${entry.message} [${entry.exception_message}]`;
+  }
+
+  return entry.message ?? entry.text;
+};
+
+const logHostLabel = (entry: ParsedLogEntry): string => {
+  const fields = entry.fields ?? {};
+  const candidates = [
+    fields['structured.request.name'],
+    fields.hostname,
+    fields['route.ip'],
+    fields.task_id,
+    fields.command,
+    fields.user,
+    fields.backend,
+    fields['cli.stream'],
+    entry.source?.module,
+    entry.process?.name,
+    entry.logger,
+  ];
+
+  for (const candidate of candidates) {
+    const value = asString(candidate);
+    if (value) {
+      return value;
+    }
+  }
+
+  return '-';
+};
+
+const logSeverityTone = (
+  entry: ParsedLogEntry,
+): 'error' | 'warning' | 'success' | 'info' | 'neutral' => {
+  const value = `${entry.level ?? ''} ${logMessageText(entry)}`.toLowerCase();
+
+  if (/(critical|crit|alert|error|err|fatal|panic|exception|failed)/.test(value)) {
+    return 'error';
+  }
+
+  if (/(warning|warn|notice|noti|deprecated)/.test(value)) {
+    return 'warning';
+  }
+
+  if (/(success|started|listening|connected|ready|complete|done)/.test(value)) {
+    return 'success';
+  }
+
+  if (/(info|inf|debug|deb|trace)/.test(value)) {
+    return 'info';
+  }
+
+  return 'neutral';
+};
+
+const getLogLevel = (level: string | null | undefined): LogLevel => {
+  switch ((level ?? '').toLowerCase()) {
+    case 'info':
+    case 'notice':
+      return 'info';
+    case 'warning':
+    case 'warn':
+      return 'warning';
+    case 'error':
+    case 'critical':
+    case 'fatal':
+    case 'alert':
+    case 'emergency':
+      return 'error';
+    default:
+      return 'debug';
+  }
+};
+
+const logTimestampLabel = (value: string | null | undefined): string => {
+  if (!value) {
+    return '--:--:--';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleTimeString([], {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+};
+
+const logTimestampTitle = (value: string | null | undefined): string => {
+  if (!value) {
+    return 'No timestamp';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString();
+};
+
+const logDisplayLine = (entry: ParsedLogEntry): string => {
+  const host = logHostLabel(entry);
+  const logger = entry.logger === host ? null : entry.logger;
+  const parts = [
+    logTimestampLabel(entry.datetime ?? entry.date),
+    '-' === host ? null : host,
+    (entry.level ?? 'info').toUpperCase(),
+    logger,
+    logMessageText(entry),
+  ];
+
+  return parts.filter((value) => value && '' !== value.trim()).join(' ');
+};
+
+const logSearchText = (entry: ParsedLogEntry): string => {
+  const values = [
+    entry.raw,
+    entry.text,
+    entry.message,
+    entry.level,
+    entry.logger,
+    entry.exception,
+    entry.exception_message,
+    entry.stack,
+  ];
+
+  try {
+    values.push(JSON.stringify(entry.fields));
+  } catch {
+    // -- ignore invalid structured payloads when building a search string.
+  }
+
+  return values.filter(Boolean).join(' ').toLowerCase();
+};
+
+const formatDetailValue = (value: unknown): string => {
+  if (value === undefined || value === null || value === '') {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  return JSON.stringify(value);
+};
+
+const compactRows = (
+  rows: Array<{ label: string; value: unknown; icon: string }>,
+): Array<LogDetailRow> => {
+  return rows
+    .map((row) => ({
+      label: row.label,
+      value: formatDetailValue(row.value),
+      icon: row.icon,
+    }))
+    .filter((row) => Boolean(row.value));
+};
+
+const formatNameId = (nameValue: unknown, idValue: unknown): string => {
+  const left = formatDetailValue(nameValue);
+  const right = formatDetailValue(idValue);
+
+  if (left && right) {
+    return `${left} / ${right}`;
+  }
+
+  return left || right;
+};
+
+const logDetailRows = (log: ParsedLogEntry): Array<LogDetailRow> => {
+  return compactRows([
+    { label: 'File', value: log.source?.file, icon: 'i-lucide-file' },
+    { label: 'Line', value: log.source?.line, icon: 'i-lucide-hash' },
+    { label: 'Function', value: log.source?.function, icon: 'i-lucide-code-2' },
+    { label: 'Module', value: log.source?.module, icon: 'i-lucide-box' },
+    { label: 'Path', value: log.source?.path, icon: 'i-lucide-folder-tree' },
+    {
+      label: 'Process / ID',
+      value: formatNameId(log.process?.name, log.process?.id),
+      icon: 'i-lucide-cpu',
+    },
+  ]);
+};
+
+const logFieldRows = (log: ParsedLogEntry): Array<LogDetailRow> => {
+  return compactRows(
+    Object.entries(log.fields ?? {}).map(([label, value]) => ({
+      label,
+      value,
+      icon: 'i-lucide-tag',
+    })),
+  );
+};
+
+const formatTraceLines = (trace: unknown): string => {
+  if (!Array.isArray(trace)) {
+    return '';
+  }
+
+  const lines = trace
+    .map((frame, index) => {
+      if (!frame || typeof frame !== 'object' || Array.isArray(frame)) {
+        return '';
+      }
+
+      const record = frame as Record<string, unknown>;
+      const file = typeof record.file === 'string' ? record.file.trim() : '';
+      const line =
+        typeof record.line === 'number'
+          ? record.line
+          : typeof record.line === 'string' && record.line.trim()
+            ? Number(record.line)
+            : null;
+      const fn = typeof record.function === 'string' ? record.function.trim() : '';
+      const klass = typeof record.class === 'string' ? record.class.trim() : '';
+      const type = typeof record.type === 'string' ? record.type.trim() : '';
+
+      const call = fn ? `${klass}${type}${fn}` : '';
+      const location = file
+        ? `${file}${line !== null && !Number.isNaN(line) ? `:${line}` : ''}`
+        : '';
+
+      if (call && location) {
+        return `#${index} ${call} at ${location}`;
+      }
+
+      if (call) {
+        return `#${index} ${call}`;
+      }
+
+      if (location) {
+        return `#${index} ${location}`;
+      }
+
+      return '';
+    })
+    .filter((line) => Boolean(line));
+
+  return lines.join('\n');
+};
+
+const formatLogException = (exception: string | null | undefined): string => {
+  if (!exception) {
+    return '';
+  }
+
+  const trimmed = exception.trim();
+  const jsonStart = trimmed.indexOf('\n[');
+
+  if (-1 === jsonStart) {
+    return trimmed;
+  }
+
+  const headline = trimmed.slice(0, jsonStart).trim();
+  const trace = trimmed.slice(jsonStart + 1).trim();
+
+  try {
+    const renderedTrace = formatTraceLines(JSON.parse(trace) as unknown);
+
+    if (!renderedTrace) {
+      return trimmed;
+    }
+
+    return `${headline}\n${renderedTrace}`;
+  } catch {
+    return trimmed;
+  }
+};
+
+const formatLogStack = (stack: string | null | undefined): string => {
+  if (!stack) {
+    return '';
+  }
+
+  try {
+    return JSON.stringify(JSON.parse(stack) as unknown, null, 2);
+  } catch {
+    return stack;
+  }
+};
+
+const logRaw = (log: ParsedLogEntry): string => {
+  try {
+    return JSON.stringify(JSON.parse(log.raw) as unknown, null, 2);
+  } catch {
+    return log.raw;
+  }
+};
+
+export {
+  emptyEntry,
+  formatLogException,
+  formatLogStack,
+  getLogLevel,
+  logDetailRows,
+  logDisplayLine,
+  logFieldRows,
+  logHostLabel,
+  logMessageText,
+  logRaw,
+  logSearchText,
+  logSeverityTone,
+  logTimestampLabel,
+  logTimestampTitle,
+  parseJsonl,
+  parseLegacy,
+  parseLogLine,
+  parseLogLines,
+};

--- a/frontend/app/utils/logs.ts
+++ b/frontend/app/utils/logs.ts
@@ -365,6 +365,29 @@ const logDisplayLine = (entry: ParsedLogEntry): string => {
   return parts.filter((value) => value && '' !== value.trim()).join(' ');
 };
 
+const logClipboardLine = (entry: ParsedLogEntry): string => {
+  const parts = [
+    logTimestampLabel(entry.datetime ?? entry.date),
+    getLogLevel(entry.level).toUpperCase(),
+  ];
+
+  if (entry.logger) {
+    parts.push(`[${entry.logger}]`);
+  }
+
+  parts.push(logMessageText(entry));
+
+  if (entry.exception_message) {
+    parts.push(`: ${entry.exception_message}`);
+  }
+
+  return parts.join(' ');
+};
+
+const logClipboardText = (entries: Array<ParsedLogEntry>): string => {
+  return entries.map((entry) => logClipboardLine(entry)).join('\n');
+};
+
 const logSearchText = (entry: ParsedLogEntry): string => {
   const values = [
     entry.raw,
@@ -562,6 +585,8 @@ export {
   LOG_LEVEL_COLOR,
   LOG_LEVEL_ICON,
   logDetailRows,
+  logClipboardLine,
+  logClipboardText,
   logDisplayLine,
   logFieldRows,
   logHostLabel,

--- a/frontend/app/utils/logs.ts
+++ b/frontend/app/utils/logs.ts
@@ -351,6 +351,11 @@ const logTimestampTitle = (value: string | null | undefined): string => {
   return date.toLocaleString();
 };
 
+const logTimestampClipboard = (value: string | null | undefined): string => {
+  const normalized = value?.trim() ?? '';
+  return '' === normalized ? '--:--:--' : normalized;
+};
+
 const logDisplayLine = (entry: ParsedLogEntry): string => {
   const host = logHostLabel(entry);
   const logger = entry.logger === host ? null : entry.logger;
@@ -366,13 +371,12 @@ const logDisplayLine = (entry: ParsedLogEntry): string => {
 };
 
 const logClipboardLine = (entry: ParsedLogEntry): string => {
-  const parts = [
-    logTimestampLabel(entry.datetime ?? entry.date),
-    getLogLevel(entry.level).toUpperCase(),
-  ];
+  const parts = [`[${logTimestampClipboard(entry.datetime ?? entry.date)}]`];
 
   if (entry.logger) {
-    parts.push(`[${entry.logger}]`);
+    parts.push(`${entry.logger}.${getLogLevel(entry.level).toUpperCase()}:`);
+  } else {
+    parts.push(getLogLevel(entry.level).toUpperCase() + ':');
   }
 
   parts.push(logMessageText(entry));

--- a/frontend/app/utils/logs.ts
+++ b/frontend/app/utils/logs.ts
@@ -3,7 +3,8 @@ import type { JsonObject, JsonValue, LogEntry } from '~/types';
 export type ParsedLogEntry = LogEntry;
 
 export type LogTone = 'neutral' | 'info' | 'warning' | 'error' | 'success';
-export type LogLevel = 'debug' | 'info' | 'warning' | 'error';
+export type LogLevel = 'debug' | 'info' | 'notice' | 'warning' | 'error';
+export type LogLevelColor = 'neutral' | 'info' | 'primary' | 'warning' | 'error';
 
 export type LogDetailRow = {
   label: string;
@@ -38,6 +39,22 @@ const EVENT_REGEX =
 const ITEM_REGEX = /'#(?<item_id>\d+):/;
 const IDENT_REGEX = /'((?<client>\w+):\s)?(?<user>\w+)@(?<backend>[\w-]+)'/i;
 let logSequence = 0;
+
+const LOG_LEVEL_ICON: Record<LogLevel, string> = {
+  debug: 'i-lucide-terminal',
+  info: 'i-lucide-info',
+  notice: 'i-lucide-bell-ring',
+  warning: 'i-lucide-triangle-alert',
+  error: 'i-lucide-circle-x',
+};
+
+const LOG_LEVEL_COLOR: Record<LogLevel, LogLevelColor> = {
+  debug: 'neutral',
+  info: 'info',
+  notice: 'primary',
+  warning: 'warning',
+  error: 'error',
+};
 
 const hashText = (value: string): string => {
   let hash = 0;
@@ -286,8 +303,9 @@ const logSeverityTone = (
 const getLogLevel = (level: string | null | undefined): LogLevel => {
   switch ((level ?? '').toLowerCase()) {
     case 'info':
-    case 'notice':
       return 'info';
+    case 'notice':
+      return 'notice';
     case 'warning':
     case 'warn':
       return 'warning';
@@ -527,15 +545,27 @@ const logRaw = (log: ParsedLogEntry): string => {
   }
 };
 
+const logLevelBadgeClass = (level: LogLevel): Array<string> => [
+  'inline-flex w-24 cursor-pointer items-center gap-1.5 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide whitespace-nowrap',
+  'debug' === level ? 'bg-muted/40 text-muted' : '',
+  'info' === level ? 'bg-info/10 text-info' : '',
+  'notice' === level ? 'bg-primary/12 text-primary' : '',
+  'warning' === level ? 'bg-warning/10 text-warning' : '',
+  'error' === level ? 'bg-error/10 text-error' : '',
+];
+
 export {
   emptyEntry,
   formatLogException,
   formatLogStack,
   getLogLevel,
+  LOG_LEVEL_COLOR,
+  LOG_LEVEL_ICON,
   logDetailRows,
   logDisplayLine,
   logFieldRows,
   logHostLabel,
+  logLevelBadgeClass,
   logMessageText,
   logRaw,
   logSearchText,

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -98,6 +98,7 @@ export default defineNuxtConfig({
         'marked-gfm-heading-id',
         '@noble/hashes/hmac.js',
         '@noble/hashes/sha2.js',
+        'cronstrue',
       ],
     },
     server: {

--- a/guides/one-way-sync.md
+++ b/guides/one-way-sync.md
@@ -36,7 +36,7 @@ The import process may take some time, depending on the size of your library. To
 the <!--i:i-lucide-server--> **Backends** page and check the `last import date` for the backend. If it shows the current time,
 the import is finished.
 
-Alternatively, visit the **Operations** > <!--i:i-lucide-scroll-text--> **Logs** page and look at the `task.YYYYMMDD.log` file, or go to
+Alternatively, visit the **Operations** > <!--i:i-lucide-scroll-text--> **Logs** page and look at the `task.YYYYMMDD.jsonl` file, or go to
 the **Activity** > <!--i:i-lucide-calendar-days--> **Events** page and look for the *`run_console`*
 events. The logs page is updated more frequently, so we recommend using it. Once the import is complete, you should see
 a message like this:

--- a/guides/using-ws-as-backup-solution.md
+++ b/guides/using-ws-as-backup-solution.md
@@ -57,7 +57,7 @@ Now that you have added the all users, simply go to the <!--i:i-lucide-list-chec
 start importing playstate. To bring all existing playstate into WatchState.
 
 The task will take some time depending on your library size. Monitor progress at the <!--i:i-lucide-globe--> **Logs** page by
-checking the `task.YYYYMMDD.log` file. Once the task completed you should see something like
+checking the `task.YYYYMMDD.jsonl` file. Once the task completed you should see something like
 
 ```
 [DD/MM HH:MM:SS]: SYSTEM: Import process completed in 'XXX's for all users.

--- a/public/index.php
+++ b/public/index.php
@@ -51,7 +51,6 @@ set_exception_handler(function (Throwable $e) {
         'kind' => $e::class,
         'line' => $e->getLine(),
         'message' => $e->getMessage(),
-        'file' => after($e->getFile(), ROOT_PATH),
     ]));
     exit(Command::FAILURE);
 });
@@ -171,12 +170,9 @@ $exitCode = $profiler->process(function () use ($request) {
 
         $out(
             r(
-                text: "HTTP: Exception '{kind}' was thrown unhandled during HTTP boot context. {message} at {file}:{line}.",
+                text: 'HTTP boot failed: {message}.',
                 context: [
-                    'kind' => $e::class,
-                    'line' => $e->getLine(),
                     'message' => $e->getMessage(),
-                    'file' => $e->getFile(),
                 ]
             )
         );
@@ -195,12 +191,9 @@ $exitCode = $profiler->process(function () use ($request) {
 
         $out(
             r(
-                text: "HTTP: Exception '{kind}' was thrown unhandled during response context. Error '{message} @ {file}:{line}'.",
+                text: 'HTTP response handling failed: {message}.',
                 context: [
-                    'kind' => $e::class,
-                    'line' => $e->getLine(),
                     'message' => $e->getMessage(),
-                    'file' => after($e->getFile(), ROOT_PATH),
                 ]
             )
         );

--- a/src/API/Backends/Add.php
+++ b/src/API/Backends/Add.php
@@ -113,10 +113,13 @@ final class Add
 
             $userContext->config->set($name, $config->getAll())->persist();
         } catch (InvalidContextException $e) {
-            $logger->error('Failed to validate backend context. {error}', [
+            $logger->error('Failed to validate backend context. ' . $e->getMessage(), [
+                'event_name' => 'backend.context.validation_failed',
+                'subsystem' => 'backend',
+                'operation' => 'context.validate',
+                'outcome' => 'failed',
                 'verify_host' => (bool) $data->get('options.client.verify_host', true),
-                'error' => $e->getMessage(),
-                'exception' => ag(exception_log($e), 'exception', []),
+                ...exception_log($e),
             ]);
             return api_error($e->getMessage(), Status::BAD_REQUEST);
         }

--- a/src/API/Backends/Users.php
+++ b/src/API/Backends/Users.php
@@ -49,7 +49,17 @@ final class Users
                 $users[] = $user;
             }
         } catch (Throwable $e) {
-            $logger->error($e->getMessage(), $e->getTrace());
+            $logger->error("Failed to fetch backend users for '{backend_type}'.", [
+                'event_name' => 'backend.context.users_failed',
+                'subsystem' => 'backend.context',
+                'operation' => 'users_list',
+                'outcome' => 'failed',
+                'backend_type' => $type,
+                'target_user' => $opts[Options::TARGET_USER] ?? null,
+                'get_tokens' => (bool) ($opts[Options::GET_TOKENS] ?? false),
+                'no_cache' => (bool) ($opts[Options::NO_CACHE] ?? false),
+                ...exception_log($e),
+            ]);
             return api_error($e->getMessage(), Status::INTERNAL_SERVER_ERROR);
         }
 

--- a/src/API/History/Index.php
+++ b/src/API/History/Index.php
@@ -550,7 +550,15 @@ final class Index
                         [],
                     );
                 } catch (Throwable $e) {
-                    $this->logger->error($e->getMessage());
+                    $this->logger->error("Failed to resolve duplicate history for '{user}' item '#{item_id}'.", [
+                        'event_name' => 'history.duplicates.resolve_failed',
+                        'subsystem' => 'history.duplicates',
+                        'operation' => 'resolve',
+                        'outcome' => 'failed',
+                        'user' => $userContext->name,
+                        'item_id' => (string) $entity['id'],
+                        ...exception_log($e),
+                    ]);
                 }
             }
 
@@ -673,7 +681,15 @@ final class Index
                     [],
                 );
             } catch (Throwable $e) {
-                $this->logger->error($e->getMessage());
+                $this->logger->error("Failed to resolve duplicate history for '{user}' item '#{item_id}'.", [
+                    'event_name' => 'history.duplicates.resolve_failed',
+                    'subsystem' => 'history.duplicates',
+                    'operation' => 'resolve',
+                    'outcome' => 'failed',
+                    'user' => $userContext->name,
+                    'item_id' => (string) $item->id,
+                    ...exception_log($e),
+                ]);
             }
         }
 
@@ -711,7 +727,15 @@ final class Index
                 [],
             );
         } catch (Throwable $e) {
-            $this->logger->error($e->getMessage());
+            $this->logger->error("Failed to resolve duplicate history for '{user}' item '#{item_id}'.", [
+                'event_name' => 'history.duplicates.resolve_failed',
+                'subsystem' => 'history.duplicates',
+                'operation' => 'resolve',
+                'outcome' => 'failed',
+                'user' => $userContext->name,
+                'item_id' => (string) $item->id,
+                ...exception_log($e),
+            ]);
             return api_error('Failed to get duplicates', Status::INTERNAL_SERVER_ERROR);
         }
 

--- a/src/API/Identities/Index.php
+++ b/src/API/Identities/Index.php
@@ -74,10 +74,10 @@ final class Index
         try {
             per_user_config($identityName);
         } catch (Throwable $e) {
-            $this->logger->error(r('Failed to create identity {identity}: {error.message}', [
+            $this->logger->error('Failed to create identity {identity}: {error.message}', [
                 'identity' => $identityName,
                 ...exception_log($e),
-            ]));
+            ]);
 
             return api_error(
                 r('Failed to create identity {identity}', ['identity' => $identityName]),
@@ -112,10 +112,10 @@ final class Index
         try {
             delete_user_config($identity, $cache);
         } catch (Throwable $e) {
-            $this->logger->error(r('Failed to delete identity {identity}: {error.message}', [
+            $this->logger->error('Failed to delete identity {identity}: {error.message}', [
                 'identity' => $identity,
                 ...exception_log($e),
-            ]));
+            ]);
 
             return api_error(
                 r('Failed to delete identity {identity}', ['identity' => $identity]),

--- a/src/API/Identities/Index.php
+++ b/src/API/Identities/Index.php
@@ -73,6 +73,7 @@ final class Index
 
         try {
             per_user_config($identityName);
+            ensure_migration(get_user_db($identityName));
         } catch (Throwable $e) {
             $this->logger->error("Failed to create identity '{identity}'.", [
                 'event_name' => 'identity.create.failed',

--- a/src/API/Identities/Index.php
+++ b/src/API/Identities/Index.php
@@ -74,7 +74,11 @@ final class Index
         try {
             per_user_config($identityName);
         } catch (Throwable $e) {
-            $this->logger->error('Failed to create identity {identity}: {error.message}', [
+            $this->logger->error("Failed to create identity '{identity}'.", [
+                'event_name' => 'identity.create.failed',
+                'subsystem' => 'identity',
+                'operation' => 'create',
+                'outcome' => 'failed',
                 'identity' => $identityName,
                 ...exception_log($e),
             ]);
@@ -112,7 +116,11 @@ final class Index
         try {
             delete_user_config($identity, $cache);
         } catch (Throwable $e) {
-            $this->logger->error('Failed to delete identity {identity}: {error.message}', [
+            $this->logger->error("Failed to delete identity '{identity}'.", [
+                'event_name' => 'identity.delete.failed',
+                'subsystem' => 'identity',
+                'operation' => 'delete',
+                'outcome' => 'failed',
                 'identity' => $identity,
                 ...exception_log($e),
             ]);

--- a/src/API/Identities/Provision.php
+++ b/src/API/Identities/Provision.php
@@ -162,6 +162,7 @@ final class Provision
         }
 
         $formatted = $this->formatMatchedIdentities(ag($result, 'identities', []));
+        $warnings = ag($result, 'warnings', []);
         $status = true === $provisionRequest->dryRun
             ? Status::OK
             : match ($mode) {
@@ -187,6 +188,8 @@ final class Provision
             'allow_single_backend_identities' => $provisionRequest->allowSingleBackendIdentities,
             'count' => count($formatted),
             'identities' => $formatted,
+            'warning_count' => count($warnings),
+            'warnings' => $warnings,
         ]);
     }
 

--- a/src/API/Logs/Index.php
+++ b/src/API/Logs/Index.php
@@ -39,7 +39,7 @@ final class Index
         $this->logsDir = [
             [
                 'path' => fix_path(Config::get('tmpDir') . '/logs'),
-                'type' => ['*.*.jsonl'],
+                'type' => ['*.*.jsonl', '*.*.log'],
             ],
             [
                 'path' => fix_path(Config::get('tmpDir') . '/webhooks'),

--- a/src/API/Logs/Index.php
+++ b/src/API/Logs/Index.php
@@ -41,7 +41,7 @@ final class Index
         $this->logsDir = [
             [
                 'path' => fix_path(Config::get('tmpDir') . '/logs'),
-                'type' => '*.*.log',
+                'type' => ['*.*.jsonl'],
             ],
             [
                 'path' => fix_path(Config::get('tmpDir') . '/webhooks'),
@@ -66,23 +66,29 @@ final class Index
 
         foreach ($this->logsDir as $pathInfo) {
             $path = ag($pathInfo, 'path');
-            $type = ag($pathInfo, 'type', '*.*.log');
-            foreach (glob($path . '/' . $type) as $file) {
-                preg_match('/(\w+)\.(.+?)\.(log|json)/i', basename($file), $matches);
-                $date = $matches[2] ?? null;
-                if (null !== $date && !is_numeric($date)) {
-                    $date = null;
+            foreach ((array) ag($pathInfo, 'type', '*.*.jsonl') as $type) {
+                $files = glob($path . '/' . $type);
+                if (false === $files) {
+                    continue;
                 }
 
-                $builder = [
-                    'filename' => basename($file),
-                    'type' => $matches[1] ?? '??',
-                    'date' => $date,
-                    'size' => filesize($file),
-                    'modified' => make_date(filemtime($file)),
-                ];
+                foreach ($files as $file) {
+                    preg_match('/(\w+)\.(.+?)\.(jsonl|json)/i', basename($file), $matches);
+                    $date = $matches[2] ?? null;
+                    if (null !== $date && !is_numeric($date)) {
+                        $date = null;
+                    }
 
-                $list[] = $builder;
+                    $builder = [
+                        'filename' => basename($file),
+                        'type' => $matches[1] ?? '??',
+                        'date' => $date,
+                        'size' => filesize($file),
+                        'modified' => make_date(filemtime($file)),
+                    ];
+
+                    $list[] = $builder;
+                }
             }
         }
 
@@ -96,8 +102,8 @@ final class Index
     public function recent(iRequest $request): iResponse
     {
         $path = $this->logsDir[0]['path'] ?? null;
-        $type = $this->logsDir[0]['type'] ?? null;
-        if (null === $path || null === $type) {
+        $types = $this->logsDir[0]['type'] ?? null;
+        if (null === $path || null === $types) {
             return api_error('Log path not configured.', Status::INTERNAL_SERVER_ERROR);
         }
 
@@ -109,41 +115,48 @@ final class Index
         $limit = (int) $params->get('limit', 50);
         $limit = $limit < 1 ? 50 : $limit;
 
-        foreach (glob($path . '/' . $type) as $file) {
-            preg_match('/(\w+)\.(\w+)\.log/i', basename($file), $matches);
-
-            $logDate = $matches[2] ?? null;
-
-            if (!$logDate || $logDate !== $today) {
+        foreach ((array) $types as $type) {
+            $files = glob($path . '/' . $type);
+            if (false === $files) {
                 continue;
             }
 
-            $builder = [
-                'filename' => basename($file),
-                'type' => $matches[1] ?? '??',
-                'date' => $matches[2] ?? '??',
-                'size' => filesize($file),
-                'modified' => make_date(filemtime($file)),
-                'lines' => [],
-            ];
+            foreach ($files as $file) {
+                preg_match('/(\w+)\.(\w+)\.(jsonl)/i', basename($file), $matches);
 
-            $file = new SplFileObject($file, 'r');
+                $logDate = $matches[2] ?? null;
 
-            if ($file->getSize() > 1) {
-                $file->seek(PHP_INT_MAX);
-                $lastLine = $file->key();
-                $it = new LimitIterator($file, max(0, $lastLine - $limit), $lastLine);
-                foreach ($it as $line) {
-                    $line = trim((string) $line);
-                    if (empty($line)) {
-                        continue;
-                    }
-
-                    $builder['lines'][] = self::formatLog($line, $this->users);
+                if (!$logDate || $logDate !== $today) {
+                    continue;
                 }
-            }
 
-            $list[] = $builder;
+                $builder = [
+                    'filename' => basename($file),
+                    'type' => $matches[1] ?? '??',
+                    'date' => $matches[2] ?? '??',
+                    'size' => filesize($file),
+                    'modified' => make_date(filemtime($file)),
+                    'lines' => [],
+                ];
+
+                $file = new SplFileObject($file, 'r');
+
+                if ($file->getSize() > 1) {
+                    $file->seek(PHP_INT_MAX);
+                    $lastLine = $file->key();
+                    $it = new LimitIterator($file, max(0, $lastLine - $limit), $lastLine);
+                    foreach ($it as $line) {
+                        $line = trim((string) $line);
+                        if (empty($line)) {
+                            continue;
+                        }
+
+                        $builder['lines'][] = $line;
+                    }
+                }
+
+                $list[] = $builder;
+            }
         }
 
         return api_response(Status::OK, $list, headers: [
@@ -210,7 +223,7 @@ final class Index
             'next' => null,
             'max' => $lastLine,
             'lines' => [],
-            'type' => $contentType,
+            'type' => 'json' === $contentType ? 'json' : 'log',
         ];
 
         if ($offset <= $lastLine) {
@@ -218,7 +231,13 @@ final class Index
             $it = new LimitIterator($file, $start, 'json' === $contentType ? PHP_INT_MAX : self::MAX_LIMIT);
 
             foreach ($it as $line) {
-                $data['lines'][] = self::formatLog(trim((string) $line), $this->users);
+                $line = trim((string) $line);
+
+                if ('' === $line) {
+                    continue;
+                }
+
+                $data['lines'][] = $line;
             }
 
             $hasMore = $lastLine > $offset;
@@ -258,11 +277,17 @@ final class Index
                         implode(
                             PHP_EOL,
                             array_map(
-                                function ($data) {
+                                static function ($data) {
                                     if (!is_string($data)) {
                                         return null;
                                     }
-                                    return 'data: ' . json_encode(self::formatLog(trim($data), $this->users));
+
+                                    $data = trim($data);
+                                    if ('' === $data) {
+                                        return null;
+                                    }
+
+                                    return 'data: ' . json_encode(['data' => $data]);
                                 },
                                 (array) preg_split("/\R/", $data),
                             ),
@@ -340,16 +365,27 @@ final class Index
     /**
      * Format log line.
      *
-     * @param string $line
+     * @param mixed $line
      * @param array $users
      *
      * @return array
      * @throws RandomException
      */
-    public static function formatLog(mixed $line, array $users = []): array
+    public static function formatLog(mixed $line, array $users = [], bool $allowStructured = true): array
     {
+        if (true === $allowStructured && is_array($line)) {
+            if (true === self::isJsonlLog($line)) {
+                return self::formatJsonlLog($line, $users);
+            }
+
+            if (1 === (int) ag($line, 'schema', 0)) {
+                return self::formatSchemaLog($line, $users);
+            }
+        }
+
         if (!is_string($line)) {
-            $line = json_encode($line);
+            $encoded = json_encode($line);
+            $line = false === $encoded ? '' : $encoded;
         }
 
         $line ??= '';
@@ -362,11 +398,122 @@ final class Index
                 'user' => null,
                 'backend' => null,
                 'date' => null,
+                'datetime' => null,
                 'level' => null,
+                'logger' => null,
                 'text' => $line,
+                'message' => null,
+                'fields' => [],
             ];
         }
 
+        $json = json_decode($line, true);
+        if (true === $allowStructured && is_array($json)) {
+            if (true === self::isJsonlLog($json)) {
+                return self::formatJsonlLog($json, $users);
+            }
+
+            if (1 === (int) ag($json, 'schema', 0)) {
+                return self::formatSchemaLog($json, $users);
+            }
+        }
+
+        return self::formatLegacyLog($line, $users);
+    }
+
+    private static function isJsonlLog(array $line): bool
+    {
+        foreach (['id', 'datetime', 'level', 'message'] as $key) {
+            if (false === array_key_exists($key, $line)) {
+                return false;
+            }
+        }
+
+        return array_key_exists('logger', $line) || array_key_exists('channel', $line);
+    }
+
+    /**
+     * @throws RandomException
+     */
+    private static function formatJsonlLog(array $line, array $users): array
+    {
+        $fields = ag($line, 'fields', []);
+        if (false === is_array($fields)) {
+            $fields = [];
+        }
+
+        $text = (string) ag($line, 'message', '');
+        $legacy = self::formatLegacyLog($text, $users);
+
+        $eventId = ag($fields, ['event_id', 'event.id', 'attributes.event.id'], ag($legacy, 'event_id'));
+        $itemId = ag($fields, ['item_id', 'item.id', 'attributes.item.id'], ag($legacy, 'item_id'));
+        $user = ag($fields, ['user', 'user.name', 'attributes.user.name'], ag($legacy, 'user'));
+        $backend = ag($fields, ['backend', 'backend.name', 'attributes.backend.name', 'via'], ag($legacy, 'backend'));
+
+        $fallbackId = static fn() => md5((string) json_encode($line) . (hrtime(true) + random_int(1, 10_000)));
+
+        return [
+            'id' => (string) ag($line, 'id', $fallbackId),
+            'item_id' => null === $itemId ? null : (string) $itemId,
+            'event_id' => null === $eventId ? null : (string) $eventId,
+            'user' => null === $user ? null : (string) $user,
+            'backend' => null === $backend ? null : (string) $backend,
+            'date' => ag($line, 'datetime'),
+            'datetime' => ag($line, 'datetime'),
+            'level' => ag($line, 'level'),
+            'logger' => ag($line, ['logger', 'channel']),
+            'text' => $text,
+            'message' => $text,
+            'fields' => $fields,
+            'source' => ag($line, 'source', []),
+        ];
+    }
+
+    /**
+     * @throws RandomException
+     */
+    private static function formatSchemaLog(array $line, array $users): array
+    {
+        $context = ag($line, 'context', []);
+        if (false === is_array($context)) {
+            $context = [];
+        }
+
+        $extras = ag($line, 'extras', []);
+        if (false === is_array($extras)) {
+            $extras = [];
+        }
+
+        $text = (string) ag($line, 'text', ag($line, 'message', ''));
+        $legacy = self::formatLegacyLog($text, $users);
+        $fallbackId = static fn() => md5((string) json_encode($line) . (hrtime(true) + random_int(1, 10_000)));
+        $itemId = ag($extras, 'item_id', ag($legacy, 'item_id'));
+        $eventId = ag($extras, 'event_id', ag($legacy, 'event_id'));
+        $user = ag($extras, 'user', ag($legacy, 'user'));
+        $backend = ag($extras, 'backend', ag($legacy, 'backend'));
+
+        return [
+            'id' => (string) ag($line, 'id', $fallbackId),
+            'item_id' => null === $itemId ? null : (string) $itemId,
+            'event_id' => null === $eventId ? null : (string) $eventId,
+            'user' => null === $user ? null : (string) $user,
+            'backend' => null === $backend ? null : (string) $backend,
+            'date' => ag($line, 'datetime'),
+            'datetime' => ag($line, 'datetime'),
+            'level' => ag($line, 'level'),
+            'logger' => ag($line, ['logger', 'channel']),
+            'text' => $text,
+            'message' => ag($line, 'message'),
+            'fields' => array_replace($context, $extras),
+            'source' => ag($extras, 'source'),
+        ];
+    }
+
+    /**
+     * @throws RandomException
+     */
+    private static function formatLegacyLog(string $line, array $users): array
+    {
         $dateRegex = '/^\[([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]+)?[+-][0-9]{2}:[0-9]{2})]/i';
         $eventRegex = '/\[event:(?<event_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})]\s*/i';
         $levelRegex = '/^(?:[a-z0-9_.-]+\.)?(?<level>EMERGENCY|ALERT|CRITICAL|ERROR|WARNING|NOTICE|INFO|DEBUG):\s*/i';
@@ -389,8 +536,12 @@ final class Index
             'user' => null,
             'backend' => null,
             'date' => 1 === $dateMatch ? $matches[1] : null,
+            'datetime' => 1 === $dateMatch ? $matches[1] : null,
             'level' => 1 === $levelMatch ? strtolower($levelMatches['level']) : null,
+            'logger' => null,
             'text' => $text,
+            'message' => null,
+            'fields' => [],
         ];
 
         if (1 === $idMatch) {

--- a/src/API/Logs/Index.php
+++ b/src/API/Logs/Index.php
@@ -32,12 +32,10 @@ final class Index
     private const int MAX_LIMIT = 100;
 
     private int $counter = 1;
-    private array $users = [];
     private array $logsDir = [];
 
     public function __construct(iImport $mapper, iLogger $logger)
     {
-        $this->users = array_keys(get_users_context(mapper: $mapper, logger: $logger));
         $this->logsDir = [
             [
                 'path' => fix_path(Config::get('tmpDir') . '/logs'),

--- a/src/API/Player/Playlist.php
+++ b/src/API/Player/Playlist.php
@@ -213,7 +213,19 @@ readonly class Playlist
                 'Access-Control-Max-Age' => 300,
             ]);
         } catch (Throwable $e) {
-            $this->logger->error($e->getMessage(), ['trace' => $e->getTrace()]);
+            $this->logger->error("Failed to build playback playlist for '{media.path}'.", [
+                'event_name' => 'player.playlist.build_failed',
+                'subsystem' => 'player.playlist',
+                'operation' => 'build',
+                'outcome' => 'failed',
+                'media' => [
+                    'path' => $path,
+                ],
+                'player' => [
+                    'token' => $token,
+                ],
+                ...exception_log($e),
+            ]);
             return api_error($e->getMessage(), Status::INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/API/Player/Segments.php
+++ b/src/API/Player/Segments.php
@@ -379,16 +379,17 @@ readonly class Segments
 
             return $response;
         } catch (Throwable $e) {
-            $this->logger->error("Failed to generate segment. '{error}' at {file}:{line}", [
+            $this->logger->error('Failed to generate player segment.', [
+                'event_name' => 'player.segment.generate_failed',
+                'subsystem' => 'player.segment',
+                'operation' => 'generate',
+                'outcome' => 'failed',
                 'stdout' => isset($process) ? $process->getOutput() : null,
                 'stderr' => isset($process) ? $process->getErrorOutput() : null,
                 'Ffmpeg' => $this->cmdLog($cmd),
                 'config' => $sConfig,
                 'command' => implode(' ', $cmd),
-                'error' => $e->getMessage(),
-                'line' => $e->getLine(),
-                'file' => $e->getFile(),
-                'trace' => $e->getTrace(),
+                ...exception_log($e),
             ]);
 
             $response = api_error('Failed to generate segment. check logs.', Status::INTERNAL_SERVER_ERROR);
@@ -467,14 +468,15 @@ readonly class Segments
             $stream->close();
             return $cacheFile;
         } catch (Throwable $e) {
-            $this->logger->error("Failed to extract subtitles. '{error}' at {file}:{line}", [
+            $this->logger->error('Failed to extract subtitle stream.', [
+                'event_name' => 'player.subtitle.extract_failed',
+                'subsystem' => 'player.subtitle',
+                'operation' => 'extract',
+                'outcome' => 'failed',
                 'stdout' => isset($process) ? $process->getOutput() : null,
                 'stderr' => isset($process) ? $process->getErrorOutput() : null,
                 'Ffmpeg' => $this->cmdLog($cmd),
-                'error' => $e->getMessage(),
-                'line' => $e->getLine(),
-                'file' => $e->getFile(),
-                'trace' => $e->getTrace(),
+                ...exception_log($e),
             ]);
             return "{$path}:stream_index={$stream}";
         }

--- a/src/API/Player/Subtitle.php
+++ b/src/API/Player/Subtitle.php
@@ -177,7 +177,21 @@ final readonly class Subtitle
                 'X-Cache' => $response->getHeaderLine('X-Cache'),
             ]);
         } catch (Throwable $e) {
-            $this->logger->error($e->getMessage(), $e->getTrace());
+            $this->logger->error("Failed to return subtitle response for '{media.path}'.", [
+                'event_name' => 'player.subtitle.response_failed',
+                'subsystem' => 'player.subtitle',
+                'operation' => 'respond',
+                'outcome' => 'failed',
+                'media' => [
+                    'path' => $path,
+                ],
+                'subtitle' => [
+                    'source' => $source,
+                    'index' => (int) $index,
+                    'format' => $type,
+                ],
+                ...exception_log($e),
+            ]);
             return api_error($e->getMessage(), Status::INTERNAL_SERVER_ERROR);
         }
     }
@@ -247,6 +261,20 @@ final readonly class Subtitle
                     );
                 }
             } catch (RuntimeException|JsonException $e) {
+                $this->logger->error("Failed to inspect subtitle stream {subtitle.stream} for '{media.path}'.", [
+                    'event_name' => 'player.subtitle.inspect_failed',
+                    'subsystem' => 'player.subtitle',
+                    'operation' => 'inspect',
+                    'outcome' => 'failed',
+                    'media' => [
+                        'path' => $file,
+                    ],
+                    'subtitle' => [
+                        'stream' => $stream,
+                        'format' => $type,
+                    ],
+                    ...exception_log($e),
+                ]);
                 return api_error($e->getMessage(), Status::INTERNAL_SERVER_ERROR);
             }
         }
@@ -278,6 +306,30 @@ final readonly class Subtitle
             $process->wait();
 
             if (!$process->isSuccessful()) {
+                $this->logger->error(
+                    null !== $stream
+                        ? "Failed to extract subtitle stream {subtitle.stream} from '{media.path}'."
+                        : "Failed to convert subtitle for '{media.path}'.",
+                    [
+                        'event_name' => null !== $stream ? 'player.subtitle.extract_failed' : 'player.subtitle.convert_failed',
+                        'subsystem' => 'player.subtitle',
+                        'operation' => null !== $stream ? 'extract' : 'convert',
+                        'outcome' => 'failed',
+                        'media' => [
+                            'path' => $file,
+                        ],
+                        'subtitle' => [
+                            'stream' => $stream,
+                            'format' => $type,
+                        ],
+                        'transcode' => [
+                            'command' => $process->getCommandLine(),
+                            'stderr' => $process->getErrorOutput(),
+                            'stdout' => $process->getOutput(),
+                        ],
+                    ],
+                );
+
                 if (true === $debug) {
                     return api_error($process->getErrorOutput(), Status::INTERNAL_SERVER_ERROR, headers: [
                         'X-FFmpeg' => $process->getCommandLine(),
@@ -317,6 +369,25 @@ final readonly class Subtitle
                 'X-Cache' => 'miss',
             ]);
         } catch (Throwable $e) {
+            $this->logger->error(
+                null !== $stream
+                    ? "Failed to extract subtitle stream {subtitle.stream} from '{media.path}'."
+                    : "Failed to convert subtitle for '{media.path}'.",
+                [
+                    'event_name' => null !== $stream ? 'player.subtitle.extract_failed' : 'player.subtitle.convert_failed',
+                    'subsystem' => 'player.subtitle',
+                    'operation' => null !== $stream ? 'extract' : 'convert',
+                    'outcome' => 'failed',
+                    'media' => [
+                        'path' => $file,
+                    ],
+                    'subtitle' => [
+                        'stream' => $stream,
+                        'format' => $type,
+                    ],
+                    ...exception_log($e),
+                ],
+            );
             return api_error($e->getMessage(), Status::INTERNAL_SERVER_ERROR);
         } finally {
             if (file_exists($tmpFile) && is_link($tmpFile)) {

--- a/src/API/System/Command.php
+++ b/src/API/System/Command.php
@@ -39,7 +39,7 @@ final class Command
     private const string REQUEST_FILE = 'request.json';
     private const string STATE_FILE = 'state.json';
     private const string STATE_LOCK_FILE = 'state.lock';
-    private const string STREAM_FILE = 'stream.log';
+    private const string STREAM_FILE = 'stream.jsonl';
     private const string WRITER_LOCK_FILE = 'writer.lock';
     private const string CANCEL_FILE = 'cancel.flag';
 

--- a/src/API/System/Events.php
+++ b/src/API/System/Events.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\API\System;
 
-use App\API\Logs\Index as LogsIndex;
 use App\Libs\Attributes\Route\Delete;
 use App\Libs\Attributes\Route\Get;
 use App\Libs\Attributes\Route\Patch;
@@ -12,12 +11,14 @@ use App\Libs\Attributes\Route\Post;
 use App\Libs\Database\DBLayer;
 use App\Libs\DataUtil;
 use App\Libs\Enums\Http\Status;
+use App\Libs\Extends\JsonlFormatter;
 use App\Libs\Options;
 use App\Model\Events\Event as EntityItem;
 use App\Model\Events\EventsRepository;
 use App\Model\Events\EventsTable as EntityTable;
 use App\Model\Events\EventStatus;
 use InvalidArgumentException;
+use Monolog\Level;
 use Psr\Http\Message\ResponseInterface as iResponse;
 use Psr\Http\Message\ServerRequestInterface as iRequest;
 
@@ -298,7 +299,15 @@ final readonly class Events
 
         if ($changed) {
             $entity->updated_at = (string) make_date();
-            $entity->logs[] = 'Event was manually updated';
+            $entity->logs[] = new JsonlFormatter()->formatValues(
+                channel: 'event',
+                level: Level::Info,
+                message: 'Event was manually updated',
+                context: [
+                    'event_id' => (string) $entity->id,
+                    'event' => $entity->event,
+                ],
+            );
             $this->repo->save($entity);
         }
 
@@ -310,10 +319,6 @@ final readonly class Events
         $data = $entity->getAll();
         $data['status_name'] = $entity->getStatusText();
         $data['display_id'] = substr(str_replace('-', '', (string) $entity->id), 0, 12);
-
-        if (is_array($entity->logs) && count($entity->logs) > 0) {
-            $data['logs'] = array_map(LogsIndex::formatLog(...), $entity->logs);
-        }
 
         if ($delay = ag($entity->options, Options::DELAY_BY)) {
             $data['delay_by'] = $delay;

--- a/src/API/System/Events.php
+++ b/src/API/System/Events.php
@@ -302,10 +302,18 @@ final readonly class Events
             $entity->logs[] = new JsonlFormatter()->formatValues(
                 channel: 'event',
                 level: Level::Info,
-                message: 'Event was manually updated',
+                message: r("Event '{queued_event}' was manually updated to {status}.", [
+                    'queued_event' => $entity->event,
+                    'status' => strtolower($entity->status->name),
+                ]),
                 context: [
                     'event_id' => (string) $entity->id,
-                    'event' => $entity->event,
+                    'queued_event' => $entity->event,
+                    'status' => strtolower($entity->status->name),
+                    'event_name' => 'events.manual_update',
+                    'subsystem' => 'events',
+                    'operation' => 'manual_update',
+                    'outcome' => 'completed',
                 ],
             );
             $this->repo->save($entity);

--- a/src/Backends/Common/CommonTrait.php
+++ b/src/Backends/Common/CommonTrait.php
@@ -7,6 +7,7 @@ namespace App\Backends\Common;
 use App\Libs\Container;
 use App\Libs\Options;
 use DateInterval;
+use JsonException;
 use Psr\Log\LoggerInterface as iLogger;
 use Throwable;
 
@@ -38,7 +39,7 @@ trait CommonTrait
                 status: false,
                 error: new Error(
                     ...lw(
-                        message: "{client} request failed for '{backend}' during {action}.",
+                        message: "{client} request failed for '{backend}' during {action}. {error.message}",
                         context: [
                             'event_name' => 'backend.client.request_failed',
                             'subsystem' => 'backend.client',
@@ -76,9 +77,9 @@ trait CommonTrait
         DateInterval $ttl,
         ?iLogger $logger = null,
     ): mixed {
+        $cache = $context->cache->getInterface();
+        $cacheKey = $context->backendName . '_' . $key;
         try {
-            $cache = $context->cache->getInterface();
-            $cacheKey = $context->backendName . '_' . $key;
             if (true === ag_exists($context->options, Options::PLEX_USER_PIN)) {
                 $cacheKey .= '_with_pin';
             }
@@ -122,5 +123,73 @@ trait CommonTrait
     protected function getLogger(): iLogger
     {
         return Container::get(iLogger::class);
+    }
+
+    /**
+     * Extract a short backend-provided reason from an HTTP response body.
+     *
+     * @param string|null $body HTTP response body.
+     * @param int $limit Maximum characters to expose.
+     *
+     * @return string|null The extracted reason if available.
+     */
+    protected function getBackendResponseReason(?string $body, int $limit = 500): ?string
+    {
+        if ('' === ($body = trim((string) $body))) {
+            return null;
+        }
+
+        try {
+            $json = json_decode($body, true, flags: JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_IGNORE);
+
+            if (is_array($json)) {
+                $reason = ag($json, [
+                    'message',
+                    'Message',
+                    'error.message',
+                    'error',
+                    'Error',
+                    'errors.0.message',
+                    'errors.0.title',
+                ]);
+
+                if (is_scalar($reason) && '' !== trim((string) $reason)) {
+                    return trim((string) $reason);
+                }
+            }
+        } catch (JsonException) {
+            // -- fallback for non-json responses, do nothing and try other methods.
+        }
+
+        if (false !== ($xml = @simplexml_load_string($body))) {
+            $xmlData = json_decode(json_encode($xml, JSON_INVALID_UTF8_IGNORE), true);
+
+            if (is_array($xmlData)) {
+                $reason = ag($xmlData, [
+                    'error',
+                    'errors.error',
+                    'message',
+                    'Message',
+                ]);
+
+                if (is_array($reason)) {
+                    $reason = array_shift($reason);
+                }
+
+                if (is_scalar($reason) && '' !== trim((string) $reason)) {
+                    return trim((string) $reason);
+                }
+            }
+        }
+
+        if ('' === ($reason = trim(strip_tags($body)))) {
+            return null;
+        }
+
+        if (strlen($reason) > $limit) {
+            return substr($reason, 0, $limit) . '...';
+        }
+
+        return $reason;
     }
 }

--- a/src/Backends/Common/CommonTrait.php
+++ b/src/Backends/Common/CommonTrait.php
@@ -38,25 +38,16 @@ trait CommonTrait
                 status: false,
                 error: new Error(
                     ...lw(
-                        message: "{client}: '{backend}' {action} thrown unhandled exception '{error.kind}'. '{error.message}' at '{error.file}:{error.line}'.",
+                        message: "{client} request failed for '{backend}' during {action}.",
                         context: [
+                            'event_name' => 'backend.client.request_failed',
+                            'subsystem' => 'backend.client',
+                            'operation' => $action ?? 'request',
+                            'outcome' => 'failed',
                             'action' => $action ?? '',
                             'backend' => $context->backendName,
                             'client' => $context->clientName,
-                            'message' => $e->getMessage(),
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
-                            'exception' => [
-                                'file' => $e->getFile(),
-                                'line' => $e->getLine(),
-                                'kind' => get_class($e),
-                                'message' => $e->getMessage(),
-                                'trace' => $e->getTrace(),
-                            ],
+                            ...exception_log($e),
                         ],
                         e: $e,
                     ),

--- a/src/Backends/Emby/Action/ParseWebhook.php
+++ b/src/Backends/Emby/Action/ParseWebhook.php
@@ -124,7 +124,7 @@ final class ParseWebhook
             return new Response(status: false, extra: [
                 'http_code' => Status::BAD_REQUEST->value,
                 'message' => r(
-                    text: "Ignoring '{client}: {user}@{backend}' request. Invalid request, no payload.",
+                    text: "Ignoring backend request from '{user}@{backend}': payload is missing.",
                     context: $logContext,
                 ),
             ]);
@@ -271,8 +271,13 @@ final class ParseWebhook
                 return new Response(
                     status: false,
                     error: new Error(
-                        message: "{action}: Ignoring '{client}: {user}@{backend}' - '{title}' webhook event. No valid/supported external ids.",
+                        message: "Ignoring webhook item '{title}' from '{user}@{backend}': no supported GUIDs were found.",
                         context: [
+                            'event_name' => 'backend.item.ignored',
+                            'subsystem' => 'backend.webhook',
+                            'operation' => 'parse_webhook',
+                            'outcome' => 'ignored',
+                            'reason' => 'missing_supported_guid',
                             'title' => $entity->getName(),
                             ...$logContext,
                             'context' => [
@@ -299,22 +304,14 @@ final class ParseWebhook
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' webhook event parsing. {error.message} at '{error.file}:{error.line}'.",
+                    message: "Failed to parse webhook event from '{user}@{backend}'.",
                     context: [
-                        'error' => [
-                            'kind' => $e::class,
-                            'line' => $e->getLine(),
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
+                        'event_name' => 'backend.operation.failed',
+                        'subsystem' => 'backend.webhook',
+                        'operation' => 'parse_webhook',
+                        'outcome' => 'failed',
                         ...$logContext,
-                        'exception' => [
-                            'file' => $e->getFile(),
-                            'line' => $e->getLine(),
-                            'kind' => get_class($e),
-                            'message' => $e->getMessage(),
-                            'trace' => $e->getTrace(),
-                        ],
+                        ...exception_log($e),
                         'context' => [
                             'attributes' => $request->getAttributes(),
                             'payload' => $request->getParsedBody(),

--- a/src/Backends/Emby/Action/Progress.php
+++ b/src/Backends/Emby/Action/Progress.php
@@ -129,16 +129,30 @@ class Progress
 
             if ($context->backendName === $entity->via) {
                 $this->logger->info(
-                    message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. Event originated from this backend.",
-                    context: $logContext,
+                    message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': event originated from this backend.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.progress',
+                        'operation' => 'prepare_progress_update',
+                        'outcome' => 'ignored',
+                        'reason' => 'origin_backend',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
 
             if (null === ag($metadata, iState::COLUMN_ID, null)) {
                 $this->logger->warning(
-                    message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. No metadata was found.",
-                    context: $logContext,
+                    message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': backend metadata is missing.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.progress',
+                        'operation' => 'load_remote_state',
+                        'outcome' => 'ignored',
+                        'reason' => 'missing_backend_metadata',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
@@ -146,8 +160,15 @@ class Progress
             $senderDate = ag($entity->getExtra($entity->via), iState::COLUMN_EXTRA_DATE);
             if (null === $senderDate) {
                 $this->logger->warning(
-                    message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. The event originator did not set a date.",
-                    context: $logContext,
+                    message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': sender event date is missing.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.progress',
+                        'operation' => 'prepare_progress_update',
+                        'outcome' => 'ignored',
+                        'reason' => 'missing_event_date',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
@@ -157,12 +178,18 @@ class Progress
             $datetime = ag($entity->getExtra($context->backendName), iState::COLUMN_EXTRA_DATE, null);
             if (false === $ignoreDate && null !== $datetime && make_date($datetime)->getTimestamp() > $senderDate) {
                 $this->logger->warning(
-                    message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. Event date '{event_date}' is older than backend local db item date '{local_date}'.",
+                    message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': event date is not newer than local backend history.",
                     context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.progress',
+                        'operation' => 'compare_dates',
+                        'outcome' => 'ignored',
+                        'reason' => 'date_not_newer_than_local_history',
                         ...$logContext,
-                        'event_date' => make_date($senderDate),
-                        'local_date' => make_date($datetime),
-                        'compare' => ['remote' => make_date($datetime), 'sender' => make_date($senderDate)],
+                        'comparison' => [
+                            'local' => make_date($datetime),
+                            'sender' => make_date($senderDate),
+                        ],
                     ],
                 );
                 continue;
@@ -171,9 +198,16 @@ class Progress
             $logContext['remote']['id'] = ag($metadata, iState::COLUMN_ID);
 
             if (array_key_exists($logContext['remote']['id'], $sessions)) {
-                $this->logger->notice(
-                    message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. The item is playing right now.",
-                    context: $logContext,
+                $this->logger->info(
+                    message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': item is active in another session.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.progress',
+                        'operation' => 'prepare_progress_update',
+                        'outcome' => 'ignored',
+                        'reason' => 'active_session',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
@@ -188,12 +222,15 @@ class Progress
 
                 if (false === $ignoreDate && make_date($remoteItem->updated)->getTimestamp() > $senderDate) {
                     $this->logger->info(
-                        message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. Event date '{event_date}' is older than backend remote item date '{remote_date}'.",
+                        message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': event date is not newer than backend state.",
                         context: [
+                            'event_name' => 'backend.item.ignored',
+                            'subsystem' => 'backend.progress',
+                            'operation' => 'compare_dates',
+                            'outcome' => 'ignored',
+                            'reason' => 'date_not_newer_than_remote_state',
                             ...$logContext,
-                            'event_date' => make_date($senderDate),
-                            'remote_date' => make_date($remoteItem->updated),
-                            'compare' => [
+                            'comparison' => [
                                 'remote' => make_date($remoteItem->updated),
                                 'sender' => make_date($senderDate),
                             ],
@@ -207,8 +244,15 @@ class Progress
                     $allowUpdate = (int) Config::get('progress.threshold', 0);
                     if (false === ($allowUpdate >= $minThreshold && time() > ($entity->updated + $allowUpdate))) {
                         $this->logger->info(
-                            message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. The backend says the item is marked as watched.",
-                            context: $logContext,
+                            message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': backend item is already watched.",
+                            context: [
+                                'event_name' => 'backend.item.ignored',
+                                'subsystem' => 'backend.progress',
+                                'operation' => 'update_progress',
+                                'outcome' => 'ignored',
+                                'reason' => 'remote_marked_watched',
+                                ...$logContext,
+                            ],
                         );
                         continue;
                     }
@@ -216,22 +260,14 @@ class Progress
             } catch (\App\Libs\Exceptions\RuntimeException|RuntimeException|InvalidArgumentException $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' get {item.type} '#{item.id}: {item.title}' status. '{error.message}' at '{error.file}:{error.line}'.",
+                        message: "Failed to load backend state for {item.type} '#{item.id}: {item.title}' from '{user}@{backend}'.",
                         context: [
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.progress',
+                            'operation' => 'load_remote_state',
+                            'outcome' => 'failed',
                             ...$logContext,
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
-                            'exception' => [
-                                'file' => $e->getFile(),
-                                'line' => $e->getLine(),
-                                'kind' => get_class($e),
-                                'message' => $e->getMessage(),
-                                'trace' => $e->getTrace(),
-                            ],
+                            ...exception_log($e),
                         ],
                         e: $e,
                     ),
@@ -250,8 +286,12 @@ class Progress
                 $logContext['remote']['url'] = (string) $url;
 
                 $this->logger->debug(
-                    message: "{action}: Updating '{client}: {user}@{backend}' {item.type} '{item.title}' watch progress to '{progress}'.",
+                    message: "Updating watch progress for {item.type} '{item.title}' on '{user}@{backend}'.",
                     context: [
+                        'event_name' => 'backend.request.started',
+                        'subsystem' => 'backend.progress',
+                        'operation' => 'update_progress',
+                        'outcome' => 'started',
                         ...$logContext,
                         'progress' => format_duration($progressValue),
                         // -- convert secs to ms for emby to understand it.
@@ -288,8 +328,12 @@ class Progress
 
                                 if (false === in_array(Status::tryFrom($statusCode), [Status::OK, Status::NO_CONTENT], true)) {
                                     $this->logger->error(
-                                        message: "{action}: Request to change '{client}: {user}@{backend}' {item.type} '{item.title}' watch progress returned with unexpected '{status_code}' status code.",
+                                        message: "Watch-progress update for {item.type} '{item.title}' on '{user}@{backend}' returned status {status_code}.",
                                         context: [
+                                            'event_name' => 'backend.response.failed',
+                                            'subsystem' => 'backend.progress',
+                                            'operation' => 'update_progress',
+                                            'outcome' => 'failed',
                                             ...$requestContext,
                                             'status_code' => $statusCode,
                                         ],
@@ -299,8 +343,12 @@ class Progress
                                 }
 
                                 $this->logger->notice(
-                                    message: "{action}: Updated '{client}: {user}@{backend}' '{item.title}' watch progress to '{progress}'.",
+                                    message: "Updated watch progress for '{item.title}' on '{user}@{backend}'.",
                                     context: [
+                                        'event_name' => 'backend.state_update.completed',
+                                        'subsystem' => 'backend.progress',
+                                        'operation' => 'update_progress',
+                                        'outcome' => 'completed',
                                         ...$requestContext,
                                         'status_code' => $statusCode,
                                     ],
@@ -311,8 +359,12 @@ class Progress
                             error: function (Throwable $e) use ($requestContext): array {
                                 $this->logger->error(
                                     ...lw(
-                                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request to change watch progress of {item.type} '{item.title}'. '{error.message}' at '{error.file}:{error.line}'.",
+                                        message: "Watch-progress request failed for {item.type} '{item.title}' on '{user}@{backend}'.",
                                         context: [
+                                            'event_name' => 'backend.client.request_failed',
+                                            'subsystem' => 'backend.progress',
+                                            'operation' => 'update_progress',
+                                            'outcome' => 'failed',
                                             ...$requestContext,
                                             ...exception_log($e),
                                         ],
@@ -332,22 +384,14 @@ class Progress
             } catch (Throwable $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' change {item.type} '{item.title}' watch progress. '{error.message}' at '{error.file}:{error.line}'.",
+                        message: "Failed to prepare watch-progress update for {item.type} '{item.title}' on '{user}@{backend}'.",
                         context: [
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.progress',
+                            'operation' => 'prepare_progress_update',
+                            'outcome' => 'failed',
                             ...$logContext,
-                            'exception' => [
-                                'file' => $e->getFile(),
-                                'line' => $e->getLine(),
-                                'kind' => get_class($e),
-                                'message' => $e->getMessage(),
-                                'trace' => $e->getTrace(),
-                            ],
+                            ...exception_log($e),
                         ],
                         e: $e,
                     ),

--- a/src/Backends/Emby/EmbyClient.php
+++ b/src/Backends/Emby/EmbyClient.php
@@ -804,7 +804,7 @@ class EmbyClient implements iClient
             message: ag(
                 $response->extra,
                 'message',
-                static fn() => $response->error?->format() ?? 'An unexpected error occurred.',
+                static fn() => $response->error?->format() ?? 'The backend request failed.',
             ),
             code: $code,
             previous: $response->error?->previous,

--- a/src/Backends/Emby/EmbyClient.php
+++ b/src/Backends/Emby/EmbyClient.php
@@ -800,12 +800,28 @@ class EmbyClient implements iClient
      */
     private function throwError(Response $response, string $className = RuntimeException::class, int $code = 0): void
     {
+        $message = ag($response->extra, 'message', null);
+
+        if (null === $message && null !== $response->error) {
+            $message = ag($response->error->extra, 'message', null);
+        }
+
+        if (!is_string($message) || '' === trim($message)) {
+            $message = $response->error?->format() ?? 'The backend request failed.';
+        }
+
+        $reason = ag($response->extra, 'error', null);
+
+        if (null === $reason && null !== $response->error) {
+            $reason = ag($response->error->extra, 'error', null);
+        }
+
+        if (is_string($reason) && '' !== trim($reason) && false === str_contains($message, $reason)) {
+            $message = trim($message . ' ' . $reason);
+        }
+
         throw new $className(
-            message: ag(
-                $response->extra,
-                'message',
-                static fn() => $response->error?->format() ?? 'The backend request failed.',
-            ),
+            message: $message,
             code: $code,
             previous: $response->error?->previous,
         );

--- a/src/Backends/Jellyfin/Action/Backup.php
+++ b/src/Backends/Jellyfin/Action/Backup.php
@@ -61,8 +61,12 @@ class Backup extends Import
 
         try {
             if ($context->trace) {
-                $this->logger->debug("{action}: Processing '{client}: {user}@{backend}' payload.", [
+                $this->logger->debug("Processing backup payload from '{user}@{backend}'.", [
                     ...$logContext,
+                    'event_name' => 'backend.response.processing',
+                    'subsystem' => 'backend.backup',
+                    'operation' => 'process_item',
+                    'outcome' => 'started',
                     'response' => ['body' => $item],
                 ]);
             }
@@ -89,10 +93,16 @@ class Backup extends Import
                     },
                     'type' => $type,
                 ];
-            } catch (InvalidArgumentException $e) {
-                $this->logger->info($e->getMessage(), [
+            } catch (InvalidArgumentException) {
+                $this->logger->info("Skipping Jellyfin backup item: unsupported content type '{item_type}'.", [
                     ...$logContext,
-                    'body' => $item,
+                    'event_name' => 'backend.item.ignored',
+                    'subsystem' => 'backend.backup',
+                    'operation' => 'process_item',
+                    'outcome' => 'ignored',
+                    'reason' => 'unsupported_type',
+                    'item_type' => $type,
+                    'response' => ['body' => $item],
                 ]);
                 return;
             }
@@ -174,22 +184,14 @@ class Backup extends Import
             }
         } catch (Throwable $e) {
             $this->logger->error(
-                message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' backup. {error.message} at '{error.file}:{error.line}'.",
+                message: "Failed to back up {item.type} '{item.title}' from '{user}@{backend}'.",
                 context: [
-                    'error' => [
-                        'kind' => $e::class,
-                        'line' => $e->getLine(),
-                        'message' => $e->getMessage(),
-                        'file' => after($e->getFile(), ROOT_PATH),
-                    ],
+                    'event_name' => 'backend.operation.failed',
+                    'subsystem' => 'backend.backup',
+                    'operation' => 'process_item',
+                    'outcome' => 'failed',
                     ...$logContext,
-                    'exception' => [
-                        'file' => $e->getFile(),
-                        'line' => $e->getLine(),
-                        'kind' => get_class($e),
-                        'message' => $e->getMessage(),
-                        'trace' => $e->getTrace(),
-                    ],
+                    ...exception_log($e),
                 ],
             );
         }

--- a/src/Backends/Jellyfin/Action/CreatePlaylist.php
+++ b/src/Backends/Jellyfin/Action/CreatePlaylist.php
@@ -68,6 +68,18 @@ class CreatePlaylist
             'url' => (string) $url,
         ];
 
+        $this->logger->debug(
+            message: "Creating playlist '{title}' on '{user}@{backend}'.",
+            context: [
+                ...$logContext,
+                'event_name' => 'backend.request.started',
+                'subsystem' => 'backend.playlist',
+                'operation' => 'create',
+                'outcome' => 'started',
+                'http' => ['method' => Method::POST->value, 'url' => (string) $url],
+            ],
+        );
+
         $response = $this->http->request(
             Method::POST,
             (string) $url,
@@ -78,8 +90,21 @@ class CreatePlaylist
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Request for '{client}: {user}@{backend}' playlist '{title}' returned with unexpected '{status_code}' status code.",
-                    context: [...$logContext, 'status_code' => $response->getStatusCode()],
+                    message: "Create playlist request for '{title}' on '{user}@{backend}' returned status {http.status_code}.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.playlist',
+                        'operation' => 'create',
+                        'outcome' => 'failed',
+                        'reason' => 'unexpected_status',
+                        'http' => [
+                            'method' => Method::POST->value,
+                            'status_code' => $response->getStatusCode(),
+                            'expected_status_codes' => [Status::OK->value],
+                            'url' => (string) $url,
+                        ],
+                    ],
                     level: Levels::ERROR,
                 ),
             );

--- a/src/Backends/Jellyfin/Action/DeletePlaylist.php
+++ b/src/Backends/Jellyfin/Action/DeletePlaylist.php
@@ -64,14 +64,39 @@ class DeletePlaylist
             'url' => (string) $url,
         ];
 
+        $this->logger->debug(
+            message: "Deleting playlist '{id}' from '{user}@{backend}'.",
+            context: [
+                ...$logContext,
+                'event_name' => 'backend.request.started',
+                'subsystem' => 'backend.playlist',
+                'operation' => 'delete',
+                'outcome' => 'started',
+                'http' => ['method' => Method::DELETE->value, 'url' => (string) $url],
+            ],
+        );
+
         $response = $this->http->request(Method::DELETE, (string) $url, $context->getHttpOptions());
 
         if (false === in_array(Status::tryFrom($response->getStatusCode()), $this->getExpectedStatuses(), true)) {
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Request for '{client}: {user}@{backend}' playlist '{id}' returned with unexpected '{status_code}' status code.",
-                    context: [...$logContext, 'status_code' => $response->getStatusCode()],
+                    message: "Delete playlist request for '{id}' on '{user}@{backend}' returned status {http.status_code}.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.playlist',
+                        'operation' => 'delete',
+                        'outcome' => 'failed',
+                        'reason' => 'unexpected_status',
+                        'http' => [
+                            'method' => Method::DELETE->value,
+                            'status_code' => $response->getStatusCode(),
+                            'expected_status_codes' => array_map(static fn(Status $status) => $status->value, $this->getExpectedStatuses()),
+                            'url' => (string) $url,
+                        ],
+                    ],
                     level: Levels::ERROR,
                 ),
             );

--- a/src/Backends/Jellyfin/Action/Export.php
+++ b/src/Backends/Jellyfin/Action/Export.php
@@ -51,10 +51,12 @@ class Export extends Import
         array $logContext = [],
         array $opts = [],
     ): void {
-        $logContext['action'] = $this->action;
-        $logContext['client'] = $context->clientName;
-        $logContext['backend'] = $context->backendName;
-        $logContext['user'] = $context->userContext->name;
+        $logContext = array_replace_recursive([
+            'action' => $this->action,
+            'client' => $context->clientName,
+            'backend' => $context->backendName,
+            'user' => $context->userContext->name,
+        ], $logContext);
 
         if (JFC::TYPE_SHOW === ($type = ag($item, 'Type'))) {
             $this->processShow(context: $context, guid: $guid, item: $item, logContext: $logContext);
@@ -65,10 +67,17 @@ class Export extends Import
 
         try {
             if ($context->trace) {
-                $this->logger->debug("{action}: Processing '{client}: {user}@{backend}' response payload.", [
-                    ...$logContext,
-                    'response' => ['body' => $item],
-                ]);
+                $this->logger->debug(
+                    message: "Processing export payload from '{user}@{backend}'.",
+                    context: [
+                        'event_name' => 'backend.response.received',
+                        'subsystem' => 'backend.export',
+                        'operation' => 'process_item',
+                        'outcome' => 'received',
+                        ...$logContext,
+                        'response' => ['body' => $item],
+                    ],
+                );
             }
 
             $queue = ag($opts, 'queue', static fn() => Container::get(QueueRequests::class));
@@ -96,12 +105,17 @@ class Export extends Import
                     'type' => $type,
                 ];
             } catch (InvalidArgumentException $e) {
-                $this->logger->info(
+                $this->logger->error(
                     ...lw(
-                        message: $e->getMessage(),
+                        message: "Failed to parse export item response from '{user}@{backend}'.",
                         context: [
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.export',
+                            'operation' => 'parse_item',
+                            'outcome' => 'failed',
                             ...$logContext,
                             'response' => ['body' => $item],
+                            ...exception_log($e),
                         ],
                         e: $e,
                     ),
@@ -114,8 +128,13 @@ class Export extends Import
 
             if (null === ag($item, $dateKey)) {
                 $this->logger->debug(
-                    message: "{action}: Ignoring '{client}: {user}@{backend}' {item.type} '{item.title}'. No date is set on object.",
+                    message: "Ignoring {item.type} '{item.title}' from '{user}@{backend}': missing date '{date_key}'.",
                     context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.export',
+                        'operation' => 'process_item',
+                        'outcome' => 'ignored',
+                        'reason' => 'missing_date',
                         'date_key' => $dateKey,
                         ...$logContext,
                         'response' => [
@@ -138,18 +157,24 @@ class Export extends Import
             if (!$rItem->hasGuids() && !$rItem->hasRelativeGuid()) {
                 $providerIds = (array) ag($item, 'ProviderIds', []);
 
-                $message = "{action}: Ignoring '{client}: {user}@{backend}' - '{item.title}'. No valid/supported external ids.";
+                $message = "Ignoring {item.type} '{item.title}' from '{user}@{backend}': no supported external IDs.";
 
                 if (empty($providerIds)) {
                     $message .= ' Most likely unmatched {item.type}.';
                 }
 
-                $this->logger->info($message, [
-                    ...$logContext,
-                    'context' => [
+                $this->logger->info(
+                    message: $message,
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.export',
+                        'operation' => 'create_entity',
+                        'outcome' => 'ignored',
+                        'reason' => 'missing_supported_guid',
+                        ...$logContext,
                         'guids' => !empty($providerIds) ? $providerIds : 'None',
                     ],
-                ]);
+                );
 
                 Message::increment("{$context->backendName}.{$mappedType}.ignored_no_supported_guid");
                 return;
@@ -158,8 +183,13 @@ class Export extends Import
             if (false === ag($context->options, Options::IGNORE_DATE, false)) {
                 if (true === $after instanceof DateTimeInterface && $rItem->updated >= $after->getTimestamp()) {
                     $this->logger->debug(
-                        message: "{action}: Ignoring '{client}: {user}@{backend}' - '{item.title}'. Backend date is equal or newer than last sync date.",
+                        message: "Ignoring {item.type} '{item.title}' from '{user}@{backend}': backend date is not newer than last sync date.",
                         context: [
+                            'event_name' => 'backend.item.ignored',
+                            'subsystem' => 'backend.export',
+                            'operation' => 'compare_dates',
+                            'outcome' => 'ignored',
+                            'reason' => 'date_not_newer_than_last_sync',
                             ...$logContext,
                             'comparison' => [
                                 'lastSync' => make_date($after),
@@ -174,9 +204,23 @@ class Export extends Import
             }
 
             if (null === ($entity = $mapper->get($rItem))) {
+                $metadataOnly = true === (bool) ag($context->options, Options::IMPORT_METADATA_ONLY);
+                $message = "Ignoring {item.type} '{item.title}' from '{user}@{backend}': item is not imported yet.";
+                if (true === $metadataOnly) {
+                    $message .= ' Backend is configured as metadata-only.';
+                }
+
                 $this->logger->info(
-                    message: "{action}: Ignoring '{client}: {user}@{backend}' - '{item.title}'. {item.type} Is not imported yet. Possibly because the backend was imported as metadata only.",
-                    context: $logContext,
+                    message: $message,
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.export',
+                        'operation' => 'load_local_state',
+                        'outcome' => 'ignored',
+                        'reason' => 'missing_local_state',
+                        ...$logContext,
+                        'metadata_only' => $metadataOnly,
+                    ],
                 );
                 Message::increment("{$context->backendName}.{$mappedType}.ignored_not_found_in_db");
                 return;
@@ -185,9 +229,15 @@ class Export extends Import
             if ($rItem->watched === $entity->watched) {
                 if (true === (bool) ag($context->options, Options::DEBUG_TRACE)) {
                     $this->logger->debug(
-                        message: "{action}: Ignoring '{client}: {user}@{backend}' - '{item.title}'. {item.type} play state is identical.",
+                        message: "Ignoring {item.type} '{item.title}' from '{user}@{backend}': play state is unchanged.",
                         context: [
+                            'event_name' => 'backend.item.ignored',
+                            'subsystem' => 'backend.export',
+                            'operation' => 'compare_state',
+                            'outcome' => 'ignored',
+                            'reason' => 'state_unchanged',
                             ...$logContext,
+                            'play_state' => $rItem->isWatched() ? 'Played' : 'Unplayed',
                             'comparison' => [
                                 'backend' => $entity->isWatched() ? 'Played' : 'Unplayed',
                                 'remote' => $rItem->isWatched() ? 'Played' : 'Unplayed',
@@ -202,8 +252,13 @@ class Export extends Import
 
             if ($rItem->updated >= $entity->updated && false === ag($context->options, Options::IGNORE_DATE, false)) {
                 $this->logger->debug(
-                    message: "{action}: Ignoring '{client}: {user}@{backend}' - '{item.title}'. Backend date is equal or newer than database date.",
+                    message: "Ignoring {item.type} '{item.title}' from '{user}@{backend}': backend date is not newer than local history date.",
                     context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.export',
+                        'operation' => 'compare_dates',
+                        'outcome' => 'ignored',
+                        'reason' => 'date_not_newer_than_local_history',
                         ...$logContext,
                         'comparison' => [
                             'database' => make_date($entity->updated),
@@ -227,20 +282,38 @@ class Export extends Import
                 $url = $url->withQuery(http_build_query(['DatePlayed' => $lastPlayed]));
             }
 
-            $logContext['item']['url'] = $url;
+            $logContext['item']['url'] = (string) $url;
 
             Message::increment("{$context->userContext->name}.{$context->backendName}.export");
 
             $playState = $entity->isWatched() ? 'Played' : 'Unplayed';
-            $requestContext = $logContext + ['backend' => $context->backendName, 'play_state' => $playState];
+            $requestContext = [...$logContext, 'play_state' => $playState];
 
             if (true === (bool) ag($context->options, Options::DRY_RUN, false)) {
                 $this->logger->notice(
-                    message: "{action}: Queuing request to change '{client}: {user}@{backend}' {item.type} '{item.title}' play state to '{play_state}'.",
-                    context: $requestContext,
+                    message: "Would update play state for {item.type} '{item.title}' on '{user}@{backend}' to '{play_state}'.",
+                    context: [
+                        'event_name' => 'backend.request.skipped',
+                        'subsystem' => 'backend.export',
+                        'operation' => 'update_state',
+                        'outcome' => 'skipped',
+                        'reason' => 'dry_run',
+                        ...$requestContext,
+                    ],
                 );
                 return;
             }
+
+            $this->logger->debug(
+                message: "Updating play state for {item.type} '{item.title}' on '{user}@{backend}' to '{play_state}'.",
+                context: [
+                    'event_name' => 'backend.request.started',
+                    'subsystem' => 'backend.export',
+                    'operation' => 'update_state',
+                    'outcome' => 'started',
+                    ...$requestContext,
+                ],
+            );
 
             $queue->add(
                 new Request(
@@ -252,8 +325,12 @@ class Export extends Import
 
                         if (Status::OK !== Status::tryFrom($statusCode)) {
                             $this->logger->error(
-                                message: "{action}: Request to change '{client}: {user}@{backend}' {item.type} '{item.title}' play state returned with unexpected '{status_code}' status code.",
+                                message: "Play-state update for {item.type} '{item.title}' on '{user}@{backend}' returned status {status_code}.",
                                 context: [
+                                    'event_name' => 'backend.response.failed',
+                                    'subsystem' => 'backend.export',
+                                    'operation' => 'update_state',
+                                    'outcome' => 'failed',
                                     ...$requestContext,
                                     'status_code' => $statusCode,
                                 ],
@@ -263,8 +340,14 @@ class Export extends Import
                         }
 
                         $this->logger->notice(
-                            message: "{action}: Updated '{client}: {user}@{backend}' {item.type} '{item.title}' play state to '{play_state}'.",
-                            context: $requestContext,
+                            message: "Updated play state for {item.type} '{item.title}' on '{user}@{backend}' to '{play_state}'.",
+                            context: [
+                                'event_name' => 'backend.state_update.completed',
+                                'subsystem' => 'backend.export',
+                                'operation' => 'update_state',
+                                'outcome' => 'completed',
+                                ...$requestContext,
+                            ],
                         );
 
                         if (true !== $entity->isWatched()) {
@@ -294,8 +377,12 @@ class Export extends Import
                     error: function (Throwable $e) use ($requestContext): array {
                         $this->logger->error(
                             ...lw(
-                                message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request to change play state of {item.type} '{item.title}'. '{error.message}' at '{error.file}:{error.line}'.",
+                                message: "Play-state request failed for {item.type} '{item.title}' on '{user}@{backend}'.",
                                 context: [
+                                    'event_name' => 'backend.client.request_failed',
+                                    'subsystem' => 'backend.export',
+                                    'operation' => 'update_state',
+                                    'outcome' => 'failed',
                                     ...$requestContext,
                                     ...exception_log($e),
                                 ],
@@ -312,24 +399,20 @@ class Export extends Import
                 ),
             );
         } catch (Throwable $e) {
+            $message = ag_exists($logContext, 'item.title')
+                ? "Export failed for {item.type} '{item.title}' on '{user}@{backend}'."
+                : "Export failed for '{user}@{backend}'.";
+
             $this->logger->error(
                 ...lw(
-                    message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' export. '{error.message}' at '{error.file}:{error.line}'.",
+                    message: $message,
                     context: [
-                        'error' => [
-                            'kind' => $e::class,
-                            'line' => $e->getLine(),
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
+                        'event_name' => 'backend.operation.failed',
+                        'subsystem' => 'backend.export',
+                        'operation' => 'process_item',
+                        'outcome' => 'failed',
                         ...$logContext,
-                        'exception' => [
-                            'file' => $e->getFile(),
-                            'line' => $e->getLine(),
-                            'kind' => get_class($e),
-                            'message' => $e->getMessage(),
-                            'trace' => $e->getTrace(),
-                        ],
+                        ...exception_log($e),
                     ],
                     e: $e,
                 ),

--- a/src/Backends/Jellyfin/Action/GenerateAccessToken.php
+++ b/src/Backends/Jellyfin/Action/GenerateAccessToken.php
@@ -130,6 +130,8 @@ class GenerateAccessToken
         ]);
 
         if (Status::OK !== Status::tryFrom($response->getStatusCode())) {
+            $body = $response->getContent(false);
+
             return new Response(
                 status: false,
                 error: new Error(
@@ -147,10 +149,13 @@ class GenerateAccessToken
                             'url' => (string) $url,
                         ],
                         'response' => [
-                            'body' => $response->getContent(false),
+                            'body' => $body,
                         ],
                     ],
                     level: Levels::ERROR,
+                    extra: array_filter([
+                        'error' => $this->getBackendResponseReason($body),
+                    ]),
                 ),
             );
         }

--- a/src/Backends/Jellyfin/Action/GenerateAccessToken.php
+++ b/src/Backends/Jellyfin/Action/GenerateAccessToken.php
@@ -100,8 +100,15 @@ class GenerateAccessToken
         ];
 
         $this->logger->debug(
-            message: "{action}: Requesting '{client}: {user}@{backend}' to generate access token for '{username}'.",
-            context: $logContext,
+            message: "Requesting an access token for '{username}' from '{user}@{backend}'.",
+            context: [
+                ...$logContext,
+                'event_name' => 'backend.request.started',
+                'subsystem' => 'backend.auth',
+                'operation' => 'token.generate',
+                'outcome' => 'started',
+                'http' => ['url' => (string) $url],
+            ],
         );
 
         $response = $this->http->request(Method::POST, (string) $url, [
@@ -126,10 +133,19 @@ class GenerateAccessToken
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Request for '{client}: {user}@{backend}' to generate access for '{username}' token returned with unexpected '{status_code}' status code. {body}",
+                    message: "Access token request for '{username}' on '{user}@{backend}' returned status {http.status_code}.",
                     context: [
                         ...$logContext,
-                        'status_code' => $response->getStatusCode(),
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.auth',
+                        'operation' => 'token.generate',
+                        'outcome' => 'failed',
+                        'reason' => 'unexpected_status',
+                        'http' => [
+                            'status_code' => $response->getStatusCode(),
+                            'expected_status_codes' => [Status::OK->value],
+                            'url' => (string) $url,
+                        ],
                         'response' => [
                             'body' => $response->getContent(false),
                         ],
@@ -147,10 +163,14 @@ class GenerateAccessToken
 
         if ($context->trace) {
             $this->logger->debug(
-                message: "{action}: Parsing '{client}: {user}@{backend}' - '{username}' access token response payload.",
+                message: "Processing access token response for '{username}' from '{user}@{backend}'.",
                 context: [
                     ...$logContext,
-                    'trace' => $json,
+                    'event_name' => 'backend.response.received',
+                    'subsystem' => 'backend.auth',
+                    'operation' => 'token.generate',
+                    'outcome' => 'received',
+                    'response' => ['body' => $json],
                 ],
             );
         }

--- a/src/Backends/Jellyfin/Action/GetInfo.php
+++ b/src/Backends/Jellyfin/Action/GetInfo.php
@@ -101,6 +101,9 @@ class GetInfo
                                 ],
                             ],
                             level: Levels::WARNING,
+                            extra: array_filter([
+                                'error' => $this->getBackendResponseReason($content),
+                            ]),
                         ),
                     );
                 }

--- a/src/Backends/Jellyfin/Action/GetInfo.php
+++ b/src/Backends/Jellyfin/Action/GetInfo.php
@@ -29,7 +29,7 @@ class GetInfo
     /**
      * Class constructor.
      *
-     * @param iHttp $http The HTTP client instance to use.
+     * @param iHttp&\App\Libs\Extends\HttpClient $http The HTTP client instance to use.
      * @param iLogger $logger The logger instance to use.
      */
     public function __construct(
@@ -59,7 +59,14 @@ class GetInfo
                     'url' => (string) $url,
                 ];
 
-                $this->logger->debug("{action}: Requesting '{client}: {user}@{backend}' info.", $logContext);
+                $this->logger->debug("Requesting backend info from '{user}@{backend}'.", [
+                    ...$logContext,
+                    'event_name' => 'backend.request.started',
+                    'subsystem' => 'backend.info',
+                    'operation' => 'load',
+                    'outcome' => 'started',
+                    'http' => ['url' => (string) $url],
+                ]);
 
                 $response = $this->http->request(
                     method: Method::GET,
@@ -76,10 +83,19 @@ class GetInfo
                     return new Response(
                         status: false,
                         error: new Error(
-                            message: "{action}: '{client}: {user}@{backend}' request returned with unexpected '{status_code}' status code.",
+                            message: "Backend info request to '{user}@{backend}' returned status {http.status_code}.",
                             context: [
                                 ...$logContext,
-                                'status_code' => $response->getStatusCode(),
+                                'event_name' => 'backend.response.failed',
+                                'subsystem' => 'backend.info',
+                                'operation' => 'load',
+                                'outcome' => 'failed',
+                                'reason' => 'unexpected_status',
+                                'http' => [
+                                    'status_code' => $response->getStatusCode(),
+                                    'expected_status_codes' => [Status::OK->value],
+                                    'url' => (string) $url,
+                                ],
                                 'response' => [
                                     'body' => $content,
                                 ],
@@ -93,11 +109,19 @@ class GetInfo
                     return new Response(
                         status: false,
                         error: new Error(
-                            message: "{action}: '{client}: {user}@{backend}' request returned with empty response. Please make sure the container can communicate with the backend.",
+                            message: "Backend info request to '{user}@{backend}' returned an empty response.",
                             context: [
                                 ...$logContext,
-                                'response' => [
+                                'event_name' => 'backend.response.failed',
+                                'subsystem' => 'backend.info',
+                                'operation' => 'load',
+                                'outcome' => 'failed',
+                                'reason' => 'empty_response',
+                                'http' => [
                                     'status_code' => $response->getStatusCode(),
+                                    'url' => (string) $url,
+                                ],
+                                'response' => [
                                     'body' => $content,
                                 ],
                             ],
@@ -113,9 +137,13 @@ class GetInfo
                 );
 
                 if (true === $context->trace) {
-                    $this->logger->debug("{action}: Processing '{client}: {user}@{backend}' request payload.", [
+                    $this->logger->debug("Processing backend info response from '{user}@{backend}'.", [
                         ...$logContext,
-                        'trace' => $item,
+                        'event_name' => 'backend.response.received',
+                        'subsystem' => 'backend.info',
+                        'operation' => 'load',
+                        'outcome' => 'received',
+                        'response' => ['body' => $item],
                     ]);
                 }
 

--- a/src/Backends/Jellyfin/Action/GetLibrariesList.php
+++ b/src/Backends/Jellyfin/Action/GetLibrariesList.php
@@ -13,6 +13,7 @@ use App\Backends\Jellyfin\JellyfinClient as JFC;
 use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Enums\Http\Method;
 use App\Libs\Enums\Http\Status;
+use App\Libs\Exceptions\AppExceptionInterface;
 use App\Libs\Exceptions\RuntimeException;
 use App\Libs\Options;
 use DateInterval;
@@ -35,7 +36,7 @@ class GetLibrariesList
     /**
      * Class constructor
      *
-     * @param iHttp $http The HTTP client object.
+     * @param iHttp&\App\Libs\Extends\HttpClient $http The HTTP client object.
      * @param iLogger $logger The logger object.
      */
     public function __construct(
@@ -82,9 +83,30 @@ class GetLibrariesList
                     logger: $this->logger,
                 );
         } catch (RuntimeException $e) {
+            $errorContext = $e instanceof AppExceptionInterface && $e->hasContext()
+                ? $e->getContext()
+                : [
+                    'action' => $this->action,
+                    'client' => $context->clientName,
+                    'backend' => $context->backendName,
+                    'user' => $context->userContext->name,
+                    'event_name' => 'backend.operation.failed',
+                    'subsystem' => 'backend.library',
+                    'operation' => 'request_libraries',
+                    'outcome' => 'failed',
+                    ...exception_log($e),
+                ];
+
             return new Response(
                 status: false,
-                error: new Error(message: $e->getMessage(), level: Levels::ERROR, previous: $e),
+                error: new Error(
+                    message: 'backend.response.failed' === ag($errorContext, 'event_name')
+                        ? "Libraries request to '{user}@{backend}' returned status {http.status_code}."
+                        : "Failed to load libraries from '{user}@{backend}'.",
+                    context: $errorContext,
+                    level: Levels::ERROR,
+                    previous: $e,
+                ),
             );
         }
 
@@ -96,8 +118,12 @@ class GetLibrariesList
         ];
 
         if ($context->trace) {
-            $this->logger->debug("{action}: Parsing '{client}: {user}@{backend}' libraries payload.", [
+            $this->logger->debug("Parsing libraries payload from '{user}@{backend}'.", [
                 ...$logContext,
+                'event_name' => 'backend.response.received',
+                'subsystem' => 'backend.library',
+                'operation' => 'request_libraries',
+                'outcome' => 'received',
                 'response' => ['body' => $json],
             ]);
         }
@@ -108,8 +134,13 @@ class GetLibrariesList
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Request for '{client}: {user}@{backend}' libraries returned empty list.",
+                    message: "Libraries response from '{user}@{backend}' was empty.",
                     context: [
+                        'event_name' => 'backend.response.completed',
+                        'subsystem' => 'backend.library',
+                        'operation' => 'request_libraries',
+                        'outcome' => 'completed',
+                        'reason' => 'empty_list',
                         ...$logContext,
                         'response' => ['body' => $json],
                     ],
@@ -197,20 +228,40 @@ class GetLibrariesList
             'url' => (string) $url,
         ];
 
-        $this->logger->debug("{action}: Requesting '{client}: {user}@{backend}' libraries list.", $logContext);
+        $this->logger->debug("Requesting libraries from '{user}@{backend}' via {client}.", [
+            ...$logContext,
+            'event_name' => 'backend.request.started',
+            'subsystem' => 'backend.library',
+            'operation' => 'request_libraries',
+            'outcome' => 'started',
+            'http' => ['url' => (string) $url],
+        ]);
 
         $response = $this->http->request(Method::GET, (string) $url, $context->getHttpOptions());
 
         if (Status::OK !== Status::tryFrom($response->getStatusCode())) {
-            throw new RuntimeException(
+            $errorContext = [
+                ...$logContext,
+                'event_name' => 'backend.response.failed',
+                'subsystem' => 'backend.library',
+                'operation' => 'request_libraries',
+                'outcome' => 'failed',
+                'reason' => 'unexpected_status',
+                'http' => [
+                    'status_code' => $response->getStatusCode(),
+                    'expected_status_codes' => [Status::OK->value],
+                    'url' => (string) $url,
+                ],
+            ];
+
+            $ex = new RuntimeException(
                 r(
-                    text: "{action}: Request for '{client}: {user}@{backend}' libraries returned with unexpected '{status_code}' status code.",
-                    context: [
-                        ...$logContext,
-                        'status_code' => $response->getStatusCode(),
-                    ],
+                    text: "Libraries request to '{user}@{backend}' returned status {http.status_code}.",
+                    context: $errorContext,
                 ),
             );
+            $ex->setContext($errorContext);
+            throw $ex;
         }
 
         return json_decode(

--- a/src/Backends/Jellyfin/Action/GetLibrary.php
+++ b/src/Backends/Jellyfin/Action/GetLibrary.php
@@ -41,7 +41,7 @@ class GetLibrary
     /**
      * Class constructor
      *
-     * @param iHttp $http The HTTP client object.
+     * @param iHttp&\App\Libs\Extends\HttpClient $http The HTTP client object.
      * @param iLogger $logger The logger object.
      */
     public function __construct(
@@ -89,8 +89,13 @@ class GetLibrary
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: No library with id '{id}' found in '{client}: {user}@{backend}' response.",
+                    message: "Library '{id}' was not found for '{user}@{backend}'.",
                     context: [
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.library',
+                        'operation' => 'load_library',
+                        'outcome' => 'failed',
+                        'reason' => 'library_not_found',
                         'action' => $this->action,
                         'client' => $context->clientName,
                         'backend' => $context->backendName,
@@ -125,8 +130,15 @@ class GetLibrary
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: The request for '{client}: {user}@{backend}' library '{library.id}: {library.title}' returned with unsupported type '{library.type}'.",
-                    context: $logContext,
+                    message: "Ignoring library '{library.title}' from '{user}@{backend}': unsupported library type '{library.type}'.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.library',
+                        'operation' => 'load_library',
+                        'outcome' => 'ignored',
+                        'reason' => 'unsupported_library_type',
+                        ...$logContext,
+                    ],
                     level: Levels::WARNING,
                 ),
             );
@@ -155,7 +167,13 @@ class GetLibrary
 
         $logContext['library']['url'] = (string) $url;
 
-        $this->logger->debug("Requesting '{client}: {user}@{backend}' library '{library.title}' content.", $logContext);
+        $this->logger->debug("Requesting library '{library.title}' from '{user}@{backend}'.", [
+            ...$logContext,
+            'event_name' => 'backend.request.started',
+            'subsystem' => 'backend.library',
+            'operation' => 'load_library',
+            'outcome' => 'started',
+        ]);
 
         $response = $this->http->request(Method::GET, (string) $url, $context->getHttpOptions());
 
@@ -163,8 +181,12 @@ class GetLibrary
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Request for '{client}: {user}@{backend}' library '{library.title}' items returned with unexpected '{status_code}' status code.",
+                    message: "Library request for '{library.title}' on '{user}@{backend}' returned status {status_code}.",
                     context: [
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.library',
+                        'operation' => 'load_library',
+                        'outcome' => 'failed',
                         'status_code' => $response->getStatusCode(),
                         ...$logContext,
                     ],
@@ -188,8 +210,13 @@ class GetLibrary
         foreach ($it as $entity) {
             if ($entity instanceof DecodingError) {
                 $this->logger->warning(
-                    "{action}: Failed to decode one item of '{client}: {user}@{backend}' library '{library.title}' content.",
+                    "Ignoring one item from library '{library.title}' on '{user}@{backend}': content could not be decoded.",
                     [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.library',
+                        'operation' => 'parse_item',
+                        'outcome' => 'ignored',
+                        'reason' => 'decode_error',
                         ...$logContext,
                         'error' => [
                             'message' => $entity->getErrorMessage(),
@@ -272,8 +299,14 @@ class GetLibrary
         }
 
         $this->logger->debug(
-            message: "{action}: Processing '{client}: {user}@{backend}' {item.type} '{item.title} ({item.year})'.",
-            context: $data,
+            message: "Processing library item {item.type} '{item.title} ({item.year})' from '{user}@{backend}'.",
+            context: [
+                'event_name' => 'backend.response.received',
+                'subsystem' => 'backend.library',
+                'operation' => 'parse_item',
+                'outcome' => 'received',
+                ...$data,
+            ],
         );
 
         $webUrl = $url->withPath('/web/index.html')->withFragment(r('!/{action}?id={id}&serverId={backend_id}', [

--- a/src/Backends/Jellyfin/Action/GetMetaData.php
+++ b/src/Backends/Jellyfin/Action/GetMetaData.php
@@ -97,8 +97,15 @@ class GetMetaData
                 ];
 
                 $this->logger->debug(
-                    "{action}: Requesting '{client}: {user}@{backend}' - '{id}' item metadata.",
-                    $logContext,
+                    "Requesting item metadata '#{id}' from '{user}@{backend}'.",
+                    [
+                        ...$logContext,
+                        'event_name' => 'backend.request.started',
+                        'subsystem' => 'backend.metadata',
+                        'operation' => 'load',
+                        'outcome' => 'started',
+                        'http' => ['url' => (string) $url],
+                    ],
                 );
 
                 if (null !== $cacheKey && $this->cache->has($cacheKey)) {
@@ -119,10 +126,19 @@ class GetMetaData
                         return new Response(
                             status: false,
                             error: new Error(
-                                message: "{action}: Request for '{client}: {user}@{backend}' - '{id}' item returned with unexpected '{status_code}' status code.",
+                                message: "Metadata request for item '#{id}' on '{user}@{backend}' returned status {http.status_code}.",
                                 context: [
                                     ...$logContext,
-                                    'status_code' => $response->getStatusCode(),
+                                    'event_name' => 'backend.response.failed',
+                                    'subsystem' => 'backend.metadata',
+                                    'operation' => 'load',
+                                    'outcome' => 'failed',
+                                    'reason' => 'unexpected_status',
+                                    'http' => [
+                                        'status_code' => $response->getStatusCode(),
+                                        'expected_status_codes' => [Status::OK->value],
+                                        'url' => (string) $url,
+                                    ],
                                 ],
                             ),
                         );
@@ -146,8 +162,12 @@ class GetMetaData
                 }
 
                 if (true === $context->trace) {
-                    $this->logger->debug("{action}: Processing '{client}: {user}@{backend}' - '{id}' item payload.", [
+                    $this->logger->debug("Processing item metadata '#{id}' from '{user}@{backend}'.", [
                         ...$logContext,
+                        'event_name' => 'backend.response.received',
+                        'subsystem' => 'backend.metadata',
+                        'operation' => 'load',
+                        'outcome' => 'received',
                         'cached' => $fromCache,
                         'response' => [
                             'body' => $item,

--- a/src/Backends/Jellyfin/Action/GetPlaylist.php
+++ b/src/Backends/Jellyfin/Action/GetPlaylist.php
@@ -61,13 +61,38 @@ class GetPlaylist
             'id' => $id,
         ];
 
+        $this->logger->debug(
+            message: "Requesting playlist '{id}' from '{user}@{backend}'.",
+            context: [
+                ...$logContext,
+                'event_name' => 'backend.request.started',
+                'subsystem' => 'backend.playlist',
+                'operation' => 'load',
+                'outcome' => 'started',
+                'http' => ['method' => Method::GET->value, 'url' => (string) $detailUrl],
+            ],
+        );
+
         $detailResponse = $this->http->request(Method::GET, (string) $detailUrl, $context->getHttpOptions());
         if (Status::OK !== Status::tryFrom($detailResponse->getStatusCode())) {
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Request for '{client}: {user}@{backend}' playlist '{id}' returned with unexpected '{status_code}' status code.",
-                    context: [...$logContext, 'status_code' => $detailResponse->getStatusCode()],
+                    message: "Playlist '{id}' request to '{user}@{backend}' returned status {http.status_code}.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.playlist',
+                        'operation' => 'load',
+                        'outcome' => 'failed',
+                        'reason' => 'unexpected_status',
+                        'http' => [
+                            'method' => Method::GET->value,
+                            'status_code' => $detailResponse->getStatusCode(),
+                            'expected_status_codes' => [Status::OK->value],
+                            'url' => (string) $detailUrl,
+                        ],
+                    ],
                     level: Levels::ERROR,
                 ),
             );
@@ -84,8 +109,21 @@ class GetPlaylist
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Request for '{client}: {user}@{backend}' playlist '{id}' items returned with unexpected '{status_code}' status code.",
-                    context: [...$logContext, 'status_code' => $itemsResponse->getStatusCode()],
+                    message: "Playlist items request for '{id}' on '{user}@{backend}' returned status {http.status_code}.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.playlist',
+                        'operation' => 'load_items',
+                        'outcome' => 'failed',
+                        'reason' => 'unexpected_status',
+                        'http' => [
+                            'method' => Method::GET->value,
+                            'status_code' => $itemsResponse->getStatusCode(),
+                            'expected_status_codes' => [Status::OK->value],
+                            'url' => (string) $itemsUrl,
+                        ],
+                    ],
                     level: Levels::ERROR,
                 ),
             );

--- a/src/Backends/Jellyfin/Action/GetPlaylistsList.php
+++ b/src/Backends/Jellyfin/Action/GetPlaylistsList.php
@@ -56,7 +56,17 @@ class GetPlaylistsList
             'url' => (string) $url,
         ];
 
-        $this->logger->debug("{action}: Requesting '{client}: {user}@{backend}' playlists list.", $logContext);
+        $this->logger->debug(
+            message: "Requesting playlists list from '{user}@{backend}'.",
+            context: [
+                ...$logContext,
+                'event_name' => 'backend.request.started',
+                'subsystem' => 'backend.playlist',
+                'operation' => 'list',
+                'outcome' => 'started',
+                'http' => ['url' => (string) $url],
+            ],
+        );
 
         $response = $this->http->request(Method::GET, (string) $url, $context->getHttpOptions());
 
@@ -64,8 +74,20 @@ class GetPlaylistsList
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Request for '{client}: {user}@{backend}' playlists returned with unexpected '{status_code}' status code.",
-                    context: [...$logContext, 'status_code' => $response->getStatusCode()],
+                    message: "Playlists list request to '{user}@{backend}' returned status {http.status_code}.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.playlist',
+                        'operation' => 'list',
+                        'outcome' => 'failed',
+                        'reason' => 'unexpected_status',
+                        'http' => [
+                            'status_code' => $response->getStatusCode(),
+                            'expected_status_codes' => [Status::OK->value],
+                            'url' => (string) $url,
+                        ],
+                    ],
                     level: Levels::ERROR,
                 ),
             );

--- a/src/Backends/Jellyfin/Action/GetSessions.php
+++ b/src/Backends/Jellyfin/Action/GetSessions.php
@@ -27,6 +27,11 @@ class GetSessions
 
     protected string $action = 'jellyfin.getSessions';
 
+    /**
+     * @param iHttp&\App\Libs\Extends\HttpClient $http
+     * @param iLogger $logger
+     * @param iCache $cache
+     */
     public function __construct(
         protected readonly iHttp $http,
         protected readonly iLogger $logger,
@@ -56,7 +61,14 @@ class GetSessions
                     'url' => (string) $url,
                 ];
 
-                $this->logger->debug("{action}: Requesting '{client}: {user}@{backend}' play sessions.", $logContext);
+                $this->logger->debug("Requesting active sessions from '{user}@{backend}'.", [
+                    ...$logContext,
+                    'event_name' => 'backend.request.started',
+                    'subsystem' => 'backend.session',
+                    'operation' => 'load',
+                    'outcome' => 'started',
+                    'http' => ['url' => (string) $url],
+                ]);
 
                 $response = $this->http->request(
                     method: Method::GET,
@@ -73,10 +85,19 @@ class GetSessions
                     return new Response(
                         status: false,
                         error: new Error(
-                            message: "{action}: Request for '{client}: {user}@{backend}' get sessions returned with unexpected '{status_code}' status code.",
+                            message: "Sessions request to '{user}@{backend}' returned status {http.status_code}.",
                             context: [
                                 ...$logContext,
-                                'status_code' => $response->getStatusCode(),
+                                'event_name' => 'backend.response.failed',
+                                'subsystem' => 'backend.session',
+                                'operation' => 'load',
+                                'outcome' => 'failed',
+                                'reason' => 'unexpected_status',
+                                'http' => [
+                                    'status_code' => $response->getStatusCode(),
+                                    'expected_status_codes' => [Status::OK->value],
+                                    'url' => (string) $url,
+                                ],
                                 'response' => ['body' => $content],
                             ],
                             level: Levels::WARNING,
@@ -88,10 +109,19 @@ class GetSessions
                     return new Response(
                         status: false,
                         error: new Error(
-                            message: "{action}: Request for '{client}: {user}@{backend}' get sessions returned with empty response.",
+                            message: "Sessions request to '{user}@{backend}' returned an empty response.",
                             context: [
                                 ...$logContext,
-                                'response' => ['status_code' => $response->getStatusCode(), 'body' => $content],
+                                'event_name' => 'backend.response.failed',
+                                'subsystem' => 'backend.session',
+                                'operation' => 'load',
+                                'outcome' => 'failed',
+                                'reason' => 'empty_response',
+                                'http' => [
+                                    'status_code' => $response->getStatusCode(),
+                                    'url' => (string) $url,
+                                ],
+                                'response' => ['body' => $content],
                             ],
                             level: Levels::ERROR,
                         ),
@@ -105,8 +135,12 @@ class GetSessions
                 );
 
                 if (true === $context->trace) {
-                    $this->logger->debug("Processing '{client}: {user}@{backend}' {action} payload.", [
+                    $this->logger->debug("Processing sessions response from '{user}@{backend}'.", [
                         ...$logContext,
+                        'event_name' => 'backend.response.received',
+                        'subsystem' => 'backend.session',
+                        'operation' => 'load',
+                        'outcome' => 'received',
                         'response' => ['body' => $items],
                     ]);
                 }

--- a/src/Backends/Jellyfin/Action/GetUser.php
+++ b/src/Backends/Jellyfin/Action/GetUser.php
@@ -34,7 +34,7 @@ class GetUser
     /**
      * Class Constructor.
      *
-     * @param iHttp $http The HTTP client instance.
+     * @param iHttp&\App\Libs\Extends\HttpClient $http The HTTP client instance.
      * @param iLogger $logger The logger instance.
      */
     public function __construct(
@@ -78,8 +78,15 @@ class GetUser
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Request for '{client}: {user}@{backend}' user info failed. User not set.",
-                    context: $logContext,
+                    message: "Skipping user info request for '{user}@{backend}': backend user is not set.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.request.skipped',
+                        'subsystem' => 'backend.user',
+                        'operation' => 'load',
+                        'outcome' => 'skipped',
+                        'reason' => 'missing_backend_user',
+                    ],
                     level: Levels::ERROR,
                 ),
             );
@@ -90,7 +97,14 @@ class GetUser
         $logContext['url'] = (string) $url;
         $logContext['userId'] = $context->backendUser;
 
-        $this->logger->debug("{action}: Requesting '{client}: {user}@{backend}' user '{userId}' info.", $logContext);
+        $this->logger->debug("Requesting user '{userId}' from '{user}@{backend}'.", [
+            ...$logContext,
+            'event_name' => 'backend.request.started',
+            'subsystem' => 'backend.user',
+            'operation' => 'load',
+            'outcome' => 'started',
+            'http' => ['url' => (string) $url],
+        ]);
 
         $options = $context->getHttpOptions();
 
@@ -104,10 +118,19 @@ class GetUser
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Request for '{client}: {user}@{backend}' user '{userId}' info returned with unexpected '{status_code}' status code.",
+                    message: "User '{userId}' info request to '{user}@{backend}' returned status {http.status_code}.",
                     context: [
                         ...$logContext,
-                        'status_code' => $response->getStatusCode(),
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.user',
+                        'operation' => 'load',
+                        'outcome' => 'failed',
+                        'reason' => 'unexpected_status',
+                        'http' => [
+                            'status_code' => $response->getStatusCode(),
+                            'expected_status_codes' => [Status::OK->value],
+                            'url' => (string) $url,
+                        ],
                     ],
                     level: Levels::ERROR,
                 ),
@@ -120,8 +143,12 @@ class GetUser
         );
 
         if ($context->trace) {
-            $this->logger->debug("{action}: Parsing '{client}: {user}@{backend}' user '{userId}' info payload.", [
+            $this->logger->debug("Processing user '{userId}' response from '{user}@{backend}'.", [
                 ...$logContext,
+                'event_name' => 'backend.response.received',
+                'subsystem' => 'backend.user',
+                'operation' => 'load',
+                'outcome' => 'received',
                 'response' => ['body' => $json],
             ]);
         }

--- a/src/Backends/Jellyfin/Action/GetUsersList.php
+++ b/src/Backends/Jellyfin/Action/GetUsersList.php
@@ -35,7 +35,7 @@ class GetUsersList
     /**
      * Class Constructor.
      *
-     * @param iHttp $http The HTTP client instance.
+     * @param iHttp&\App\Libs\Extends\HttpClient $http The HTTP client instance.
      * @param iLogger $logger The logger instance.
      */
     public function __construct(
@@ -89,7 +89,14 @@ class GetUsersList
             'url' => (string) $url,
         ];
 
-        $this->logger->debug("{action}: Requesting '{client}: {user}@{backend}' users list.", $logContext);
+        $this->logger->debug("Requesting users list from '{user}@{backend}'.", [
+            ...$logContext,
+            'event_name' => 'backend.request.started',
+            'subsystem' => 'backend.user',
+            'operation' => 'list',
+            'outcome' => 'started',
+            'http' => ['url' => (string) $url],
+        ]);
 
         $headers = $context->getHttpOptions();
 
@@ -107,10 +114,19 @@ class GetUsersList
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Request for '{client}: {user}@{backend}' users list returned with unexpected '{status_code}' status code.",
+                    message: "Users list request to '{user}@{backend}' returned status {http.status_code}.",
                     context: [
                         ...$logContext,
-                        'status_code' => $response->getStatusCode(),
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.user',
+                        'operation' => 'list',
+                        'outcome' => 'failed',
+                        'reason' => 'unexpected_status',
+                        'http' => [
+                            'status_code' => $response->getStatusCode(),
+                            'expected_status_codes' => [Status::OK->value],
+                            'url' => (string) $url,
+                        ],
                     ],
                     level: Levels::ERROR,
                 ),
@@ -124,8 +140,12 @@ class GetUsersList
         );
 
         if ($context->trace) {
-            $this->logger->debug("{action}: Parsing '{client}: {user}@{backend}' user list payload.", [
+            $this->logger->debug("Processing users list response from '{user}@{backend}'.", [
                 ...$logContext,
+                'event_name' => 'backend.response.received',
+                'subsystem' => 'backend.user',
+                'operation' => 'list',
+                'outcome' => 'received',
                 'response' => ['body' => $json],
             ]);
         }

--- a/src/Backends/Jellyfin/Action/GetUsersList.php
+++ b/src/Backends/Jellyfin/Action/GetUsersList.php
@@ -111,6 +111,8 @@ class GetUsersList
         $response = $this->http->request(Method::GET, (string) $url, $headers);
 
         if (Status::OK !== Status::tryFrom($response->getStatusCode())) {
+            $body = $response->getContent(false);
+
             return new Response(
                 status: false,
                 error: new Error(
@@ -127,8 +129,14 @@ class GetUsersList
                             'expected_status_codes' => [Status::OK->value],
                             'url' => (string) $url,
                         ],
+                        'response' => [
+                            'body' => $body,
+                        ],
                     ],
                     level: Levels::ERROR,
+                    extra: array_filter([
+                        'error' => $this->getBackendResponseReason($body),
+                    ]),
                 ),
             );
         }

--- a/src/Backends/Jellyfin/Action/GetWebUrl.php
+++ b/src/Backends/Jellyfin/Action/GetWebUrl.php
@@ -40,13 +40,18 @@ class GetWebUrl
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Invalid Web url type '{type}' for '{client}: {user}@{backend}'.",
+                    message: "Cannot build a web URL for '{user}@{backend}': type '{type}' is unsupported.",
                     context: [
                         'type' => $type,
                         'action' => $this->action,
                         'client' => $context->clientName,
                         'backend' => $context->backendName,
-                        'user' => $context->userContext,
+                        'user' => $context->userContext->name,
+                        'event_name' => 'backend.request.skipped',
+                        'subsystem' => 'backend.web',
+                        'operation' => 'build_url',
+                        'outcome' => 'skipped',
+                        'reason' => 'unsupported_type',
                     ],
                     level: Levels::WARNING,
                 ),

--- a/src/Backends/Jellyfin/Action/Import.php
+++ b/src/Backends/Jellyfin/Action/Import.php
@@ -108,8 +108,12 @@ class Import
                     logContext: $logContext,
                 ),
                 error: fn(array $logContext = []) => fn(Throwable $e) => $this->logger->error(
-                    message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' library '{library.title}' request. '{error.message}' at '{error.file}:{error.line}'.",
+                    message: "Library request failed for '{user}@{backend}'.",
                     context: [
+                        'event_name' => 'backend.client.request_failed',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'request_library',
+                        'outcome' => 'failed',
                         'action' => property_exists($this, 'action') ? $this->action : 'import',
                         'backend' => $context->backendName,
                         'client' => $context->clientName,
@@ -149,7 +153,13 @@ class Import
             $url = $context->backendUrl->withPath(r('/Users/{user_id}/items/', ['user_id' => $context->backendUser]));
             $rContext['url'] = (string) $url;
 
-            $this->logger->debug("Requesting '{client}: {user}@{backend}' libraries.", $rContext);
+            $this->logger->debug("Requesting libraries from '{user}@{backend}' via {client}.", [
+                ...$rContext,
+                'event_name' => 'backend.request.started',
+                'subsystem' => 'backend.import',
+                'operation' => 'request_libraries',
+                'outcome' => 'started',
+            ]);
 
             $response = $this->http->request(Method::GET, (string) $url, $context->getHttpOptions());
 
@@ -157,8 +167,12 @@ class Import
 
             if ($context->trace) {
                 $json = json_decode($payload, true);
-                $this->logger->debug("{action}: Processing '{client}: {user}@{backend}' response.", [
+                $this->logger->debug("Received libraries response from '{user}@{backend}'.", [
                     ...$rContext,
+                    'event_name' => 'backend.response.received',
+                    'subsystem' => 'backend.import',
+                    'operation' => 'request_libraries',
+                    'outcome' => 'received',
                     'response' => [
                         'headers' => $response->getHeaders(false),
                         'status_code' => $response->getStatusCode(),
@@ -168,18 +182,26 @@ class Import
             }
 
             if (Status::OK !== Status::tryFrom($response->getStatusCode())) {
-                $rContext = ag_sets($rContext, [
+                $logContext = [
+                    ...$rContext,
+                    'event_name' => 'backend.response.failed',
+                    'subsystem' => 'backend.import',
+                    'operation' => 'request_libraries',
+                    'outcome' => 'failed',
+                    'reason' => 'unexpected_status',
                     'status_code' => $response->getStatusCode(),
-                    'headers' => $response->getHeaders(false),
-                ]);
+                    'response' => [
+                        'headers' => $response->getHeaders(false),
+                    ],
+                ];
 
                 if ($context->trace) {
-                    $rContext = ag_set($rContext, 'response.body', $response->getInfo('debug'));
+                    $logContext['response']['body'] = $response->getInfo('debug');
                 }
 
                 $this->logger->error(
-                    message: "{action}: Request for '{client}: {user}@{backend}' libraries returned with unexpected '{status_code}' status code.",
-                    context: $rContext,
+                    message: "Libraries request to '{user}@{backend}' returned status {status_code}.",
+                    context: $logContext,
                 );
 
                 Message::add("{$context->backendName}.has_errors", true);
@@ -196,9 +218,14 @@ class Import
 
             if (empty($listDirs)) {
                 $this->logger->warning(
-                    message: "{action}: Request for '{client}: {user}@{backend}' libraries returned with empty list.",
+                    message: "Libraries response from '{user}@{backend}' was empty.",
                     context: [
                         ...$rContext,
+                        'event_name' => 'backend.response.completed',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'request_libraries',
+                        'outcome' => 'completed',
+                        'reason' => 'empty_list',
                         'response' => ['body' => $payload],
                     ],
                 );
@@ -208,8 +235,15 @@ class Import
         } catch (iException $e) {
             $this->logger->error(
                 ...lw(
-                    message: "{action}: Request for '{client}: {user}@{backend}' libraries has failed. '{error.kind}' with message '{error.message}' at '{error.file}:{error.line}'.",
-                    context: [...$rContext, ...exception_log($e)],
+                    message: "Libraries request to '{user}@{backend}' failed.",
+                    context: [
+                        ...$rContext,
+                        'event_name' => 'backend.client.request_failed',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'request_libraries',
+                        'outcome' => 'failed',
+                        ...exception_log($e),
+                    ],
                     e: $e,
                 ),
             );
@@ -218,8 +252,15 @@ class Import
         } catch (JsonException $e) {
             $this->logger->error(
                 ...lw(
-                    message: "{action}: Request for '{client}: {user}@{backend}' libraries returned with invalid body. '{error.message}' at '{error.file}:{error.line}'.",
-                    context: [...$rContext, ...exception_log($e)],
+                    message: "Libraries response from '{user}@{backend}' could not be parsed.",
+                    context: [
+                        ...$rContext,
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'request_libraries',
+                        'outcome' => 'failed',
+                        ...exception_log($e),
+                    ],
                     e: $e,
                 ),
             );
@@ -228,8 +269,15 @@ class Import
         } catch (Throwable $e) {
             $this->logger->error(
                 ...lw(
-                    message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request for libraries. '{error.message}' at '{error.file}:{error.line}'.",
-                    context: [...$rContext, ...exception_log($e)],
+                    message: "Loading libraries from '{user}@{backend}' failed.",
+                    context: [
+                        ...$rContext,
+                        'event_name' => 'backend.operation.failed',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'load_libraries',
+                        'outcome' => 'failed',
+                        ...exception_log($e),
+                    ],
                     e: $e,
                 ),
             );
@@ -270,14 +318,50 @@ class Import
             }
 
             if (true === in_array($libraryId, $ignoreIds ?? [], true)) {
+                $ignored++;
+                $this->logger->info(
+                    message: "Ignoring library '{library.title}' from '{user}@{backend}': excluded by selection.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'filter_library',
+                        'outcome' => 'ignored',
+                        'reason' => 'selected_excluded',
+                        ...$logContext,
+                    ],
+                );
                 continue;
             }
 
             if ($selectLibraryList && $inverseLibrarySelect === in_array($libraryId, $selectLibraryList, true)) {
+                $ignored++;
+                $this->logger->info(
+                    message: "Ignoring library '{library.title}' from '{user}@{backend}': excluded by selection.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'filter_library',
+                        'outcome' => 'ignored',
+                        'reason' => 'selected_excluded',
+                        ...$logContext,
+                    ],
+                );
                 continue;
             }
 
             if (!in_array(ag($logContext, 'library.type'), $types, true)) {
+                $unsupported++;
+                $this->logger->info(
+                    message: "Ignoring library '{library.title}' from '{user}@{backend}': type '{library.type}' is unsupported.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'filter_library',
+                        'outcome' => 'ignored',
+                        'reason' => 'unsupported_library_type',
+                        ...$logContext,
+                    ],
+                );
                 continue;
             }
 
@@ -303,8 +387,14 @@ class Import
             $logContext['library']['url'] = (string) $url;
 
             $this->logger->debug(
-                message: "{action}: Requesting '{client}: {user}@{backend}' - '{library.title}' items count.",
-                context: $logContext,
+                message: "Requesting item count for library '{library.title}' from '{user}@{backend}'.",
+                context: [
+                    'event_name' => 'backend.request.started',
+                    'subsystem' => 'backend.import',
+                    'operation' => 'request_library_count',
+                    'outcome' => 'started',
+                    ...$logContext,
+                ],
             );
 
             try {
@@ -316,8 +406,15 @@ class Import
             } catch (iException $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Request for '{client}: {user}@{backend}' - '{library.title}' items count failed. '{error.kind}' with message '{error.message}' at '{error.file}:{error.line}'.",
-                        context: [...$logContext, ...exception_log($e)],
+                        message: "Library count request failed for '{user}@{backend}'.",
+                        context: [
+                            'event_name' => 'backend.client.request_failed',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'request_library_count',
+                            'outcome' => 'failed',
+                            ...$logContext,
+                            ...exception_log($e),
+                        ],
                         e: $e,
                     ),
                 );
@@ -325,8 +422,15 @@ class Import
             } catch (Throwable $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' - '{library.title}' items count request. '{error.message}' at '{error.file}:{error.line}'.",
-                        context: [...$logContext, ...exception_log($e)],
+                        message: "Queueing library count requests failed for '{user}@{backend}'.",
+                        context: [
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'queue_library_requests',
+                            'outcome' => 'failed',
+                            ...$logContext,
+                            ...exception_log($e),
+                        ],
                         e: $e,
                     ),
                 );
@@ -341,8 +445,13 @@ class Import
             try {
                 if (Status::OK !== Status::tryFrom($response->getStatusCode())) {
                     $this->logger->error(
-                        message: "{action}: Request for '{client}: {user}@{backend}' - '{library.title}' items count returned with unexpected '{status_code}' status code.",
+                        message: "Library count request for '{library.title}' on '{user}@{backend}' returned status {status_code}.",
                         context: [
+                            'event_name' => 'backend.response.failed',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'request_library_count',
+                            'outcome' => 'failed',
+                            'reason' => 'unexpected_status',
                             ...$logContext,
                             'status_code' => $response->getStatusCode(),
                         ],
@@ -356,8 +465,13 @@ class Import
 
                 if ($totalCount < 1) {
                     $this->logger->warning(
-                        message: "{action}: Request for '{client}: {user}@{backend}' - '{library.title}' items count returned with 0 or less.",
+                        message: "Ignoring library '{library.title}' from '{user}@{backend}': item count is empty.",
                         context: [
+                            'event_name' => 'backend.item.ignored',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'filter_library',
+                            'outcome' => 'ignored',
+                            'reason' => 'empty_library',
                             ...$logContext,
                             'response' => [
                                 'headers' => $response->getHeaders(),
@@ -372,8 +486,15 @@ class Import
             } catch (iException $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Request for '{client}: {user}@{backend}' - '{library.title}' total items has failed. '{error.kind}' '{error.message}' at '{error.file}:{error.line}'.",
-                        context: [...$logContext, ...exception_log($e)],
+                        message: "Reading library count response failed for '{library.title}' on '{user}@{backend}'.",
+                        context: [
+                            'event_name' => 'backend.client.request_failed',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'request_library_count',
+                            'outcome' => 'failed',
+                            ...$logContext,
+                            ...exception_log($e),
+                        ],
                         e: $e,
                     ),
                 );
@@ -381,8 +502,15 @@ class Import
             } catch (Throwable $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' requests for items count. '{error.message}' at '{error.file}:{error.line}'.",
-                        context: [...$logContext, ...exception_log($e)],
+                        message: "Parsing library count response failed for '{library.title}' on '{user}@{backend}'.",
+                        context: [
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'parse_library_count',
+                            'outcome' => 'failed',
+                            ...$logContext,
+                            ...exception_log($e),
+                        ],
                         e: $e,
                     ),
                 );
@@ -450,8 +578,14 @@ class Import
             $logContext['library']['url'] = (string) $url;
 
             $this->logger->debug(
-                message: "{action}: Requesting '{client}: {user}@{backend}' - '{library.title}' series external ids.",
-                context: $logContext,
+                message: "Requesting series metadata for library '{library.title}' from '{user}@{backend}'.",
+                context: [
+                    'event_name' => 'backend.request.started',
+                    'subsystem' => 'backend.import',
+                    'operation' => 'request_series_metadata',
+                    'outcome' => 'started',
+                    ...$logContext,
+                ],
             );
 
             try {
@@ -466,8 +600,15 @@ class Import
             } catch (Throwable $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' '{library.title}' series external ids request. '{error.message}' at '{error.file}:{error.line}'.",
-                        context: [...$logContext, ...exception_log($e)],
+                        message: "Queueing series metadata request for library '{library.title}' from '{user}@{backend}' failed.",
+                        context: [
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'queue_series_requests',
+                            'outcome' => 'failed',
+                            ...$logContext,
+                            ...exception_log($e),
+                        ],
                         e: $e,
                     ),
                 );
@@ -490,16 +631,30 @@ class Import
             if (true === in_array($libraryId, $ignoreIds ?? [], true)) {
                 $ignored++;
                 $this->logger->info(
-                    message: "{action}: Ignoring '{client}: {user}@{backend}' - '{library.title}'. Requested by user.",
-                    context: $logContext,
+                    message: "Ignoring library '{library.title}' from '{user}@{backend}': excluded by selection.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'filter_library',
+                        'outcome' => 'ignored',
+                        'reason' => 'selected_excluded',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
 
             if ($selectLibraryList && $inverseLibrarySelect === in_array($libraryId, $selectLibraryList, true)) {
                 $this->logger->info(
-                    message: "{action}: Excluding '{client}: {user}@{backend}' - '{library.title}'. Requested by user.",
-                    context: $logContext,
+                    message: "Ignoring library '{library.title}' from '{user}@{backend}': excluded by selection.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'filter_library',
+                        'outcome' => 'ignored',
+                        'reason' => 'selected_excluded',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
@@ -507,8 +662,15 @@ class Import
             if (!in_array(ag($logContext, 'library.type'), $types, true)) {
                 $unsupported++;
                 $this->logger->info(
-                    message: "{action}: Ignoring '{client}: {user}@{backend}' - '{library.title}'. Library type '{library.type}' is not supported.",
-                    context: $logContext,
+                    message: "Ignoring library '{library.title}' from '{user}@{backend}': type '{library.type}' is unsupported.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'filter_library',
+                        'outcome' => 'ignored',
+                        'reason' => 'unsupported_library_type',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
@@ -516,8 +678,15 @@ class Import
             if (false === array_key_exists($libraryId, $total)) {
                 $ignored++;
                 $this->logger->warning(
-                    message: "{action}: Ignoring '{client}: {user}@{backend}' - '{library.title}'. No items count was found.",
-                    context: $logContext,
+                    message: "Ignoring library '{library.title}' from '{user}@{backend}': item count is unavailable.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'filter_library',
+                        'outcome' => 'ignored',
+                        'reason' => 'missing_item_count',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
@@ -563,8 +732,14 @@ class Import
                     $logContext['library']['url'] = (string) $url;
 
                     $this->logger->debug(
-                        message: "{action}: Requesting '{client}: {user}@{backend}' '{library.title} {segment.number}/{segment.of}' content list.",
-                        context: $logContext,
+                        message: "Requesting library items for '{library.title}' segment {segment.number}/{segment.of} from '{user}@{backend}'.",
+                        context: [
+                            'event_name' => 'backend.request.started',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'request_library',
+                            'outcome' => 'started',
+                            ...$logContext,
+                        ],
                     );
 
                     $requests[] = new Request(
@@ -578,8 +753,15 @@ class Import
                 } catch (Throwable $e) {
                     $this->logger->error(
                         ...lw(
-                            message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' '{library.title} {segment.number}/{segment.of}' content list request. '{error.message}' at '{error.file}:{error.line}'.",
-                            context: [...$logContext, ...exception_log($e)],
+                            message: "Queueing library items request for '{library.title}' segment {segment.number}/{segment.of} from '{user}@{backend}' failed.",
+                            context: [
+                                'event_name' => 'backend.operation.failed',
+                                'subsystem' => 'backend.import',
+                                'operation' => 'queue_library_requests',
+                                'outcome' => 'failed',
+                                ...$logContext,
+                                ...exception_log($e),
+                            ],
                             e: $e,
                         ),
                     );
@@ -589,9 +771,14 @@ class Import
         }
 
         if (0 === count($requests)) {
-            $this->logger->warning("No requests for '{client}: {user}@{backend}' libraries were queued.", [
+            $this->logger->warning("No eligible library requests were queued for '{user}@{backend}'.", [
                 ...$rContext,
-                'context' => [
+                'event_name' => 'backend.request.skipped',
+                'subsystem' => 'backend.import',
+                'operation' => 'queue_library_requests',
+                'outcome' => 'skipped',
+                'reason' => 'no_eligible_requests',
+                'stats' => [
                     'total' => count($listDirs),
                     'ignored' => $ignored,
                     'unsupported' => $unsupported,
@@ -619,8 +806,13 @@ class Import
     {
         if (Status::OK !== Status::tryFrom($response->getStatusCode())) {
             $this->logger->error(
-                message: "{action}: Request for '{client}: {user}@{backend}' - '{library.title} {segment.number}/{segment.of}' content returned with unexpected '{status_code}' status code.",
+                message: "Library request for '{library.title}' segment {segment.number}/{segment.of} on '{user}@{backend}' returned status {status_code}.",
                 context: [
+                    'event_name' => 'backend.response.failed',
+                    'subsystem' => 'backend.import',
+                    'operation' => 'request_library',
+                    'outcome' => 'failed',
+                    'reason' => 'unexpected_status',
                     ...$logContext,
                     'status_code' => $response->getStatusCode(),
                 ],
@@ -630,14 +822,20 @@ class Import
 
         $start = microtime(true);
         $this->logger->info(
-            message: "{action}: Parsing '{client}: {user}@{backend}' - '{library.title} {segment.number}/{segment.of}' response.",
+            message: "Parsing library '{library.title}' segment {segment.number}/{segment.of} from '{user}@{backend}'.",
             context: [
+                'event_name' => 'backend.response.processing',
+                'subsystem' => 'backend.import',
+                'operation' => 'parse_library_response',
+                'outcome' => 'started',
                 ...$logContext,
                 'time' => [
                     'start' => $start,
                 ],
             ],
         );
+
+        $isParsed = false;
 
         try {
             $it = Items::fromIterable(
@@ -654,8 +852,13 @@ class Import
                 try {
                     if ($entity instanceof DecodingError) {
                         $this->logger->warning(
-                            "{action}: Failed to decode one item of '{client}: {user}@{backend}' - '{library.title} {segment.number}/{segment.of}' content.",
-                            [
+                            message: "Ignoring malformed item from library '{library.title}' segment {segment.number}/{segment.of} on '{user}@{backend}': {error.message}.",
+                            context: [
+                                'event_name' => 'backend.item.ignored',
+                                'subsystem' => 'backend.import',
+                                'operation' => 'parse_item',
+                                'outcome' => 'ignored',
+                                'reason' => 'decode_error',
                                 ...$logContext,
                                 'error' => [
                                     'message' => $entity->getErrorMessage(),
@@ -674,9 +877,14 @@ class Import
                         $range = range(ag($entity, 'IndexNumber'), $indexNumberEnd);
                         if (count($range) > $episodeRangeLimit) {
                             $this->logger->warning(
-                                "{action}: Ignoring '{client}: {user}@{backend}' - '{library.title} {segment.number}/{segment.of}' {item.type} '{item.id}: {item.title}' episode range, and treating it as single episode. Backend says it covers '{item.indexNumber}-{item.indexNumberEnd}' '{item.rangeCount}' The limit is '{rangeLimit}' per record.",
-                                [
-                                    'rangeLimit' => $episodeRangeLimit,
+                                message: "Treating episode range for {item.type} '{item.title}' in '{library.title}' from '{user}@{backend}' as a single episode: {item.indexNumber}-{item.indexNumberEnd} exceeds limit {range_limit}.",
+                                context: [
+                                    'event_name' => 'backend.response.processing',
+                                    'subsystem' => 'backend.import',
+                                    'operation' => 'expand_episode_range',
+                                    'outcome' => 'skipped',
+                                    'reason' => 'range_limit_exceeded',
+                                    'range_limit' => $episodeRangeLimit,
                                     'item' => [
                                         'id' => ag($entity, 'Id'),
                                         'title' => ag($entity, ['Name', 'OriginalTitle'], '??'),
@@ -692,8 +900,12 @@ class Import
                         } else {
                             foreach ($range as $i) {
                                 $this->logger->debug(
-                                    "{action}: Making virtual episode for '{client}:{user}@{backend}' '{library.title}] [{segment.number}/{segment.of}' {item.type} '{item.id}: {item.title}' '{item.indexNumber} => {item.i} of {item.indexNumberEnd}'.",
-                                    [
+                                    message: "Creating virtual episode {item.i} for {item.type} '{item.title}' in '{library.title}' from '{user}@{backend}'.",
+                                    context: [
+                                        'event_name' => 'backend.response.processing',
+                                        'subsystem' => 'backend.import',
+                                        'operation' => 'expand_episode_range',
+                                        'outcome' => 'completed',
                                         ...$logContext,
                                         'item' => [
                                             'id' => ag($entity, 'Id'),
@@ -715,35 +927,62 @@ class Import
                 } catch (Throwable $e) {
                     $this->logger->error(
                         ...lw(
-                            message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' parsing '{library.title} {segment.number}/{segment.of}' item response. '{error.message}' at '{error.file}:{error.line}'.",
-                            context: ['entity' => $entity, ...$logContext, ...exception_log($e)],
+                            message: "Processing library item from '{library.title}' segment {segment.number}/{segment.of} on '{user}@{backend}' failed.",
+                            context: [
+                                'event_name' => 'backend.operation.failed',
+                                'subsystem' => 'backend.import',
+                                'operation' => 'process_item',
+                                'outcome' => 'failed',
+                                ...$logContext,
+                                'entity' => $entity,
+                                ...exception_log($e),
+                            ],
                             e: $e,
                         ),
                     );
                 }
             }
+
+            $isParsed = true;
         } catch (Throwable $e) {
             $this->logger->error(
                 ...lw(
-                    message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' parsing of '{library.title} {segment.number}/{segment.of}' response. '{error.message}' at '{error.file}:{error.line}'.",
-                    context: [...$logContext, ...exception_log($e)],
+                    message: "Parsing library '{library.title}' segment {segment.number}/{segment.of} on '{user}@{backend}' failed.",
+                    context: [
+                        'event_name' => 'backend.operation.failed',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'parse_library_response',
+                        'outcome' => 'failed',
+                        ...$logContext,
+                        ...exception_log($e),
+                    ],
                     e: $e,
                 ),
             );
         }
 
         $end = microtime(true);
-        $this->logger->info(
-            "{action}: Parsing '{client}: {user}@{backend}' - '{library.title} {segment.number}/{segment.of}' completed in '{time.duration}'s.",
-            [
-                ...$logContext,
-                'time' => [
-                    'start' => $start,
-                    'end' => $end,
-                    'duration' => round($end - $start, 2),
+
+        if (true === $isParsed) {
+            $duration = round($end - $start, 2);
+
+            $this->logger->info(
+                message: "Parsed library '{library.title}' segment {segment.number}/{segment.of} from '{user}@{backend}' in {duration_seconds}s.",
+                context: [
+                    'event_name' => 'backend.response.processing',
+                    'subsystem' => 'backend.import',
+                    'operation' => 'parse_library_response',
+                    'outcome' => 'completed',
+                    ...$logContext,
+                    'duration_seconds' => $duration,
+                    'time' => [
+                        'start' => $start,
+                        'end' => $end,
+                        'duration' => $duration,
+                    ],
                 ],
-            ],
-        );
+            );
+        }
 
         Message::increment('response.size', (int) $response->getInfo('size_download'));
     }
@@ -770,8 +1009,12 @@ class Import
 
         if ($context->trace) {
             $this->logger->debug(
-                "{action}: Processing '{client}: {user}@{backend}' {item.type} '{item.title} ({item.year})' payload.",
-                [
+                message: "Processing {item.type} '{item.title}' from '{user}@{backend}'.",
+                context: [
+                    'event_name' => 'backend.response.received',
+                    'subsystem' => 'backend.import',
+                    'operation' => 'process_item',
+                    'outcome' => 'received',
                     ...$logContext,
                     'response' => ['body' => $item],
                 ],
@@ -782,7 +1025,7 @@ class Import
         $showMetadata = $this->cacheShowMetadata(context: $context, guid: $guid, item: $item, logContext: $logContext);
 
         if ([] === ag($showMetadata, 'guids', [])) {
-            $message = "{action}: Ignoring '{client}: {user}@{backend}' - '{item.title}'. {item.type} has no valid/supported external ids.";
+            $message = "Ignoring {item.type} '{item.title}' from '{user}@{backend}': no supported external IDs.";
 
             if (empty($providersId)) {
                 $message .= ' Most likely unmatched {item.type}.';
@@ -790,6 +1033,11 @@ class Import
 
             $this->logger->info($message, [
                 'guids' => !empty($providersId) ? $providersId : 'None',
+                'event_name' => 'backend.item.ignored',
+                'subsystem' => 'backend.import',
+                'operation' => 'process_item',
+                'outcome' => 'ignored',
+                'reason' => 'missing_supported_guid',
                 ...$logContext,
             ]);
 
@@ -824,10 +1072,17 @@ class Import
 
         try {
             if ($context->trace) {
-                $this->logger->debug("{action}: Processing '{client}: {user}@{backend}' response payload.", [
-                    ...$logContext,
-                    'response' => ['body' => $item],
-                ]);
+                $this->logger->debug(
+                    message: "Processing {item.type} '{item.title}' from '{user}@{backend}'.",
+                    context: [
+                        'event_name' => 'backend.response.received',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'process_item',
+                        'outcome' => 'received',
+                        ...$logContext,
+                        'response' => ['body' => $item],
+                    ],
+                );
             }
 
             Message::increment("{$context->backendName}.{$mappedType}.total");
@@ -846,10 +1101,10 @@ class Import
                             'episode' => str_pad((string) ag($item, 'IndexNumber', 0), 3, '0', STR_PAD_LEFT),
                         ]),
                         default => throw new InvalidArgumentException(
-                            r("Unexpected Content type '{type}: {title}' was received.", [
-                                'type' => $type,
-                                'title' => ag($item, ['Name', 'OriginalTitle', 'SeriesName'], '??'),
-                            ]),
+                            r(
+                                "Unexpected content type '{type}' was received from '{user}@{backend}'.",
+                                [...$logContext, 'type' => $type],
+                            ),
                         ),
                     },
                     'type' => ag($item, 'Type'),
@@ -857,16 +1112,15 @@ class Import
             } catch (InvalidArgumentException $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Failed to parse '{client}: {user}@{backend}' item response. '{error.kind}' with '{error.message}' at '{error.file}:{error.line}' ",
+                        message: "Failed to parse item response from '{user}@{backend}'.",
                         context: [
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'parse_item',
+                            'outcome' => 'failed',
                             'response' => ['body' => $item],
                             ...$logContext,
+                            ...exception_log($e),
                         ],
                         e: $e,
                     ),
@@ -885,8 +1139,13 @@ class Import
             if (true === $isPlayed && false === ag_exists($item, 'UserData.LastPlayedDate')) {
                 if ($context->trace) {
                     $this->logger->debug(
-                        "{action}: The {item.type} '{client}: {user}@{backend}' - '{item.id}: {item.title}' is marked as played without LastPlayedDate field.",
-                        [
+                        message: "Using 'DateCreated' for {item.type} '{item.title}' from '{user}@{backend}': 'LastPlayedDate' is missing.",
+                        context: [
+                            'event_name' => 'backend.response.processing',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'normalize_played_date',
+                            'outcome' => 'skipped',
+                            'reason' => 'missing_last_played_date',
                             'response' => ['body' => $item],
                             ...$logContext,
                         ],
@@ -897,8 +1156,13 @@ class Import
 
             if (null === ag($item, $dateKey)) {
                 $this->logger->debug(
-                    message: "{action}: Ignoring '{client}: {user}@{backend}' - '{item.id}: {item.title}'. No date key '{date_key}' is set on object. '{response.body}'",
+                    message: "Ignoring {item.type} '#{item.id}: {item.title}' from '{user}@{backend}': missing date '{date_key}'.",
                     context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'process_item',
+                        'outcome' => 'ignored',
+                        'reason' => 'missing_date',
                         'date_key' => $dateKey,
                         'response' => ['body' => $item],
                         ...$logContext,
@@ -929,8 +1193,16 @@ class Import
             } catch (Throwable $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Exception '{error.kind}' occurred during '{client}: {user}@{backend}' - '{library.title}' - '{item.id}: {item.title}' entity creation. '{error.message}' at '{error.file}:{error.line}'.",
-                        context: [...$logContext, ...exception_log($e)],
+                        message: "Creating local entity for {item.type} '{item.title}' from '{user}@{backend}' failed.",
+                        context: [
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'create_entity',
+                            'outcome' => 'failed',
+                            ...$logContext,
+                            'response' => ['body' => $item],
+                            ...exception_log($e),
+                        ],
                         e: $e,
                     ),
                 );
@@ -941,7 +1213,7 @@ class Import
 
             if (false === $entity->hasGuids() && false === $entity->hasRelativeGuid()) {
                 $providerIds = (array) ag($item, 'ProviderIds', []);
-                $message = "{action}: Ignoring '{client}: {user}@{backend}' - '{item.title}'. No valid/supported external ids.";
+                $message = "Ignoring {item.type} '{item.title}' from '{user}@{backend}': no supported external IDs.";
 
                 if (empty($providerIds)) {
                     $message .= " Most likely unmatched '{item.type}'.";
@@ -949,6 +1221,11 @@ class Import
 
                 $this->logger->info($message, [
                     'guids' => !empty($providerIds) ? $providerIds : 'None',
+                    'event_name' => 'backend.item.ignored',
+                    'subsystem' => 'backend.import',
+                    'operation' => 'create_entity',
+                    'outcome' => 'ignored',
+                    'reason' => 'missing_supported_guid',
                     ...$logContext,
                 ]);
 
@@ -968,8 +1245,16 @@ class Import
         } catch (Throwable $e) {
             $this->logger->error(
                 ...lw(
-                    message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}'  - '{library.title}' - '{item.title}' {action}. '{error.message}' at '{error.file}:{error.line}'.",
-                    context: [...$logContext, ...exception_log($e)],
+                    message: "Processing item response from '{user}@{backend}' failed.",
+                    context: [
+                        'event_name' => 'backend.operation.failed',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'process_item',
+                        'outcome' => 'failed',
+                        ...$logContext,
+                        'response' => ['body' => $item],
+                        ...exception_log($e),
+                    ],
                     e: $e,
                 ),
             );

--- a/src/Backends/Jellyfin/Action/ParseWebhook.php
+++ b/src/Backends/Jellyfin/Action/ParseWebhook.php
@@ -110,7 +110,7 @@ final class ParseWebhook
             return new Response(status: false, extra: [
                 'http_code' => Status::BAD_REQUEST->value,
                 'message' => r(
-                    text: "Ignoring '{client}: {user}@{backend}' request. Invalid request, no payload.",
+                    text: "Ignoring backend request from '{user}@{backend}': payload is missing.",
                     context: $logContext,
                 ),
             ]);
@@ -242,8 +242,13 @@ final class ParseWebhook
                 return new Response(
                     status: false,
                     error: new Error(
-                        message: "{action}: Ignoring '{client}: {user}@{backend}' - '{title}' webhook event. No valid/supported external ids.",
+                        message: "Ignoring webhook item '{title}' from '{user}@{backend}': no supported GUIDs were found.",
                         context: [
+                            'event_name' => 'backend.item.ignored',
+                            'subsystem' => 'backend.webhook',
+                            'operation' => 'parse_webhook',
+                            'outcome' => 'ignored',
+                            'reason' => 'missing_supported_guid',
                             'title' => $entity->getName(),
                             ...$logContext,
                             'context' => [
@@ -270,22 +275,14 @@ final class ParseWebhook
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' webhook event parsing. {error.message} at '{error.file}:{error.line}'.",
+                    message: "Failed to parse webhook event from '{user}@{backend}'.",
                     context: [
-                        'error' => [
-                            'kind' => $e::class,
-                            'line' => $e->getLine(),
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
+                        'event_name' => 'backend.operation.failed',
+                        'subsystem' => 'backend.webhook',
+                        'operation' => 'parse_webhook',
+                        'outcome' => 'failed',
                         ...$logContext,
-                        'exception' => [
-                            'file' => $e->getFile(),
-                            'line' => $e->getLine(),
-                            'kind' => get_class($e),
-                            'message' => $e->getMessage(),
-                            'trace' => $e->getTrace(),
-                        ],
+                        ...exception_log($e),
                         'context' => [
                             'attributes' => $request->getAttributes(),
                             'payload' => $request->getParsedBody(),

--- a/src/Backends/Jellyfin/Action/Progress.php
+++ b/src/Backends/Jellyfin/Action/Progress.php
@@ -156,16 +156,30 @@ class Progress
 
             if ($context->backendName === $entity->via) {
                 $this->logger->info(
-                    message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. Event originated from this backend.",
-                    context: $logContext,
+                    message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': event originated from this backend.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.progress',
+                        'operation' => 'prepare_progress_update',
+                        'outcome' => 'ignored',
+                        'reason' => 'origin_backend',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
 
             if (null === ag($metadata, iState::COLUMN_ID, null)) {
                 $this->logger->warning(
-                    message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. No metadata was found.",
-                    context: $logContext,
+                    message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': backend metadata is missing.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.progress',
+                        'operation' => 'load_remote_state',
+                        'outcome' => 'ignored',
+                        'reason' => 'missing_backend_metadata',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
@@ -173,8 +187,15 @@ class Progress
             $senderDate = ag($entity->getExtra($entity->via), iState::COLUMN_EXTRA_DATE);
             if (null === $senderDate) {
                 $this->logger->warning(
-                    message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. The event originator did not set a date.",
-                    context: $logContext,
+                    message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': sender event date is missing.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.progress',
+                        'operation' => 'prepare_progress_update',
+                        'outcome' => 'ignored',
+                        'reason' => 'missing_event_date',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
@@ -184,12 +205,18 @@ class Progress
             $datetime = ag($entity->getExtra($context->backendName), iState::COLUMN_EXTRA_DATE, null);
             if (false === $ignoreDate && null !== $datetime && make_date($datetime)->getTimestamp() > $senderDate) {
                 $this->logger->warning(
-                    message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. Event date '{event_date}' is older than backend local db item date '{local_date}'.",
+                    message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': event date is not newer than local backend history.",
                     context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.progress',
+                        'operation' => 'compare_dates',
+                        'outcome' => 'ignored',
+                        'reason' => 'date_not_newer_than_local_history',
                         ...$logContext,
-                        'event_date' => make_date($senderDate),
-                        'local_date' => make_date($datetime),
-                        'compare' => ['remote' => make_date($datetime), 'sender' => make_date($senderDate)],
+                        'comparison' => [
+                            'local' => make_date($datetime),
+                            'sender' => make_date($senderDate),
+                        ],
                     ],
                 );
                 continue;
@@ -198,9 +225,16 @@ class Progress
             $logContext['remote']['id'] = ag($metadata, iState::COLUMN_ID);
 
             if (array_key_exists($logContext['remote']['id'], $sessions)) {
-                $this->logger->notice(
-                    message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. The item is playing right now.",
-                    context: $logContext,
+                $this->logger->info(
+                    message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': item is active in another session.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.progress',
+                        'operation' => 'prepare_progress_update',
+                        'outcome' => 'ignored',
+                        'reason' => 'active_session',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
@@ -211,12 +245,15 @@ class Progress
 
                 if (false === $ignoreDate && make_date($remoteItem->updated)->getTimestamp() > $senderDate) {
                     $this->logger->info(
-                        message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. Event date '{event_date}' is older than backend remote item date '{remote_date}'.",
+                        message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': event date is not newer than backend state.",
                         context: [
+                            'event_name' => 'backend.item.ignored',
+                            'subsystem' => 'backend.progress',
+                            'operation' => 'compare_dates',
+                            'outcome' => 'ignored',
+                            'reason' => 'date_not_newer_than_remote_state',
                             ...$logContext,
-                            'event_date' => make_date($senderDate),
-                            'remote_date' => make_date($remoteItem->updated),
-                            'compare' => [
+                            'comparison' => [
                                 'remote' => make_date($remoteItem->updated),
                                 'sender' => make_date($senderDate),
                             ],
@@ -230,8 +267,15 @@ class Progress
                     $minThreshold = (int) Config::get('progress.minThreshold', 86_400);
                     if (false === ($allowUpdate >= $minThreshold && time() > ($entity->updated + $allowUpdate))) {
                         $this->logger->info(
-                            message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. The backend says the item is marked as watched.",
-                            context: $logContext,
+                            message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': backend item is already watched.",
+                            context: [
+                                'event_name' => 'backend.item.ignored',
+                                'subsystem' => 'backend.progress',
+                                'operation' => 'update_progress',
+                                'outcome' => 'ignored',
+                                'reason' => 'remote_marked_watched',
+                                ...$logContext,
+                            ],
                         );
                         continue;
                     }
@@ -239,22 +283,14 @@ class Progress
             } catch (\App\Libs\Exceptions\RuntimeException|RuntimeException|InvalidArgumentException $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' get {item.type} '#{item.id}: {item.title}' status. '{error.message}' at '{error.file}:{error.line}'.",
+                        message: "Failed to load backend state for {item.type} '#{item.id}: {item.title}' from '{user}@{backend}'.",
                         context: [
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.progress',
+                            'operation' => 'load_remote_state',
+                            'outcome' => 'failed',
                             ...$logContext,
-                            'exception' => [
-                                'file' => $e->getFile(),
-                                'line' => $e->getLine(),
-                                'kind' => get_class($e),
-                                'message' => $e->getMessage(),
-                                'trace' => $e->getTrace(),
-                            ],
+                            ...exception_log($e),
                         ],
                         e: $e,
                     ),
@@ -273,8 +309,12 @@ class Progress
                 $logContext['remote']['url'] = (string) $url;
 
                 $this->logger->debug(
-                    message: "{action}: Updating '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' watch progress to '{progress}'.",
+                    message: "Updating watch progress for {item.type} '#{item.id}: {item.title}' on '{user}@{backend}'.",
                     context: [
+                        'event_name' => 'backend.request.started',
+                        'subsystem' => 'backend.progress',
+                        'operation' => 'update_progress',
+                        'outcome' => 'started',
                         ...$logContext,
                         'progress' => format_duration($progressValue),
                         // -- convert secs to ms for jellyfin/emby to understand it.
@@ -311,8 +351,12 @@ class Progress
 
                                 if (false === in_array(Status::tryFrom($statusCode), [Status::OK, Status::NO_CONTENT], true)) {
                                     $this->logger->error(
-                                        message: "{action}: Request to change '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' watch progress returned with unexpected '{status_code}' status code.",
+                                        message: "Watch-progress update for {item.type} '#{item.id}: {item.title}' on '{user}@{backend}' returned status {status_code}.",
                                         context: [
+                                            'event_name' => 'backend.response.failed',
+                                            'subsystem' => 'backend.progress',
+                                            'operation' => 'update_progress',
+                                            'outcome' => 'failed',
                                             ...$requestContext,
                                             'status_code' => $statusCode,
                                         ],
@@ -322,8 +366,12 @@ class Progress
                                 }
 
                                 $this->logger->notice(
-                                    message: "{action}: Updated '{client}: {user}@{backend}' '#{item.id}: {item.title}' watch progress to '{progress}'.",
+                                    message: "Updated watch progress for '#{item.id}: {item.title}' on '{user}@{backend}'.",
                                     context: [
+                                        'event_name' => 'backend.state_update.completed',
+                                        'subsystem' => 'backend.progress',
+                                        'operation' => 'update_progress',
+                                        'outcome' => 'completed',
                                         ...$requestContext,
                                         'status_code' => $statusCode,
                                     ],
@@ -334,8 +382,12 @@ class Progress
                             error: function (Throwable $e) use ($requestContext): array {
                                 $this->logger->error(
                                     ...lw(
-                                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request to change watch progress of {item.type} '#{item.id}: {item.title}'. '{error.message}' at '{error.file}:{error.line}'.",
+                                        message: "Watch-progress request failed for {item.type} '#{item.id}: {item.title}' on '{user}@{backend}'.",
                                         context: [
+                                            'event_name' => 'backend.client.request_failed',
+                                            'subsystem' => 'backend.progress',
+                                            'operation' => 'update_progress',
+                                            'outcome' => 'failed',
                                             ...$requestContext,
                                             ...exception_log($e),
                                         ],
@@ -355,22 +407,14 @@ class Progress
             } catch (Throwable $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' change {item.type} '#{item.id}: {item.title}' watch progress. '{error.message}' at '{error.file}:{error.line}'.",
+                        message: "Failed to prepare watch-progress update for {item.type} '#{item.id}: {item.title}' on '{user}@{backend}'.",
                         context: [
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.progress',
+                            'operation' => 'prepare_progress_update',
+                            'outcome' => 'failed',
                             ...$logContext,
-                            'exception' => [
-                                'file' => $e->getFile(),
-                                'line' => $e->getLine(),
-                                'kind' => get_class($e),
-                                'message' => $e->getMessage(),
-                                'trace' => $e->getTrace(),
-                            ],
+                            ...exception_log($e),
                         ],
                         e: $e,
                     ),

--- a/src/Backends/Jellyfin/Action/Proxy.php
+++ b/src/Backends/Jellyfin/Action/Proxy.php
@@ -22,6 +22,10 @@ class Proxy
 
     private string $action = 'jellyfin.proxy';
 
+    /**
+     * @param iHttp&\App\Libs\Extends\HttpClient $http
+     * @param iLogger $logger
+     */
     public function __construct(
         protected readonly iHttp $http,
         protected readonly iLogger $logger,
@@ -59,8 +63,18 @@ class Proxy
                 ];
 
                 $this->logger->debug(
-                    message: "{action}: proxying request via '{client}: {user}@{backend}'.",
-                    context: $logContext,
+                    message: "Proxying {http.method} request to '{user}@{backend}'.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.request.started',
+                        'subsystem' => 'backend.proxy',
+                        'operation' => 'proxy',
+                        'outcome' => 'started',
+                        'http' => [
+                            'method' => $method->value,
+                            'url' => $url,
+                        ],
+                    ],
                 );
 
                 $requestOpts = $context->getHttpOptions();

--- a/src/Backends/Jellyfin/Action/Push.php
+++ b/src/Backends/Jellyfin/Action/Push.php
@@ -111,8 +111,15 @@ class Push
 
             if (null === ag($metadata, iState::COLUMN_ID, null)) {
                 $this->logger->warning(
-                    message: "{action}: Ignoring '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. No metadata was found.",
-                    context: $logContext,
+                    message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': backend metadata is missing.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.push',
+                        'operation' => 'load_remote_state',
+                        'outcome' => 'ignored',
+                        'reason' => 'missing_backend_metadata',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
@@ -139,8 +146,14 @@ class Push
                 $logContext['remote']['url'] = (string) $url;
 
                 $this->logger->debug(
-                    message: "{action}: Requesting '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' metadata.",
-                    context: $logContext,
+                    message: "Loading backend state for {item.type} '#{item.id}: {item.title}' from '{user}@{backend}'.",
+                    context: [
+                        'event_name' => 'backend.request.started',
+                        'subsystem' => 'backend.push',
+                        'operation' => 'load_remote_state',
+                        'outcome' => 'started',
+                        ...$logContext,
+                    ],
                 );
 
                 $requests[] = $this->http->request(
@@ -153,22 +166,14 @@ class Push
             } catch (Throwable $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Exception '{error.kind}' unhandled during '{client}: {user}@{backend}' request for {item.type} '#{item.id}: {item.title}' metadata. {error.message} at '{error.file}:{error.line}'.",
+                        message: "Failed to load backend state for {item.type} '#{item.id}: {item.title}' from '{user}@{backend}'.",
                         context: [
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
+                            'event_name' => 'backend.client.request_failed',
+                            'subsystem' => 'backend.push',
+                            'operation' => 'load_remote_state',
+                            'outcome' => 'failed',
                             ...$logContext,
-                            'exception' => [
-                                'file' => $e->getFile(),
-                                'line' => $e->getLine(),
-                                'kind' => get_class($e),
-                                'message' => $e->getMessage(),
-                                'trace' => $e->getTrace(),
-                            ],
+                            ...exception_log($e),
                         ],
                         e: $e,
                     ),
@@ -184,8 +189,15 @@ class Push
             try {
                 if (null === ($id = ag($response->getInfo('user_data'), 'id'))) {
                     $this->logger->error(
-                        message: "{action}: Unable to get entity object id for '{client}: {user}@{backend}'.",
-                        context: $logContext,
+                        message: "Push response for '{user}@{backend}' is missing the local entity reference.",
+                        context: [
+                            'event_name' => 'backend.response.failed',
+                            'subsystem' => 'backend.push',
+                            'operation' => 'load_remote_state',
+                            'outcome' => 'failed',
+                            'reason' => 'missing_entity_reference',
+                            ...$logContext,
+                        ],
                     );
                     continue;
                 }
@@ -197,13 +209,28 @@ class Push
                 if (Status::OK !== Status::tryFrom($response->getStatusCode())) {
                     if (Status::NOT_FOUND === Status::tryFrom($response->getStatusCode())) {
                         $this->logger->warning(
-                            message: "{action}: Request for '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' metadata returned with (404: Not Found) status code.",
-                            context: [...$logContext, 'status_code' => $response->getStatusCode()],
+                            message: "Backend state for {item.type} '#{item.id}: {item.title}' was not found on '{user}@{backend}'.",
+                            context: [
+                                'event_name' => 'backend.response.failed',
+                                'subsystem' => 'backend.push',
+                                'operation' => 'load_remote_state',
+                                'outcome' => 'failed',
+                                'reason' => 'not_found',
+                                ...$logContext,
+                                'status_code' => $response->getStatusCode(),
+                            ],
                         );
                     } else {
                         $this->logger->error(
-                            message: "{action}: Request for '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' metadata returned with unexpected '{status_code}' status code.",
-                            context: [...$logContext, 'status_code' => $response->getStatusCode()],
+                            message: "Backend state request for {item.type} '#{item.id}: {item.title}' on '{user}@{backend}' returned status {status_code}.",
+                            context: [
+                                'event_name' => 'backend.response.failed',
+                                'subsystem' => 'backend.push',
+                                'operation' => 'load_remote_state',
+                                'outcome' => 'failed',
+                                ...$logContext,
+                                'status_code' => $response->getStatusCode(),
+                            ],
                         );
                     }
 
@@ -218,17 +245,33 @@ class Push
 
                 if ($context->trace) {
                     $this->logger->debug(
-                        message: "{action}: Parsing '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' payload.",
-                        context: [...$logContext, 'response' => ['body' => $json]],
+                        message: "Parsing backend state for {item.type} '#{item.id}: {item.title}' from '{user}@{backend}'.",
+                        context: [
+                            'event_name' => 'backend.response.received',
+                            'subsystem' => 'backend.push',
+                            'operation' => 'load_remote_state',
+                            'outcome' => 'received',
+                            ...$logContext,
+                            'response' => ['body' => $json],
+                        ],
                     );
                 }
 
                 $isWatched = (int) (bool) ag($json, 'UserData.Played', false);
+                $playState = 1 === $isWatched ? 'Played' : 'Unplayed';
 
                 if ($entity->watched === $isWatched) {
                     $this->logger->info(
-                        message: "{action}: Ignoring '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}'. Play state is identical.",
-                        context: $logContext,
+                        message: "Ignoring {item.type} '#{item.id}: {item.title}' from '{user}@{backend}': play state is already '{play_state}'.",
+                        context: [
+                            'event_name' => 'backend.item.ignored',
+                            'subsystem' => 'backend.push',
+                            'operation' => 'update_state',
+                            'outcome' => 'ignored',
+                            'reason' => 'state_unchanged',
+                            ...$logContext,
+                            'play_state' => $playState,
+                        ],
                     );
                     continue;
                 }
@@ -237,8 +280,17 @@ class Push
                     $dateKey = 1 === $isWatched ? 'UserData.LastPlayedDate' : 'DateCreated';
                     if (null === ($date = ag($json, $dateKey))) {
                         $this->logger->error(
-                            message: "{action}: Ignoring '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}'. No {date_key} is set on backend object.",
-                            context: ['date_key' => $dateKey, ...$logContext, 'response' => ['body' => $json]],
+                            message: "Ignoring {item.type} '#{item.id}: {item.title}' from '{user}@{backend}': missing backend date '{date_key}'.",
+                            context: [
+                                'event_name' => 'backend.item.ignored',
+                                'subsystem' => 'backend.push',
+                                'operation' => 'update_state',
+                                'outcome' => 'ignored',
+                                'reason' => 'missing_date',
+                                'date_key' => $dateKey,
+                                ...$logContext,
+                                'response' => ['body' => $json],
+                            ],
                         );
                         continue;
                     }
@@ -249,8 +301,13 @@ class Push
 
                     if ($date->getTimestamp() >= ($timeExtra + $entity->updated)) {
                         $this->logger->notice(
-                            message: "{action}: Ignoring '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}'. Database date is older than backend date.",
+                            message: "Ignoring {item.type} '#{item.id}: {item.title}' from '{user}@{backend}': backend date is newer than local state.",
                             context: [
+                                'event_name' => 'backend.item.ignored',
+                                'subsystem' => 'backend.push',
+                                'operation' => 'update_state',
+                                'outcome' => 'ignored',
+                                'reason' => 'backend_date_newer',
                                 ...$logContext,
                                 'comparison' => [
                                     'database' => make_date($entity->updated),
@@ -277,12 +334,17 @@ class Push
                 }
 
                 $logContext['remote']['url'] = (string) $url;
-                $playState = $entity->isWatched() ? 'Played' : 'Unplayed';
-                $requestContext = $logContext + ['play_state' => $playState];
+                $requestContext = $logContext + ['play_state' => $entity->isWatched() ? 'Played' : 'Unplayed'];
 
                 $this->logger->debug(
-                    message: "{action}: Queuing request to change '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' play state to '{play_state}'.",
-                    context: $requestContext,
+                    message: "Updating play state for {item.type} '#{item.id}: {item.title}' on '{user}@{backend}' to '{play_state}'.",
+                    context: [
+                        'event_name' => 'backend.request.started',
+                        'subsystem' => 'backend.push',
+                        'operation' => 'update_state',
+                        'outcome' => 'started',
+                        ...$requestContext,
+                    ],
                 );
 
                 if (false === (bool) ag($context->options, Options::DRY_RUN, false)) {
@@ -302,8 +364,12 @@ class Push
 
                                 if (Status::OK !== Status::tryFrom($statusCode)) {
                                     $this->logger->error(
-                                        message: "{action}: Request to change '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' play state returned with unexpected '{status_code}' status code.",
+                                        message: "Play-state update for {item.type} '#{item.id}: {item.title}' on '{user}@{backend}' returned status {status_code}.",
                                         context: [
+                                            'event_name' => 'backend.response.failed',
+                                            'subsystem' => 'backend.push',
+                                            'operation' => 'update_state',
+                                            'outcome' => 'failed',
                                             ...$requestContext,
                                             'status_code' => $statusCode,
                                         ],
@@ -313,8 +379,14 @@ class Push
                                 }
 
                                 $this->logger->notice(
-                                    message: "{action}: Updated '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' play state to '{play_state}'.",
-                                    context: $requestContext,
+                                    message: "Updated play state for {item.type} '#{item.id}: {item.title}' on '{user}@{backend}' to '{play_state}'.",
+                                    context: [
+                                        'event_name' => 'backend.state_update.completed',
+                                        'subsystem' => 'backend.push',
+                                        'operation' => 'update_state',
+                                        'outcome' => 'completed',
+                                        ...$requestContext,
+                                    ],
                                 );
 
                                 if (true !== $entity->isWatched()) {
@@ -344,8 +416,12 @@ class Push
                             error: function (Throwable $e) use ($requestContext): array {
                                 $this->logger->error(
                                     ...lw(
-                                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request to change play state of {item.type} '#{item.id}: {item.title}'. '{error.message}' at '{error.file}:{error.line}'.",
+                                        message: "Play-state request failed for {item.type} '#{item.id}: {item.title}' on '{user}@{backend}'.",
                                         context: [
+                                            'event_name' => 'backend.client.request_failed',
+                                            'subsystem' => 'backend.push',
+                                            'operation' => 'update_state',
+                                            'outcome' => 'failed',
                                             ...$requestContext,
                                             ...exception_log($e),
                                         ],
@@ -365,22 +441,14 @@ class Push
             } catch (Throwable $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' push play state. {error.message} at '{error.file}:{error.line}'.",
+                        message: "Failed to prepare play-state update for {item.type} '#{item.id}: {item.title}' on '{user}@{backend}'.",
                         context: [
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.push',
+                            'operation' => 'prepare_state_update',
+                            'outcome' => 'failed',
                             ...$logContext,
-                            'exception' => [
-                                'file' => $e->getFile(),
-                                'line' => $e->getLine(),
-                                'kind' => get_class($e),
-                                'message' => $e->getMessage(),
-                                'trace' => $e->getTrace(),
-                            ],
+                            ...exception_log($e),
                         ],
                         e: $e,
                     ),

--- a/src/Backends/Jellyfin/Action/SearchQuery.php
+++ b/src/Backends/Jellyfin/Action/SearchQuery.php
@@ -37,6 +37,12 @@ class SearchQuery
      */
     protected string $action = 'jellyfin.searchQuery';
 
+    /**
+     * @param iHttp&\App\Libs\Extends\HttpClient $http
+     * @param iLogger $logger
+     * @param JellyfinGuid $jellyfinGuid
+     * @param iDB $db
+     */
     public function __construct(
         protected iHttp $http,
         protected iLogger $logger,
@@ -104,7 +110,14 @@ class SearchQuery
             'url' => (string) $url,
         ];
 
-        $this->logger->debug("{action}: Searching '{client}: {user}@{backend}' libraries for '{query}'.", $logContext);
+        $this->logger->debug("Searching '{user}@{backend}' for '{query}'.", [
+            ...$logContext,
+            'event_name' => 'backend.request.started',
+            'subsystem' => 'backend.search',
+            'operation' => 'query',
+            'outcome' => 'started',
+            'http' => ['url' => (string) $url],
+        ]);
 
         $response = $this->http->request(
             method: Method::GET,
@@ -119,10 +132,19 @@ class SearchQuery
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Search request for '{query}' in '{client}: {user}@{backend}' returned with unexpected '{status_code}' status code.",
+                    message: "Search request for '{query}' on '{user}@{backend}' returned status {http.status_code}.",
                     context: [
                         ...$logContext,
-                        'status_code' => $response->getStatusCode(),
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.search',
+                        'operation' => 'query',
+                        'outcome' => 'failed',
+                        'reason' => 'unexpected_status',
+                        'http' => [
+                            'status_code' => $response->getStatusCode(),
+                            'expected_status_codes' => [Status::OK->value],
+                            'url' => (string) $url,
+                        ],
                     ],
                     level: Levels::ERROR,
                 ),
@@ -137,8 +159,15 @@ class SearchQuery
 
         if ($context->trace) {
             $this->logger->debug(
-                message: "{action}: Parsing Searching '{client}: {user}@{backend}' libraries for '{query}' payload.",
-                context: [...$logContext, 'response' => ['body' => $json]],
+                message: "Processing search response from '{user}@{backend}' for '{query}'.",
+                context: [
+                    ...$logContext,
+                    'event_name' => 'backend.response.received',
+                    'subsystem' => 'backend.search',
+                    'operation' => 'query',
+                    'outcome' => 'received',
+                    'response' => ['body' => $json],
+                ],
             );
         }
 
@@ -151,8 +180,15 @@ class SearchQuery
                 $entity = $this->createEntity($context, $jellyfinGuid, $item, $opts);
             } catch (Throwable $e) {
                 $this->logger->error(
-                    message: "{action}: Failed to map '{client}: {user}@{backend}' item to entity. {error}",
-                    context: [...$logContext, 'error' => $e->getMessage()],
+                    message: "Failed to map search result from '{user}@{backend}' to a local entity.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.operation.failed',
+                        'subsystem' => 'backend.search',
+                        'operation' => 'map_result',
+                        'outcome' => 'failed',
+                        ...exception_log($e),
+                    ],
                 );
                 continue;
             }

--- a/src/Backends/Jellyfin/Action/UpdateState.php
+++ b/src/Backends/Jellyfin/Action/UpdateState.php
@@ -84,8 +84,13 @@ class UpdateState
 
                     if (true === (bool) ag($context->options, Options::DRY_RUN, false)) {
                         $this->logger->notice(
-                            message: "{action}: Would mark '{client}: {user}@{backend}' {item.type} '{item.title}' as '{item.play_state}'.",
+                            message: "Would update play state for {item.type} '{item.title}' on '{user}@{backend}' to '{item.play_state}'.",
                             context: [
+                                'event_name' => 'backend.request.skipped',
+                                'subsystem' => 'backend.restore',
+                                'operation' => 'update_state',
+                                'outcome' => 'skipped',
+                                'reason' => 'dry_run',
                                 ...$rContext,
                                 'item' => [
                                     'id' => $itemId,
@@ -98,29 +103,44 @@ class UpdateState
                         return new Response(status: true);
                     }
 
+                    $requestContext = [
+                        ...$rContext,
+                        'play_state' => $entity->isWatched() ? 'played' : 'unplayed',
+                        'item' => [
+                            'id' => $itemId,
+                            'title' => $entity->getName(),
+                            'type' => $entity->type === iState::TYPE_EPISODE ? 'episode' : 'movie',
+                            'state' => $entity->isWatched() ? 'played' : 'unplayed',
+                        ],
+                        'url' => (string) $url,
+                    ];
+
+                    $this->logger->debug(
+                        message: "Updating play state for {item.type} '{item.title}' on '{user}@{backend}' to '{play_state}'.",
+                        context: [
+                            'event_name' => 'backend.request.started',
+                            'subsystem' => 'backend.restore',
+                            'operation' => 'update_state',
+                            'outcome' => 'started',
+                            ...$requestContext,
+                        ],
+                    );
+
                     $queue->add(
                         new Request(
                             method: $entity->isWatched() ? Method::POST : Method::DELETE,
                             url: $url,
                             options: $context->getHttpOptions(),
-                            success: function (iResponse $response) use ($entity, $itemId, $rContext, $url): array {
-                                $requestContext = [
-                                    ...$rContext,
-                                    'play_state' => $entity->isWatched() ? 'played' : 'unplayed',
-                                    'item' => [
-                                        'id' => $itemId,
-                                        'title' => $entity->getName(),
-                                        'type' => $entity->type === iState::TYPE_EPISODE ? 'episode' : 'movie',
-                                        'state' => $entity->isWatched() ? 'played' : 'unplayed',
-                                    ],
-                                    'url' => (string) $url,
-                                ];
-
+                            success: function (iResponse $response) use ($requestContext): array {
                                 $statusCode = $response->getStatusCode();
                                 if (Status::OK !== Status::tryFrom($statusCode)) {
                                     $this->logger->error(
-                                        message: "{action}: Failed to change '{client}: {user}@{backend}' - '{item.title}' play state. Invalid HTTP '{status_code}' status code returned.",
+                                        message: "Play-state update for {item.type} '{item.title}' on '{user}@{backend}' returned status {status_code}.",
                                         context: [
+                                            'event_name' => 'backend.response.failed',
+                                            'subsystem' => 'backend.restore',
+                                            'operation' => 'update_state',
+                                            'outcome' => 'failed',
                                             ...$requestContext,
                                             'status_code' => $statusCode,
                                         ],
@@ -130,25 +150,28 @@ class UpdateState
                                 }
 
                                 $this->logger->notice(
-                                    message: "{action}: Changed '{client}: {user}@{backend}' - '{item.title}' play state to '{play_state}'.",
-                                    context: $requestContext,
+                                    message: "Updated play state for {item.type} '{item.title}' on '{user}@{backend}' to '{play_state}'.",
+                                    context: [
+                                        'event_name' => 'backend.state_update.completed',
+                                        'subsystem' => 'backend.restore',
+                                        'operation' => 'update_state',
+                                        'outcome' => 'completed',
+                                        ...$requestContext,
+                                    ],
                                 );
 
                                 return [];
                             },
-                            error: function (Throwable $e) use ($context, $entity, $itemId, $rContext): array {
+                            error: function (Throwable $e) use ($requestContext): array {
                                 $this->logger->error(
                                     ...lw(
-                                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' restore play state of {item.type} '{item.title}'. '{error.message}' at '{error.file}:{error.line}'.",
+                                        message: "Play-state request failed for {item.type} '{item.title}' on '{user}@{backend}'.",
                                         context: [
-                                            ...$rContext,
-                                            'play_state' => $entity->isWatched() ? 'played' : 'unplayed',
-                                            'item' => [
-                                                'id' => $itemId,
-                                                'title' => $entity->getName(),
-                                                'type' => $entity->type === iState::TYPE_EPISODE ? 'episode' : 'movie',
-                                                'state' => $entity->isWatched() ? 'played' : 'unplayed',
-                                            ],
+                                            'event_name' => 'backend.client.request_failed',
+                                            'subsystem' => 'backend.restore',
+                                            'operation' => 'update_state',
+                                            'outcome' => 'failed',
+                                            ...$requestContext,
                                             ...exception_log($e),
                                         ],
                                         e: $e,
@@ -158,17 +181,7 @@ class UpdateState
                                 return [];
                             },
                             extras: [
-                                'context' => [
-                                    ...$rContext,
-                                    'play_state' => $entity->isWatched() ? 'played' : 'unplayed',
-                                    'item' => [
-                                        'id' => $itemId,
-                                        'title' => $entity->getName(),
-                                        'type' => $entity->type === iState::TYPE_EPISODE ? 'episode' : 'movie',
-                                        'state' => $entity->isWatched() ? 'played' : 'unplayed',
-                                    ],
-                                    'url' => (string) $url,
-                                ],
+                                'context' => $requestContext,
                                 iHttp::class => $this->http,
                             ],
                         ),

--- a/src/Backends/Jellyfin/JellyfinClient.php
+++ b/src/Backends/Jellyfin/JellyfinClient.php
@@ -851,12 +851,28 @@ class JellyfinClient implements iClient
      */
     private function throwError(Response $response, string $className = RuntimeException::class, int $code = 0): void
     {
+        $message = ag($response->extra, 'message', null);
+
+        if (null === $message && null !== $response->error) {
+            $message = ag($response->error->extra, 'message', null);
+        }
+
+        if (!is_string($message) || '' === trim($message)) {
+            $message = $response->error?->format() ?? 'The backend request failed.';
+        }
+
+        $reason = ag($response->extra, 'error', null);
+
+        if (null === $reason && null !== $response->error) {
+            $reason = ag($response->error->extra, 'error', null);
+        }
+
+        if (is_string($reason) && '' !== trim($reason) && false === str_contains($message, $reason)) {
+            $message = trim($message . ' ' . $reason);
+        }
+
         throw new $className(
-            message: ag(
-                $response->extra,
-                'message',
-                static fn() => $response->error?->format() ?? 'The backend request failed.',
-            ),
+            message: $message,
             code: $code,
             previous: $response->error?->previous,
         );

--- a/src/Backends/Jellyfin/JellyfinClient.php
+++ b/src/Backends/Jellyfin/JellyfinClient.php
@@ -855,7 +855,7 @@ class JellyfinClient implements iClient
             message: ag(
                 $response->extra,
                 'message',
-                static fn() => $response->error?->format() ?? 'An unexpected error occurred.',
+                static fn() => $response->error?->format() ?? 'The backend request failed.',
             ),
             code: $code,
             previous: $response->error?->previous,

--- a/src/Backends/Jellyfin/JellyfinGuid.php
+++ b/src/Backends/Jellyfin/JellyfinGuid.php
@@ -52,17 +52,14 @@ class JellyfinGuid implements iGuid
                 $this->parseGUIDFile($file);
             }
         } catch (Throwable $e) {
-            $this->logger->error("{class}: Failed to read or parse '{guid}' file. Error '{error}'.", [
-                'class' => after_last(static::class, '\\'),
-                'guid' => $file,
-                'error' => $e->getMessage(),
-                'exception' => [
-                    'message' => $e->getMessage(),
-                    'code' => $e->getCode(),
-                    'file' => $e->getFile(),
-                    'line' => $e->getLine(),
-                    'trace' => $e->getTrace(),
-                ],
+            $this->logger->error("Failed to parse GUID mapping file '{file}' for {client}.", [
+                'event_name' => 'guid.file.parse_failed',
+                'subsystem' => 'guid',
+                'operation' => 'load_config',
+                'outcome' => 'failed',
+                'client' => $this->clientName(),
+                'file' => $file,
+                ...exception_log($e),
             ]);
         }
     }
@@ -85,7 +82,19 @@ class JellyfinGuid implements iGuid
         }
 
         if (filesize($file) < 1) {
-            $this->logger->info("The external GUID mapping file '{file}' is empty.", ['file' => $file]);
+            $this->logger->info("GUID mapping file '{file}' is empty.", [
+                'event_name' => 'guid.mapping.ignored',
+                'subsystem' => 'guid',
+                'operation' => 'load_config',
+                'outcome' => 'ignored',
+                'reason' => 'empty_file',
+                'reason_label' => 'mapping file is empty',
+                'client' => $this->clientName(),
+                'mapping_key' => null,
+                'mapping_from' => null,
+                'mapping_to' => null,
+                'file' => $file,
+            ]);
             return;
         }
 
@@ -132,9 +141,18 @@ class JellyfinGuid implements iGuid
 
         foreach ($mapping as $key => $map) {
             if (false === is_array($map)) {
-                $this->logger->warning("Ignoring 'links.{key}'. Value must be an object. '{given}' is given.", [
-                    'key' => $key,
-                    'type' => $this->type,
+                $this->logger->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                    'event_name' => 'guid.mapping.ignored',
+                    'subsystem' => 'guid',
+                    'operation' => 'parse_config',
+                    'outcome' => 'ignored',
+                    'reason' => 'invalid_link_value',
+                    'reason_label' => 'value must be an object',
+                    'client' => $this->clientName(),
+                    'mapping_key' => 'links.' . $key,
+                    'mapping_from' => null,
+                    'mapping_to' => null,
+                    'file' => $file,
                     'given' => get_debug_type($map),
                 ]);
                 continue;
@@ -147,9 +165,18 @@ class JellyfinGuid implements iGuid
             $mapper = ag($map, 'map', null);
 
             if (false === is_array($mapper)) {
-                $this->logger->warning("Ignoring 'links.{key}'. map value must be an object. '{given}' is given.", [
-                    'key' => $key,
-                    'type' => $this->type,
+                $this->logger->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                    'event_name' => 'guid.mapping.ignored',
+                    'subsystem' => 'guid',
+                    'operation' => 'parse_config',
+                    'outcome' => 'ignored',
+                    'reason' => 'invalid_map_value',
+                    'reason_label' => 'map must be an object',
+                    'client' => $this->clientName(),
+                    'mapping_key' => 'links.' . $key,
+                    'mapping_from' => null,
+                    'mapping_to' => null,
+                    'file' => $file,
                     'given' => get_debug_type($mapper),
                 ]);
                 continue;
@@ -159,35 +186,69 @@ class JellyfinGuid implements iGuid
             $to = ag($mapper, 'to', null);
 
             if (empty($from) || false === is_string($from)) {
-                $this->logger->warning("Ignoring 'links.{key}'. map.from field is empty or not a string.", [
-                    'type' => $this->type,
-                    'key' => $key,
+                $this->logger->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                    'event_name' => 'guid.mapping.ignored',
+                    'subsystem' => 'guid',
+                    'operation' => 'parse_config',
+                    'outcome' => 'ignored',
+                    'reason' => 'invalid_map_from',
+                    'reason_label' => 'map.from must be a non-empty string',
+                    'client' => $this->clientName(),
+                    'mapping_key' => 'links.' . $key,
+                    'mapping_from' => true === is_string($from) ? $from : null,
+                    'mapping_to' => true === is_string($to) ? $to : null,
+                    'file' => $file,
                 ]);
                 continue;
             }
 
             if (empty($to) || false === is_string($to)) {
-                $this->logger->warning("Ignoring 'links.{key}'. map.to field is empty or not a string.", [
-                    'type' => $this->type,
-                    'key' => $key,
+                $this->logger->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                    'event_name' => 'guid.mapping.ignored',
+                    'subsystem' => 'guid',
+                    'operation' => 'parse_config',
+                    'outcome' => 'ignored',
+                    'reason' => 'invalid_map_to',
+                    'reason_label' => 'map.to must be a non-empty string',
+                    'client' => $this->clientName(),
+                    'mapping_key' => 'links.' . $key,
+                    'mapping_from' => true === is_string($from) ? $from : null,
+                    'mapping_to' => true === is_string($to) ? $to : null,
+                    'file' => $file,
                 ]);
                 continue;
             }
 
             if (false === Guid::validateGUIDName($to)) {
-                $this->logger->warning("Ignoring 'links.{key}'. map.to '{to}' field does not starts with 'guid_'.", [
-                    'type' => $this->type,
-                    'key' => $key,
-                    'to' => $to,
+                $this->logger->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                    'event_name' => 'guid.mapping.ignored',
+                    'subsystem' => 'guid',
+                    'operation' => 'parse_config',
+                    'outcome' => 'ignored',
+                    'reason' => 'invalid_guid_type_name',
+                    'reason_label' => "map.to must start with 'guid_'",
+                    'client' => $this->clientName(),
+                    'mapping_key' => 'links.' . $key,
+                    'mapping_from' => $from,
+                    'mapping_to' => $to,
+                    'file' => $file,
                 ]);
                 continue;
             }
 
             if (false === in_array($to, $supported, true)) {
-                $this->logger->warning("Ignoring 'links.{key}'. map.to field is not a supported GUID type.", [
-                    'type' => $this->type,
-                    'key' => $key,
-                    'to' => $to,
+                $this->logger->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                    'event_name' => 'guid.mapping.ignored',
+                    'subsystem' => 'guid',
+                    'operation' => 'parse_config',
+                    'outcome' => 'ignored',
+                    'reason' => 'unsupported_guid_type',
+                    'reason_label' => 'map.to is not a supported GUID type',
+                    'client' => $this->clientName(),
+                    'mapping_key' => 'links.' . $key,
+                    'mapping_from' => $from,
+                    'mapping_to' => $to,
+                    'file' => $file,
                 ]);
                 continue;
             }
@@ -251,13 +312,20 @@ class JellyfinGuid implements iGuid
                 if (true === is_ignored_id($this->context->userContext, $bName, $type, $key, $value, $id)) {
                     if (true === $log) {
                         $this->logger->debug(
-                            "{class}: Ignoring '{client}: {user}@{backend}' external id '{source}' for {item.type} '{item.id}: {item.title}' as requested.",
+                            "Ignoring external id '{guid_source}:{guid_value}' for '#{item_id}' from '{user}@{backend}': {reason_label}.",
                             [
-                                'class' => after_last(static::class, '\\'),
+                                'event_name' => 'guid.external_id.ignored',
+                                'subsystem' => 'guid',
+                                'operation' => 'parse',
+                                'outcome' => 'ignored',
+                                'reason' => 'user_ignored',
+                                'reason_label' => 'external id is ignored by user config',
                                 'client' => $this->context->clientName,
                                 'user' => $this->context->userContext->name,
                                 'backend' => $bName,
-                                'source' => $key . '://' . $value,
+                                'item_id' => $id,
+                                'guid_source' => $key,
+                                'guid_value' => $value,
                                 'guid' => [
                                     'source' => $key,
                                     'value' => $value,
@@ -273,12 +341,20 @@ class JellyfinGuid implements iGuid
             } catch (Throwable $e) {
                 if (true === $log) {
                     $this->logger->info(
-                        message: "{class}: Ignoring '{user}@{backend}' invalid GUID '{agent}' for {item.type} '{item.id}: {item.title}'.",
+                        message: "Ignoring external id '{guid_source}:{guid_value}' for '#{item_id}' from '{user}@{backend}': {reason_label}.",
                         context: [
-                            'class' => after_last(static::class, '\\'),
+                            'event_name' => 'guid.external_id.ignored',
+                            'subsystem' => 'guid',
+                            'operation' => 'parse',
+                            'outcome' => 'ignored',
+                            'reason' => 'invalid_guid',
+                            'reason_label' => 'external id is invalid',
+                            'client' => $this->context->clientName,
                             'user' => $this->context->userContext->name,
                             'backend' => $this->context->backendName,
-                            'agent' => $value,
+                            'item_id' => $id,
+                            'guid_source' => $key,
+                            'guid_value' => $value,
                             ...$context,
                             ...exception_log($e),
                         ],
@@ -301,5 +377,10 @@ class JellyfinGuid implements iGuid
     public function getConfig(): array
     {
         return ['guidMapper' => $this->guidMapper];
+    }
+
+    private function clientName(): string
+    {
+        return $this->context->clientName ?? ('emby' === $this->type ? EmbyClient::CLIENT_NAME : JellyfinClient::CLIENT_NAME);
     }
 }

--- a/src/Backends/Jellyfin/JellyfinValidateContext.php
+++ b/src/Backends/Jellyfin/JellyfinValidateContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Backends\Jellyfin;
 
+use App\Backends\Common\CommonTrait;
 use App\Backends\Common\Context;
 use App\Backends\Jellyfin\Action\GetUser;
 use App\Libs\Container;
@@ -11,6 +12,7 @@ use App\Libs\Enums\Http\Method;
 use App\Libs\Enums\Http\Status;
 use App\Libs\Exceptions\Backends\InvalidContextException;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -18,6 +20,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface as iHttp;
 
 class JellyfinValidateContext
 {
+    use CommonTrait;
+
     public function __construct(
         private readonly iHttp $http,
     ) {}
@@ -102,17 +106,39 @@ class JellyfinValidateContext
         } catch (TransportExceptionInterface $e) {
             throw new InvalidContextException(r('Failed to connect to backend. {error}', ['error' => $e->getMessage()]), previous: $e);
         } catch (ClientExceptionInterface $e) {
-            throw new InvalidContextException(r('Got non 200 response. {error}', ['error' => $e->getMessage()]), previous: $e);
+            throw $this->httpException('Got non 200 response.', $e);
         } catch (RedirectionExceptionInterface $e) {
-            throw new InvalidContextException(
-                r('Redirection recursion detected. {error}', ['error' => $e->getMessage()]),
-                previous: $e,
-            );
+            throw $this->httpException('Redirection recursion detected.', $e);
         } catch (ServerExceptionInterface $e) {
-            throw new InvalidContextException(
-                r('Backend responded with 5xx error. {error}', ['error' => $e->getMessage()]),
-                previous: $e,
-            );
+            throw $this->httpException('Backend responded with 5xx error.', $e);
         }
+    }
+
+    /**
+     * Build a context-rich backend validation exception from an HTTP exception.
+     */
+    private function httpException(string $message, HttpExceptionInterface $e): InvalidContextException
+    {
+        $response = $e->getResponse();
+        $body = $response->getContent(false);
+        $reason = $this->getBackendResponseReason($body) ?? $e->getMessage();
+
+        $ex = new InvalidContextException(r('{message} Backend responded with {status_code}. {error}', [
+            'message' => $message,
+            'status_code' => $response->getStatusCode(),
+            'error' => $reason,
+        ]), previous: $e);
+
+        $ex->setContext([
+            'http' => [
+                'status_code' => $response->getStatusCode(),
+            ],
+            'response' => [
+                'body' => $body,
+                'reason' => $reason,
+            ],
+        ]);
+
+        return $ex;
     }
 }

--- a/src/Backends/Plex/Action/Backup.php
+++ b/src/Backends/Plex/Action/Backup.php
@@ -37,7 +37,11 @@ final class Backup extends Import
 
         try {
             if ($context->trace) {
-                $this->logger->debug("{action}: Processing '{client}: {backend}' payload.", [
+                $this->logger->debug('Parsing backup payload from \'{backend}\'.', [
+                    'event_name' => 'backend.response.received',
+                    'subsystem' => 'backend.backup',
+                    'operation' => 'process_item',
+                    'outcome' => 'received',
                     ...$logContext,
                     'response' => [
                         'body' => $item,
@@ -74,18 +78,18 @@ final class Backup extends Import
                 ];
             } catch (InvalidArgumentException $e) {
                 $this->logger->info(
-                    message: "{action}: Failed to parse '{client}: {backend}' item response. '{error.kind}' with '{error.message}' at '{error.file}:{error.line}' ",
+                    message: "Ignoring backup item from '{backend}': payload could not be parsed.",
                     context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.backup',
+                        'operation' => 'parse_item',
+                        'outcome' => 'ignored',
+                        'reason' => 'invalid_item_payload',
                         ...$logContext,
-                        'error' => [
-                            'kind' => $e::class,
-                            'line' => $e->getLine(),
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
                         'response' => [
                             'body' => $item,
                         ],
+                        ...exception_log($e),
                     ],
                 );
                 return;
@@ -175,23 +179,18 @@ final class Backup extends Import
             }
         } catch (Throwable $e) {
             $this->logger->error(
-                message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {backend}' backup. {error.message} at '{error.file}:{error.line}'.",
-                context: [
-                    ...$logContext,
-                    'error' => [
-                        'kind' => $e::class,
-                        'line' => $e->getLine(),
-                        'message' => $e->getMessage(),
-                        'file' => after($e->getFile(), ROOT_PATH),
+                ...lw(
+                    message: "Failed to back up {item.type} '{item.title}' from '{backend}'.",
+                    context: [
+                        'event_name' => 'backend.operation.failed',
+                        'subsystem' => 'backend.backup',
+                        'operation' => 'process_item',
+                        'outcome' => 'failed',
+                        ...$logContext,
+                        ...exception_log($e),
                     ],
-                    'exception' => [
-                        'file' => $e->getFile(),
-                        'line' => $e->getLine(),
-                        'kind' => get_class($e),
-                        'message' => $e->getMessage(),
-                        'trace' => $e->getTrace(),
-                    ],
-                ],
+                    e: $e,
+                ),
             );
         }
     }

--- a/src/Backends/Plex/Action/CreatePlaylist.php
+++ b/src/Backends/Plex/Action/CreatePlaylist.php
@@ -70,8 +70,15 @@ final class CreatePlaylist
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Missing machine identifier for '{client}: {user}@{backend}' playlist create request.",
-                    context: $logContext,
+                    message: "Cannot create playlist '{title}' on '{user}@{backend}': machine identifier is missing.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.request.skipped',
+                        'subsystem' => 'backend.playlist',
+                        'operation' => 'create',
+                        'outcome' => 'skipped',
+                        'reason' => 'missing_machine_identifier',
+                    ],
                     level: Levels::ERROR,
                 ),
             );
@@ -95,14 +102,39 @@ final class CreatePlaylist
                 'uri' => $uri,
             ]));
 
+        $this->logger->debug(
+            message: "Creating playlist '{title}' on '{user}@{backend}'.",
+            context: [
+                ...$logContext,
+                'event_name' => 'backend.request.started',
+                'subsystem' => 'backend.playlist',
+                'operation' => 'create',
+                'outcome' => 'started',
+                'http' => ['method' => Method::POST->value, 'url' => (string) $url],
+            ],
+        );
+
         $response = $this->http->request(Method::POST, (string) $url, $context->getHttpOptions());
 
         if (Status::OK !== Status::tryFrom($response->getStatusCode())) {
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Request for '{client}: {user}@{backend}' playlist '{title}' returned with unexpected '{status_code}' status code.",
-                    context: [...$logContext, 'status_code' => $response->getStatusCode(), 'url' => (string) $url],
+                    message: "Create playlist request for '{title}' on '{user}@{backend}' returned status {http.status_code}.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.playlist',
+                        'operation' => 'create',
+                        'outcome' => 'failed',
+                        'reason' => 'unexpected_status',
+                        'http' => [
+                            'method' => Method::POST->value,
+                            'status_code' => $response->getStatusCode(),
+                            'expected_status_codes' => [Status::OK->value],
+                            'url' => (string) $url,
+                        ],
+                    ],
                     level: Levels::ERROR,
                 ),
             );

--- a/src/Backends/Plex/Action/DeletePlaylist.php
+++ b/src/Backends/Plex/Action/DeletePlaylist.php
@@ -64,14 +64,39 @@ final class DeletePlaylist
             'url' => (string) $url,
         ];
 
+        $this->logger->debug(
+            message: "Deleting playlist '{id}' from '{user}@{backend}'.",
+            context: [
+                ...$logContext,
+                'event_name' => 'backend.request.started',
+                'subsystem' => 'backend.playlist',
+                'operation' => 'delete',
+                'outcome' => 'started',
+                'http' => ['method' => Method::DELETE->value, 'url' => (string) $url],
+            ],
+        );
+
         $response = $this->http->request(Method::DELETE, (string) $url, $context->getHttpOptions());
 
         if (Status::NO_CONTENT !== Status::tryFrom($response->getStatusCode())) {
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Request for '{client}: {user}@{backend}' playlist '{id}' returned with unexpected '{status_code}' status code.",
-                    context: [...$logContext, 'status_code' => $response->getStatusCode()],
+                    message: "Delete playlist request for '{id}' on '{user}@{backend}' returned status {http.status_code}.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.playlist',
+                        'operation' => 'delete',
+                        'outcome' => 'failed',
+                        'reason' => 'unexpected_status',
+                        'http' => [
+                            'method' => Method::DELETE->value,
+                            'status_code' => $response->getStatusCode(),
+                            'expected_status_codes' => [Status::NO_CONTENT->value],
+                            'url' => (string) $url,
+                        ],
+                    ],
                     level: Levels::ERROR,
                 ),
             );

--- a/src/Backends/Plex/Action/Export.php
+++ b/src/Backends/Plex/Action/Export.php
@@ -35,6 +35,12 @@ final class Export extends Import
     ): void {
         $queue = ag($opts, 'queue', static fn() => Container::get(QueueRequests::class));
         $after = ag($opts, 'after', null);
+        $logContext = array_replace_recursive([
+            'action' => $this->action,
+            'client' => $context->clientName,
+            'backend' => $context->backendName,
+            'user' => $context->userContext->name,
+        ], $logContext);
         $library = ag($logContext, 'library.id');
         $type = ag($item, 'type');
 
@@ -47,10 +53,17 @@ final class Export extends Import
 
         try {
             if ($context->trace) {
-                $this->logger->debug("{action}: Processing '{client}: {user}@{backend}' response payload.", [
-                    ...$logContext,
-                    'response' => ['body' => $item],
-                ]);
+                $this->logger->debug(
+                    message: "Processing export payload from '{user}@{backend}'.",
+                    context: [
+                        'event_name' => 'backend.response.received',
+                        'subsystem' => 'backend.export',
+                        'operation' => 'process_item',
+                        'outcome' => 'received',
+                        ...$logContext,
+                        'response' => ['body' => $item],
+                    ],
+                );
             }
 
             Message::increment("{$context->backendName}.{$library}.total");
@@ -83,16 +96,15 @@ final class Export extends Import
             } catch (InvalidArgumentException $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Failed to parse '{client}: {user}@{backend}' item response. '{error.kind}' with '{error.message}' at '{error.file}:{error.line}' ",
+                        message: "Failed to parse export item response from '{user}@{backend}'.",
                         context: [
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.export',
+                            'operation' => 'parse_item',
+                            'outcome' => 'failed',
                             ...$logContext,
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
                             'response' => ['body' => $item],
+                            ...exception_log($e),
                         ],
                         e: $e,
                     ),
@@ -102,8 +114,13 @@ final class Export extends Import
 
             if (null === ag($item, true === (bool) ag($item, 'viewCount', false) ? 'lastViewedAt' : 'addedAt')) {
                 $this->logger->debug(
-                    message: "{action}: Ignoring '{client}: {user}@{backend}' {item.type} '{item.title}'. No Date is set on object.",
+                    message: "Ignoring {item.type} '{item.title}' from '{user}@{backend}': missing date '{date_key}'.",
                     context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.export',
+                        'operation' => 'process_item',
+                        'outcome' => 'ignored',
+                        'reason' => 'missing_date',
                         ...$logContext,
                         'date_key' => true === (bool) ag($item, 'viewCount', false) ? 'lastViewedAt' : 'addedAt',
                         'response' => ['body' => $item],
@@ -122,7 +139,7 @@ final class Export extends Import
             );
 
             if (!$rItem->hasGuids() && !$rItem->hasRelativeGuid()) {
-                $message = "{action}: Ignoring '{client}: {user}@{backend}' - '{item.title}'. No valid/supported external ids.";
+                $message = "Ignoring {item.type} '{item.title}' from '{user}@{backend}': no supported external IDs.";
 
                 if (null === ($item['Guid'] ?? null)) {
                     $item['Guid'] = [];
@@ -133,13 +150,21 @@ final class Export extends Import
                 }
 
                 if (empty($item['Guid'])) {
-                    $message .= " Most likely unmatched '{item.type}'.";
+                    $message .= ' Most likely unmatched {item.type}.';
                 }
 
-                $this->logger->info($message, [
-                    ...$logContext,
-                    'context' => ['guids' => !empty($item['Guid']) ? $item['Guid'] : 'None'],
-                ]);
+                $this->logger->info(
+                    message: $message,
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.export',
+                        'operation' => 'create_entity',
+                        'outcome' => 'ignored',
+                        'reason' => 'missing_supported_guid',
+                        ...$logContext,
+                        'guids' => !empty($item['Guid']) ? $item['Guid'] : 'None',
+                    ],
+                );
 
                 Message::increment("{$context->backendName}.{$mappedType}.ignored_no_supported_guid");
                 return;
@@ -148,8 +173,13 @@ final class Export extends Import
             if (false === ag($context->options, Options::IGNORE_DATE, false)) {
                 if (true === $after instanceof DateTimeInterface && $rItem->updated >= $after->getTimestamp()) {
                     $this->logger->debug(
-                        message: "{action}: Ignoring '{client}: {user}@{backend}' - '{item.title}'. Backend date '{backend_date}' is equal or newer than last sync date '{last_sync}'.",
+                        message: "Ignoring {item.type} '{item.title}' from '{user}@{backend}': backend date is not newer than last sync date.",
                         context: [
+                            'event_name' => 'backend.item.ignored',
+                            'subsystem' => 'backend.export',
+                            'operation' => 'compare_dates',
+                            'outcome' => 'ignored',
+                            'reason' => 'date_not_newer_than_last_sync',
                             ...$logContext,
                             'last_sync' => make_date($after),
                             'backend_date' => make_date($rItem->updated),
@@ -162,12 +192,24 @@ final class Export extends Import
             }
 
             if (null === ($entity = $mapper->get($rItem))) {
-                $message = "{action}: Ignoring '{client}: {user}@{backend}' - '{item.title}'. {item.type} is not imported yet.";
-                if (true === (bool) ag($context->options, Options::IMPORT_METADATA_ONLY)) {
-                    $message .= ' The backend is marked as metadata source only.';
+                $metadataOnly = true === (bool) ag($context->options, Options::IMPORT_METADATA_ONLY);
+                $message = "Ignoring {item.type} '{item.title}' from '{user}@{backend}': item is not imported yet.";
+                if (true === $metadataOnly) {
+                    $message .= ' Backend is configured as metadata-only.';
                 }
 
-                $this->logger->info(message: $message, context: $logContext);
+                $this->logger->info(
+                    message: $message,
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.export',
+                        'operation' => 'load_local_state',
+                        'outcome' => 'ignored',
+                        'reason' => 'missing_local_state',
+                        ...$logContext,
+                        'metadata_only' => $metadataOnly,
+                    ],
+                );
                 Message::increment("{$context->backendName}.{$mappedType}.ignored_not_found_in_db");
                 return;
             }
@@ -175,8 +217,16 @@ final class Export extends Import
             if ($rItem->watched === $entity->watched) {
                 if (true === (bool) ag($context->options, Options::DEBUG_TRACE)) {
                     $this->logger->debug(
-                        message: "{action}: Ignoring '{client}: {backend}' - '{item.title}'. {item.type} play state is identical.",
-                        context: $logContext,
+                        message: "Ignoring {item.type} '{item.title}' from '{user}@{backend}': play state is unchanged.",
+                        context: [
+                            'event_name' => 'backend.item.ignored',
+                            'subsystem' => 'backend.export',
+                            'operation' => 'compare_state',
+                            'outcome' => 'ignored',
+                            'reason' => 'state_unchanged',
+                            ...$logContext,
+                            'play_state' => $rItem->isWatched() ? 'Played' : 'Unplayed',
+                        ],
                     );
                 }
 
@@ -186,8 +236,13 @@ final class Export extends Import
 
             if ($rItem->updated >= $entity->updated && false === ag($context->options, Options::IGNORE_DATE, false)) {
                 $this->logger->debug(
-                    message: "{action}: Ignoring '{client}: {user}@{backend}' - '{item.title}'. Backend date '{backend_date}' is equal or newer than local history date '{db_date}'.",
+                    message: "Ignoring {item.type} '{item.title}' from '{user}@{backend}': backend date is not newer than local history date.",
                     context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.export',
+                        'operation' => 'compare_dates',
+                        'outcome' => 'ignored',
+                        'reason' => 'date_not_newer_than_local_history',
                         ...$logContext,
                         'db_date' => make_date($entity->updated),
                         'backend_date' => make_date($rItem->updated),
@@ -203,19 +258,37 @@ final class Export extends Import
                 http_build_query(['identifier' => 'com.plexapp.plugins.library', 'key' => $item['ratingKey']]),
             );
 
-            $logContext['item']['url'] = $url;
+            $logContext['item']['url'] = (string) $url;
 
             Message::increment("{$context->userContext->name}.{$context->backendName}.export");
 
-            $requestContext = $logContext + ['play_state' => $entity->isWatched() ? 'Played' : 'Unplayed'];
+            $requestContext = [...$logContext, 'play_state' => $entity->isWatched() ? 'Played' : 'Unplayed'];
 
             if (true === (bool) ag($context->options, Options::DRY_RUN, false)) {
                 $this->logger->notice(
-                    message: "{action}: Queuing request to change '{client}: {user}@{backend}' {item.type} '{item.title}' play state to '{play_state}'.",
-                    context: $requestContext,
+                    message: "Would update play state for {item.type} '{item.title}' on '{user}@{backend}' to '{play_state}'.",
+                    context: [
+                        'event_name' => 'backend.request.skipped',
+                        'subsystem' => 'backend.export',
+                        'operation' => 'update_state',
+                        'outcome' => 'skipped',
+                        'reason' => 'dry_run',
+                        ...$requestContext,
+                    ],
                 );
                 return;
             }
+
+            $this->logger->debug(
+                message: "Updating play state for {item.type} '{item.title}' on '{user}@{backend}' to '{play_state}'.",
+                context: [
+                    'event_name' => 'backend.request.started',
+                    'subsystem' => 'backend.export',
+                    'operation' => 'update_state',
+                    'outcome' => 'started',
+                    ...$requestContext,
+                ],
+            );
 
             $queue->add(
                 new Request(
@@ -227,8 +300,12 @@ final class Export extends Import
 
                         if (Status::OK !== Status::tryFrom($statusCode)) {
                             $this->logger->error(
-                                message: "{action}: Request to change '{client}: {user}@{backend}' {item.type} '{item.title}' play state returned with unexpected '{status_code}' status code.",
+                                message: "Play-state update for {item.type} '{item.title}' on '{user}@{backend}' returned status {status_code}.",
                                 context: [
+                                    'event_name' => 'backend.response.failed',
+                                    'subsystem' => 'backend.export',
+                                    'operation' => 'update_state',
+                                    'outcome' => 'failed',
                                     ...$requestContext,
                                     'status_code' => $statusCode,
                                 ],
@@ -238,8 +315,14 @@ final class Export extends Import
                         }
 
                         $this->logger->notice(
-                            message: "{action}: Updated '{client}: {user}@{backend}' {item.type} '{item.title}' play state to '{play_state}'.",
-                            context: $requestContext,
+                            message: "Updated play state for {item.type} '{item.title}' on '{user}@{backend}' to '{play_state}'.",
+                            context: [
+                                'event_name' => 'backend.state_update.completed',
+                                'subsystem' => 'backend.export',
+                                'operation' => 'update_state',
+                                'outcome' => 'completed',
+                                ...$requestContext,
+                            ],
                         );
 
                         return [];
@@ -247,8 +330,12 @@ final class Export extends Import
                     error: function (Throwable $e) use ($requestContext): array {
                         $this->logger->error(
                             ...lw(
-                                message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request to change play state of {item.type} '{item.title}'. '{error.message}' at '{error.file}:{error.line}'.",
+                                message: "Play-state request failed for {item.type} '{item.title}' on '{user}@{backend}'.",
                                 context: [
+                                    'event_name' => 'backend.client.request_failed',
+                                    'subsystem' => 'backend.export',
+                                    'operation' => 'update_state',
+                                    'outcome' => 'failed',
                                     ...$requestContext,
                                     ...exception_log($e),
                                 ],
@@ -265,24 +352,20 @@ final class Export extends Import
                 ),
             );
         } catch (Throwable $e) {
+            $message = ag_exists($logContext, 'item.title')
+                ? "Export failed for {item.type} '{item.title}' on '{user}@{backend}'."
+                : "Export failed for '{user}@{backend}'.";
+
             $this->logger->error(
                 ...lw(
-                    message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' export. {error.message} at '{error.file}:{error.line}'.",
+                    message: $message,
                     context: [
+                        'event_name' => 'backend.operation.failed',
+                        'subsystem' => 'backend.export',
+                        'operation' => 'process_item',
+                        'outcome' => 'failed',
                         ...$logContext,
-                        'error' => [
-                            'kind' => $e::class,
-                            'line' => $e->getLine(),
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
-                        'exception' => [
-                            'file' => $e->getFile(),
-                            'line' => $e->getLine(),
-                            'kind' => get_class($e),
-                            'message' => $e->getMessage(),
-                            'trace' => $e->getTrace(),
-                        ],
+                        ...exception_log($e),
                     ],
                     e: $e,
                 ),

--- a/src/Backends/Plex/Action/GetInfo.php
+++ b/src/Backends/Plex/Action/GetInfo.php
@@ -96,6 +96,9 @@ final class GetInfo
                                 'response' => ['body' => $content],
                             ],
                             level: Levels::WARNING,
+                            extra: array_filter([
+                                'error' => $this->getBackendResponseReason($content),
+                            ]),
                         ),
                     );
                 }

--- a/src/Backends/Plex/Action/GetInfo.php
+++ b/src/Backends/Plex/Action/GetInfo.php
@@ -21,6 +21,10 @@ final class GetInfo
 
     protected string $action = 'plex.getInfo';
 
+    /**
+     * @param iHttp&\App\Libs\Extends\HttpClient $http
+     * @param iLogger $logger
+     */
     public function __construct(
         protected readonly iHttp $http,
         protected readonly iLogger $logger,
@@ -50,8 +54,15 @@ final class GetInfo
                 ];
 
                 $this->logger->debug(
-                    message: "{action}: Requesting '{client}: {user}@{backend}' unique identifier.",
-                    context: $logContext,
+                    message: "Requesting backend info from '{user}@{backend}'.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.request.started',
+                        'subsystem' => 'backend.info',
+                        'operation' => 'load',
+                        'outcome' => 'started',
+                        'http' => ['url' => (string) $url],
+                    ],
                 );
 
                 $response = $this->http->request(
@@ -69,10 +80,19 @@ final class GetInfo
                     return new Response(
                         status: false,
                         error: new Error(
-                            message: "{action}: Request for '{client}: {user}@{backend}' get info returned with unexpected '{status_code}' status code.",
+                            message: "Backend info request to '{user}@{backend}' returned status {http.status_code}.",
                             context: [
                                 ...$logContext,
-                                'status_code' => $response->getStatusCode(),
+                                'event_name' => 'backend.response.failed',
+                                'subsystem' => 'backend.info',
+                                'operation' => 'load',
+                                'outcome' => 'failed',
+                                'reason' => 'unexpected_status',
+                                'http' => [
+                                    'status_code' => $response->getStatusCode(),
+                                    'expected_status_codes' => [Status::OK->value],
+                                    'url' => (string) $url,
+                                ],
                                 'response' => ['body' => $content],
                             ],
                             level: Levels::WARNING,
@@ -84,8 +104,20 @@ final class GetInfo
                     return new Response(
                         status: false,
                         error: new Error(
-                            message: "{action}: Request for '{client}: {user}@{backend}' get info returned with empty response.",
-                            context: [...$logContext, 'response' => ['body' => $content]],
+                            message: "Backend info request to '{user}@{backend}' returned an empty response.",
+                            context: [
+                                ...$logContext,
+                                'event_name' => 'backend.response.failed',
+                                'subsystem' => 'backend.info',
+                                'operation' => 'load',
+                                'outcome' => 'failed',
+                                'reason' => 'empty_response',
+                                'http' => [
+                                    'status_code' => $response->getStatusCode(),
+                                    'url' => (string) $url,
+                                ],
+                                'response' => ['body' => $content],
+                            ],
                             level: Levels::ERROR,
                         ),
                     );
@@ -99,8 +131,15 @@ final class GetInfo
 
                 if (true === $context->trace) {
                     $this->logger->debug(
-                        message: "{action}: Processing '{client}: {user}@{backend}' get info payload.",
-                        context: [...$logContext, 'response' => ['body' => $item]],
+                        message: "Processing backend info response from '{user}@{backend}'.",
+                        context: [
+                            ...$logContext,
+                            'event_name' => 'backend.response.received',
+                            'subsystem' => 'backend.info',
+                            'operation' => 'load',
+                            'outcome' => 'received',
+                            'response' => ['body' => $item],
+                        ],
                     );
                 }
 

--- a/src/Backends/Plex/Action/GetLibrariesList.php
+++ b/src/Backends/Plex/Action/GetLibrariesList.php
@@ -13,6 +13,7 @@ use App\Backends\Plex\PlexClient;
 use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Enums\Http\Method;
 use App\Libs\Enums\Http\Status;
+use App\Libs\Exceptions\AppExceptionInterface;
 use App\Libs\Exceptions\RuntimeException;
 use App\Libs\Options;
 use DateInterval;
@@ -27,6 +28,10 @@ final class GetLibrariesList
 
     private string $action = 'plex.getLibrariesList';
 
+    /**
+     * @param iHttp&\App\Libs\Extends\HttpClient $http
+     * @param iLogger $logger
+     */
     public function __construct(
         protected iHttp $http,
         protected iLogger $logger,
@@ -78,16 +83,41 @@ final class GetLibrariesList
                     $this->logger,
                 );
         } catch (RuntimeException $e) {
+            $errorContext = $e instanceof AppExceptionInterface && $e->hasContext()
+                ? $e->getContext()
+                : [
+                    ...$logContext,
+                    'event_name' => 'backend.operation.failed',
+                    'subsystem' => 'backend.library',
+                    'operation' => 'request_libraries',
+                    'outcome' => 'failed',
+                    ...exception_log($e),
+                ];
+
             return new Response(
                 status: false,
-                error: new Error(message: $e->getMessage(), level: Levels::ERROR, previous: $e),
+                error: new Error(
+                    message: 'backend.response.failed' === ag($errorContext, 'event_name')
+                        ? "Libraries request to '{user}@{backend}' returned status {http.status_code}."
+                        : "Failed to load libraries from '{user}@{backend}'.",
+                    context: $errorContext,
+                    level: Levels::ERROR,
+                    previous: $e,
+                ),
             );
         }
 
         if ($context->trace) {
             $this->logger->debug(
-                message: "{action}: Parsing '{client}: {user}@{backend}' libraries payload.",
-                context: [...$logContext, 'response' => ['body' => $json]],
+                message: "Parsing libraries payload from '{user}@{backend}'.",
+                context: [
+                    ...$logContext,
+                    'event_name' => 'backend.response.received',
+                    'subsystem' => 'backend.library',
+                    'operation' => 'request_libraries',
+                    'outcome' => 'received',
+                    'response' => ['body' => $json],
+                ],
             );
         }
 
@@ -97,8 +127,16 @@ final class GetLibrariesList
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Request for '{client}: {user}@{backend}' libraries returned empty list.",
-                    context: [...$logContext, 'response' => ['key' => 'MediaContainer.Directory', 'body' => $json]],
+                    message: "Libraries response from '{user}@{backend}' was empty.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.response.completed',
+                        'subsystem' => 'backend.library',
+                        'operation' => 'request_libraries',
+                        'outcome' => 'completed',
+                        'reason' => 'empty_list',
+                        'response' => ['key' => 'MediaContainer.Directory', 'body' => $json],
+                    ],
                     level: Levels::WARNING,
                 ),
             );
@@ -171,7 +209,14 @@ final class GetLibrariesList
 
         $logContext['url'] = (string) $url;
 
-        $this->logger->debug("{action}: Requesting '{client}: {user}@{backend}' libraries list.", $logContext);
+        $this->logger->debug("Requesting libraries from '{user}@{backend}' via {client}.", [
+            ...$logContext,
+            'event_name' => 'backend.request.started',
+            'subsystem' => 'backend.library',
+            'operation' => 'request_libraries',
+            'outcome' => 'started',
+            'http' => ['url' => (string) $url],
+        ]);
 
         $response = $this->http->request(Method::GET, (string) $url, $context->getHttpOptions());
 
@@ -179,18 +224,42 @@ final class GetLibrariesList
 
         if ($context->trace) {
             $this->logger->debug(
-                message: "{action}: Processing '{client}: {user}@{backend}' response.",
-                context: [...$logContext, 'response' => ['body' => $payload]],
+                message: "Received libraries response from '{user}@{backend}'.",
+                context: [
+                    ...$logContext,
+                    'event_name' => 'backend.response.received',
+                    'subsystem' => 'backend.library',
+                    'operation' => 'request_libraries',
+                    'outcome' => 'received',
+                    'response' => ['body' => $payload],
+                ],
             );
         }
 
         if (Status::OK !== Status::tryFrom($response->getStatusCode())) {
-            throw new RuntimeException(
+            $errorContext = [
+                ...$logContext,
+                'event_name' => 'backend.response.failed',
+                'subsystem' => 'backend.library',
+                'operation' => 'request_libraries',
+                'outcome' => 'failed',
+                'reason' => 'unexpected_status',
+                'http' => [
+                    'status_code' => $response->getStatusCode(),
+                    'expected_status_codes' => [Status::OK->value],
+                    'url' => (string) $url,
+                ],
+                'response' => ['body' => $payload],
+            ];
+
+            $ex = new RuntimeException(
                 r(
-                    text: "{action}: Request for '{client}: {user}@{backend}' libraries returned with unexpected '{status_code}' status code.",
-                    context: [...$logContext, 'status_code' => $response->getStatusCode()],
+                    text: "Libraries request to '{user}@{backend}' returned status {http.status_code}.",
+                    context: $errorContext,
                 ),
             );
+            $ex->setContext($errorContext);
+            throw $ex;
         }
 
         return json_decode(

--- a/src/Backends/Plex/Action/GetLibrary.php
+++ b/src/Backends/Plex/Action/GetLibrary.php
@@ -35,6 +35,10 @@ final class GetLibrary
 
     private string $action = 'plex.getLibrary';
 
+    /**
+     * @param iHttp&\App\Libs\Extends\HttpClient $http
+     * @param iLogger $logger
+     */
     public function __construct(
         protected iHttp $http,
         protected iLogger $logger,
@@ -82,8 +86,17 @@ final class GetLibrary
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: No library with id '{id}' found in '{client}: {user}@{backend}' response.",
-                    context: [...$logContext, 'id' => $id, 'response' => ['body' => $libraries]],
+                    message: "Library '{id}' was not found for '{user}@{backend}'.",
+                    context: [
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.library',
+                        'operation' => 'load_library',
+                        'outcome' => 'failed',
+                        'reason' => 'library_not_found',
+                        ...$logContext,
+                        'id' => $id,
+                        'response' => ['body' => $libraries],
+                    ],
                     level: Levels::WARNING,
                 ),
             );
@@ -104,8 +117,15 @@ final class GetLibrary
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: The requested '{client}: {user}@{backend}' library '{library.title}' returned with unsupported type '{library.type}'.",
-                    context: $logContext,
+                    message: "Ignoring library '{library.title}' from '{user}@{backend}': unsupported library type '{library.type}'.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.library',
+                        'operation' => 'load_library',
+                        'outcome' => 'ignored',
+                        'reason' => 'unsupported_library_type',
+                        ...$logContext,
+                    ],
                     level: Levels::WARNING,
                 ),
             );
@@ -133,8 +153,14 @@ final class GetLibrary
         $logContext['library']['url'] = (string) $url;
 
         $this->logger->debug(
-            message: "{action}: Requesting '{client}: {user}@{backend}' library '{library.title}' content.",
-            context: $logContext,
+            message: "Requesting library '{library.title}' from '{user}@{backend}'.",
+            context: [
+                'event_name' => 'backend.request.started',
+                'subsystem' => 'backend.library',
+                'operation' => 'load_library',
+                'outcome' => 'started',
+                ...$logContext,
+            ],
         );
 
         $response = $this->http->request(
@@ -147,8 +173,15 @@ final class GetLibrary
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Request for '{client}: {user}@{backend}' library '{library.title}' returned with unexpected '{status_code}' status code.",
-                    context: [...$logContext, 'status_code' => $response->getStatusCode()],
+                    message: "Library request for '{library.title}' on '{user}@{backend}' returned status {status_code}.",
+                    context: [
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.library',
+                        'operation' => 'load_library',
+                        'outcome' => 'failed',
+                        ...$logContext,
+                        'status_code' => $response->getStatusCode(),
+                    ],
                     level: Levels::ERROR,
                 ),
             );
@@ -169,8 +202,13 @@ final class GetLibrary
         foreach ($it as $entity) {
             if ($entity instanceof DecodingError) {
                 $this->logger->warning(
-                    message: "{action}: Failed to decode one item of '{client}: {user}@{backend}' library '{library.title}' content. {error.message}",
+                    message: "Ignoring one item from library '{library.title}' on '{user}@{backend}': content could not be decoded.",
                     context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.library',
+                        'operation' => 'parse_item',
+                        'outcome' => 'ignored',
+                        'reason' => 'decode_error',
                         ...$logContext,
                         'error' => ['message' => $entity->getErrorMessage(), 'body' => $entity->getMalformedJson()],
                     ],
@@ -209,9 +247,19 @@ final class GetLibrary
         }
 
         if (!empty($requests)) {
+            $requestLogContext = $logContext;
+            unset($requestLogContext['item']);
+
             $this->logger->info(
-                message: "{action}: Requesting '{total}' items metadata from '{client}: {user}@{backend}' library '{library.title}'.",
-                context: [...$logContext, 'total' => number_format(count($requests))],
+                message: "Requesting metadata for {request_count} items from library '{library.title}' on '{user}@{backend}'.",
+                context: [
+                    'event_name' => 'backend.request.started',
+                    'subsystem' => 'backend.library',
+                    'operation' => 'load_item_metadata',
+                    'outcome' => 'started',
+                    ...$requestLogContext,
+                    'request_count' => count($requests),
+                ],
             );
         }
 
@@ -224,8 +272,12 @@ final class GetLibrary
                 if (Status::OK !== Status::tryFrom($response->getStatusCode())) {
                     if (false === $noLog) {
                         $this->logger->warning(
-                            message: "{action}: Request for '{client}: {user}@{backend}' {item.type} '{item.title}' metadata returned with unexpected '{status_code}' status code.",
+                            message: "Metadata request for {item.type} '{item.title}' on '{user}@{backend}' returned status {status_code}.",
                             context: [
+                                'event_name' => 'backend.response.failed',
+                                'subsystem' => 'backend.library',
+                                'operation' => 'load_item_metadata',
+                                'outcome' => 'failed',
                                 ...$requestContext,
                                 'status_code' => $response->getStatusCode(),
                                 'response' => ['body' => $response->getContent(false)],
@@ -252,22 +304,14 @@ final class GetLibrary
                 return new Response(
                     status: false,
                     error: new Error(
-                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request for {item.type} '{item.title}' metadata. {error.message} at '{error.file}:{error.line}'.",
+                        message: "Failed to load metadata for {item.type} '{item.title}' from '{user}@{backend}'.",
                         context: [
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.library',
+                            'operation' => 'load_item_metadata',
+                            'outcome' => 'failed',
                             ...$requestContext,
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
-                            'exception' => [
-                                'file' => $e->getFile(),
-                                'line' => $e->getLine(),
-                                'kind' => get_class($e),
-                                'message' => $e->getMessage(),
-                                'trace' => $e->getTrace(),
-                            ],
+                            ...exception_log($e),
                         ],
                         level: Levels::WARNING,
                         previous: $e,
@@ -316,8 +360,14 @@ final class GetLibrary
         }
 
         $this->logger->debug(
-            message: "{action}: Processing '{client}: {user}@{backend}' {item.type} '{item.title} ({item.year})'.",
-            context: $logContext,
+            message: "Processing library item {item.type} '{item.title} ({item.year})' from '{user}@{backend}'.",
+            context: [
+                'event_name' => 'backend.response.received',
+                'subsystem' => 'backend.library',
+                'operation' => 'parse_item',
+                'outcome' => 'received',
+                ...$logContext,
+            ],
         );
 
         $webUrl = $url->withPath('/web/index.html')->withFragment(
@@ -388,12 +438,21 @@ final class GetLibrary
                 }
                 break;
             default:
-                throw new RuntimeException(
-                    r(
-                        text: "{action}: Unexpected item type '{type}' was encountered while parsing '{client}: {user}@{backend}' library '{library.title}'.",
+                $ex = new RuntimeException(
+                    message: r(
+                        text: "Unsupported item type '{type}' was encountered while parsing library '{library.title}' from '{user}@{backend}'.",
                         context: [...$logContext, 'type' => ag($item, 'type')],
                     ),
                 );
+                $ex->setContext([
+                    'event_name' => 'backend.operation.failed',
+                    'subsystem' => 'backend.library',
+                    'operation' => 'parse_item',
+                    'outcome' => 'failed',
+                    ...$logContext,
+                    'type' => ag($item, 'type'),
+                ]);
+                throw $ex;
         }
 
         if (null !== ($itemGuid = ag($item, 'guid')) && false === $guid->isLocal($itemGuid)) {

--- a/src/Backends/Plex/Action/GetMetaData.php
+++ b/src/Backends/Plex/Action/GetMetaData.php
@@ -69,8 +69,15 @@ final class GetMetaData
                 ];
 
                 $this->logger->debug(
-                    message: "{action}: Requesting '{client}: {user}@{backend}' - '{id}' item metadata.",
-                    context: $logContext,
+                    message: "Requesting item metadata '#{id}' from '{user}@{backend}'.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.request.started',
+                        'subsystem' => 'backend.metadata',
+                        'operation' => 'load',
+                        'outcome' => 'started',
+                        'http' => ['url' => (string) $url],
+                    ],
                 );
 
                 if (null !== $cacheKey && $this->cache->has($cacheKey)) {
@@ -91,8 +98,20 @@ final class GetMetaData
                         return new Response(
                             status: false,
                             error: new Error(
-                                message: "{action}: Request for '{client}: {user}@{backend}' - '{id}' item returned with unexpected '{status_code}' status code.",
-                                context: [...$logContext, 'status_code' => $response->getStatusCode()],
+                                message: "Metadata request for item '#{id}' on '{user}@{backend}' returned status {http.status_code}.",
+                                context: [
+                                    ...$logContext,
+                                    'event_name' => 'backend.response.failed',
+                                    'subsystem' => 'backend.metadata',
+                                    'operation' => 'load',
+                                    'outcome' => 'failed',
+                                    'reason' => 'unexpected_status',
+                                    'http' => [
+                                        'status_code' => $response->getStatusCode(),
+                                        'expected_status_codes' => [Status::OK->value],
+                                        'url' => (string) $url,
+                                    ],
+                                ],
                             ),
                         );
                     }
@@ -118,8 +137,16 @@ final class GetMetaData
 
                 if (true === $context->trace) {
                     $this->logger->debug(
-                        message: "{action}: Processing '{client}: {user}@{backend}' - '{id}' item payload.",
-                        context: [...$logContext, 'cached' => $fromCache, 'response' => ['body' => $item]],
+                        message: "Processing item metadata '#{id}' from '{user}@{backend}'.",
+                        context: [
+                            ...$logContext,
+                            'event_name' => 'backend.response.received',
+                            'subsystem' => 'backend.metadata',
+                            'operation' => 'load',
+                            'outcome' => 'received',
+                            'cached' => $fromCache,
+                            'response' => ['body' => $item],
+                        ],
                     );
                 }
 

--- a/src/Backends/Plex/Action/GetPlaylist.php
+++ b/src/Backends/Plex/Action/GetPlaylist.php
@@ -59,13 +59,38 @@ final class GetPlaylist
             'id' => $id,
         ];
 
+        $this->logger->debug(
+            message: "Requesting playlist '{id}' from '{user}@{backend}'.",
+            context: [
+                ...$logContext,
+                'event_name' => 'backend.request.started',
+                'subsystem' => 'backend.playlist',
+                'operation' => 'load',
+                'outcome' => 'started',
+                'http' => ['method' => Method::GET->value, 'url' => (string) $detailUrl],
+            ],
+        );
+
         $detailResponse = $this->http->request(Method::GET, (string) $detailUrl, $context->getHttpOptions());
         if (Status::OK !== Status::tryFrom($detailResponse->getStatusCode())) {
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Request for '{client}: {user}@{backend}' playlist '{id}' returned with unexpected '{status_code}' status code.",
-                    context: [...$logContext, 'status_code' => $detailResponse->getStatusCode()],
+                    message: "Playlist '{id}' request to '{user}@{backend}' returned status {http.status_code}.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.playlist',
+                        'operation' => 'load',
+                        'outcome' => 'failed',
+                        'reason' => 'unexpected_status',
+                        'http' => [
+                            'method' => Method::GET->value,
+                            'status_code' => $detailResponse->getStatusCode(),
+                            'expected_status_codes' => [Status::OK->value],
+                            'url' => (string) $detailUrl,
+                        ],
+                    ],
                     level: Levels::ERROR,
                 ),
             );
@@ -83,8 +108,16 @@ final class GetPlaylist
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Playlist '{id}' was not found in '{client}: {user}@{backend}'.",
-                    context: $logContext,
+                    message: "Playlist '{id}' was not found on '{user}@{backend}'.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.request.skipped',
+                        'subsystem' => 'backend.playlist',
+                        'operation' => 'load',
+                        'outcome' => 'skipped',
+                        'reason' => 'playlist_not_found',
+                        'http' => ['method' => Method::GET->value, 'url' => (string) $detailUrl],
+                    ],
                     level: Levels::WARNING,
                 ),
             );
@@ -95,8 +128,21 @@ final class GetPlaylist
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Request for '{client}: {user}@{backend}' playlist '{id}' items returned with unexpected '{status_code}' status code.",
-                    context: [...$logContext, 'status_code' => $itemsResponse->getStatusCode()],
+                    message: "Playlist items request for '{id}' on '{user}@{backend}' returned status {http.status_code}.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.playlist',
+                        'operation' => 'load_items',
+                        'outcome' => 'failed',
+                        'reason' => 'unexpected_status',
+                        'http' => [
+                            'method' => Method::GET->value,
+                            'status_code' => $itemsResponse->getStatusCode(),
+                            'expected_status_codes' => [Status::OK->value],
+                            'url' => (string) $itemsUrl,
+                        ],
+                    ],
                     level: Levels::ERROR,
                 ),
             );

--- a/src/Backends/Plex/Action/GetPlaylistsList.php
+++ b/src/Backends/Plex/Action/GetPlaylistsList.php
@@ -57,7 +57,17 @@ final class GetPlaylistsList
             'url' => (string) $url,
         ];
 
-        $this->logger->debug("{action}: Requesting '{client}: {user}@{backend}' playlists list.", $logContext);
+        $this->logger->debug(
+            message: "Requesting playlists list from '{user}@{backend}'.",
+            context: [
+                ...$logContext,
+                'event_name' => 'backend.request.started',
+                'subsystem' => 'backend.playlist',
+                'operation' => 'list',
+                'outcome' => 'started',
+                'http' => ['url' => (string) $url],
+            ],
+        );
 
         $response = $this->http->request(Method::GET, (string) $url, $context->getHttpOptions());
 
@@ -65,8 +75,20 @@ final class GetPlaylistsList
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Request for '{client}: {user}@{backend}' playlists returned with unexpected '{status_code}' status code.",
-                    context: [...$logContext, 'status_code' => $response->getStatusCode()],
+                    message: "Playlists list request to '{user}@{backend}' returned status {http.status_code}.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.playlist',
+                        'operation' => 'list',
+                        'outcome' => 'failed',
+                        'reason' => 'unexpected_status',
+                        'http' => [
+                            'status_code' => $response->getStatusCode(),
+                            'expected_status_codes' => [Status::OK->value],
+                            'url' => (string) $url,
+                        ],
+                    ],
                     level: Levels::ERROR,
                 ),
             );

--- a/src/Backends/Plex/Action/GetSessions.php
+++ b/src/Backends/Plex/Action/GetSessions.php
@@ -21,6 +21,10 @@ final class GetSessions
 
     private string $action = 'plex.getSessions';
 
+    /**
+     * @param iHttp&\App\Libs\Extends\HttpClient $http
+     * @param iLogger $logger
+     */
     public function __construct(
         protected readonly iHttp $http,
         protected readonly iLogger $logger,
@@ -50,8 +54,15 @@ final class GetSessions
                 ];
 
                 $this->logger->debug(
-                    message: "{action}: Requesting '{client}: {user}@{backend}' active play sessions.",
-                    context: $logContext,
+                    message: "Requesting active sessions from '{user}@{backend}'.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.request.started',
+                        'subsystem' => 'backend.session',
+                        'operation' => 'load',
+                        'outcome' => 'started',
+                        'http' => ['url' => (string) $url],
+                    ],
                 );
 
                 $response = $this->http->request(
@@ -69,10 +80,19 @@ final class GetSessions
                     return new Response(
                         status: false,
                         error: new Error(
-                            message: "{action}: Request for '{client}: {user}@{backend}' active play sessions returned with unexpected '{status_code}' status code.",
+                            message: "Sessions request to '{user}@{backend}' returned status {http.status_code}.",
                             context: [
                                 ...$logContext,
-                                'status_code' => $response->getStatusCode(),
+                                'event_name' => 'backend.response.failed',
+                                'subsystem' => 'backend.session',
+                                'operation' => 'load',
+                                'outcome' => 'failed',
+                                'reason' => 'unexpected_status',
+                                'http' => [
+                                    'status_code' => $response->getStatusCode(),
+                                    'expected_status_codes' => [Status::OK->value],
+                                    'url' => (string) $url,
+                                ],
                                 'response' => ['body' => $content],
                             ],
                             level: Levels::WARNING,
@@ -84,10 +104,18 @@ final class GetSessions
                     return new Response(
                         status: false,
                         error: new Error(
-                            message: "{action}: Request for '{client}: {user}@{backend}' active play sessions returned with empty response.",
+                            message: "Sessions request to '{user}@{backend}' returned an empty response.",
                             context: [
                                 ...$logContext,
-                                'status_code' => $response->getStatusCode(),
+                                'event_name' => 'backend.response.failed',
+                                'subsystem' => 'backend.session',
+                                'operation' => 'load',
+                                'outcome' => 'failed',
+                                'reason' => 'empty_response',
+                                'http' => [
+                                    'status_code' => $response->getStatusCode(),
+                                    'url' => (string) $url,
+                                ],
                                 'response' => ['body' => $content],
                             ],
                             level: Levels::ERROR,
@@ -103,8 +131,15 @@ final class GetSessions
 
                 if (true === $context->trace) {
                     $this->logger->debug(
-                        message: "{action}: Processing '{client}: {user}@{backend}' active play sessions payload.",
-                        context: [...$logContext, 'response' => ['body' => $content]],
+                        message: "Processing sessions response from '{user}@{backend}'.",
+                        context: [
+                            ...$logContext,
+                            'event_name' => 'backend.response.received',
+                            'subsystem' => 'backend.session',
+                            'operation' => 'load',
+                            'outcome' => 'received',
+                            'response' => ['body' => $content],
+                        ],
                     );
                 }
 

--- a/src/Backends/Plex/Action/GetUserToken.php
+++ b/src/Backends/Plex/Action/GetUserToken.php
@@ -73,6 +73,15 @@ final class GetUserToken
      */
     private function getUserToken(Context $context, int|string $userId, string $username, array $opts = []): Response
     {
+        $logContext = [
+            'action' => $this->action,
+            'client' => $context->clientName,
+            'backend' => $context->backendName,
+            'user' => $context->userContext->name,
+            'username' => $username,
+            'user_id' => $userId,
+        ];
+
         try {
             $url = Container::getNew(iUri::class)
                 ->withPort(443)
@@ -84,11 +93,12 @@ final class GetUserToken
                 $url = $url->withQuery(http_build_query(['pin' => (string) $pin]));
             }
 
-            $this->logger->debug("Requesting temporary access token for '{user}@{backend}' user '{username}'.", [
-                'user' => $context->userContext->name,
-                'backend' => $context->backendName,
-                'username' => $username,
-                'user_id' => $userId,
+            $this->logger->debug("Requesting temporary access token for '{username}' from '{user}@{backend}'.", [
+                ...$logContext,
+                'event_name' => 'backend.request.started',
+                'subsystem' => 'backend.auth',
+                'operation' => 'request_temporary_token',
+                'outcome' => 'started',
                 'url' => (string) $url,
             ]);
 
@@ -109,11 +119,12 @@ final class GetUserToken
             );
 
             if ($context->trace) {
-                $this->logger->debug("Parsing temporary access token for '{user}@{backend}' user '{username}'.", [
-                    'user' => $context->userContext->name,
-                    'backend' => $context->backendName,
-                    'username' => $username,
-                    'user_id' => $userId,
+                $this->logger->debug("Received temporary access token payload for '{username}' from '{user}@{backend}'.", [
+                    ...$logContext,
+                    'event_name' => 'backend.response.received',
+                    'subsystem' => 'backend.auth',
+                    'operation' => 'request_temporary_token',
+                    'outcome' => 'received',
                     'url' => (string) $url,
                     'trace' => $json,
                     'headers' => $response->getHeaders(),
@@ -129,11 +140,12 @@ final class GetUserToken
                 ->withPath('/api/v2/resources')
                 ->withQuery(http_build_query(['includeIPv6' => 1, 'includeHttps' => 1, 'includeRelay' => 1]));
 
-            $this->logger->debug("Requesting permanent access token for '{user}@{backend}' user '{username}'.", [
-                'user' => $context->userContext->name,
-                'backend' => $context->backendName,
-                'username' => $username,
-                'user_id' => $userId,
+            $this->logger->debug("Requesting permanent access token for '{username}' from '{user}@{backend}'.", [
+                ...$logContext,
+                'event_name' => 'backend.request.started',
+                'subsystem' => 'backend.auth',
+                'operation' => 'request_permanent_token',
+                'outcome' => 'started',
                 'url' => (string) $url,
             ]);
 
@@ -157,12 +169,13 @@ final class GetUserToken
 
             if ($context->trace) {
                 $this->logger->debug(
-                    "Parsing permanent access token for '{user}@{backend}' user '{username}' payload.",
+                    "Received permanent access token payload for '{username}' from '{user}@{backend}'.",
                     [
-                        'user' => $context->userContext->name,
-                        'backend' => $context->backendName,
-                        'username' => $username,
-                        'user_id' => $userId,
+                        ...$logContext,
+                        'event_name' => 'backend.response.received',
+                        'subsystem' => 'backend.auth',
+                        'operation' => 'request_permanent_token',
+                        'outcome' => 'received',
                         'url' => (string) $url,
                         'trace' => $json,
                     ],
@@ -186,11 +199,15 @@ final class GetUserToken
             }
 
             $this->logger->error(
-                "Response had '{count}' associated servers, non match '{user}@{backend}: {backend_id}' unique identifier.",
+                "Permanent token response for '{username}' from '{user}@{backend}' did not include backend '{backend_id}'.",
                 [
+                    'event_name' => 'backend.response.failed',
+                    'subsystem' => 'backend.auth',
+                    'operation' => 'request_permanent_token',
+                    'outcome' => 'failed',
+                    'reason' => 'backend_identifier_not_found',
+                    ...$logContext,
                     'count' => count($json),
-                    'user' => $context->userContext->name,
-                    'backend' => $context->backendName,
                     'backend_id' => $context->backendId,
                     'servers' => $servers,
                 ],
@@ -199,12 +216,14 @@ final class GetUserToken
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "No permanent access token was found for '{username}' in '{user}@{backend}' response. Likely invalid unique identifier was selected or plex.tv API error, check https://status.plex.tv or try running same command with [--debug] flag for more information.",
+                    message: "No permanent access token was found for '{username}' from '{user}@{backend}'.",
                     context: [
-                        'user' => $context->userContext->name,
-                        'backend' => $context->backendName,
-                        'username' => $username,
-                        'user_id' => $userId,
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.auth',
+                        'operation' => 'request_permanent_token',
+                        'outcome' => 'failed',
+                        'reason' => 'token_not_found',
+                        ...$logContext,
                     ],
                     level: Levels::ERROR,
                 ),
@@ -213,27 +232,15 @@ final class GetUserToken
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request for '{username}'{pin} access token. Error '{error.message}' at '{error.file}:{error.line}'.",
+                    message: "Failed to get access token for '{username}' from '{user}@{backend}'.",
                     context: [
-                        'user' => $context->userContext->name,
-                        'backend' => $context->backendName,
-                        'client' => $context->clientName,
+                        'event_name' => 'backend.operation.failed',
+                        'subsystem' => 'backend.auth',
+                        'operation' => 'request_access_token',
+                        'outcome' => 'failed',
+                        ...$logContext,
                         'pin' => isset($pin) ? ' with pin' : '',
-                        'error' => [
-                            'kind' => $e::class,
-                            'line' => $e->getLine(),
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
-                        'username' => $username,
-                        'user_id' => $userId,
-                        'exception' => [
-                            'file' => after($e->getFile(), ROOT_PATH),
-                            'line' => $e->getLine(),
-                            'kind' => get_class($e),
-                            'message' => $e->getMessage(),
-                            'trace' => $e->getTrace(),
-                        ],
+                        ...exception_log($e),
                     ],
                     level: Levels::ERROR,
                     previous: $e,
@@ -279,11 +286,16 @@ final class GetUserToken
         return new Response(
             status: false,
             error: new Error(
-                message: "Failed to generate '{user}@{backend}'. '{userId}:{username}' access-token.",
+                message: "Failed to get external access token for '{username}' from '{user}@{backend}'.",
                 context: [
+                    'event_name' => 'backend.response.failed',
+                    'subsystem' => 'backend.auth',
+                    'operation' => 'request_external_token',
+                    'outcome' => 'failed',
+                    'reason' => 'user_not_found',
                     'user' => $context->userContext->name,
                     'backend' => $context->backendName,
-                    'userId' => $userId,
+                    'user_id' => $userId,
                     'username' => $username,
                 ],
                 level: Levels::ERROR,
@@ -357,8 +369,12 @@ final class GetUserToken
         return new Response(
             status: false,
             error: new Error(
-                message: "Request to '{user}@{backend}' to grant access token for '{user_id}' returned with unexpected '{status_code}' status code. {tokenType}{extra_msg}",
+                message: "Access-token request for '{user_id}' on '{user}@{backend}' returned status {status_code}.",
                 context: [
+                    'event_name' => 'backend.response.failed',
+                    'subsystem' => 'backend.auth',
+                    'operation' => 'request_access_token',
+                    'outcome' => 'failed',
                     'user' => $context->userContext->name,
                     'backend' => $context->backendName,
                     'user_id' => ag($opts, 'user_info.user_id', '??'),

--- a/src/Backends/Plex/Action/GetUsersList.php
+++ b/src/Backends/Plex/Action/GetUsersList.php
@@ -189,6 +189,13 @@ final class GetUsersList
                     ],
                     level: Levels::ERROR,
                     previous: $e,
+                    extra: array_filter([
+                        'error' => ag(
+                            $errorContext,
+                            'error.message',
+                            fn() => $this->getBackendResponseReason((string) ag($errorContext, 'response.body', '')),
+                        ),
+                    ]),
                 ),
             );
         } catch (iException $e) {
@@ -207,6 +214,9 @@ final class GetUsersList
                     ],
                     level: Levels::ERROR,
                     previous: $e,
+                    extra: array_filter([
+                        'error' => $e->getMessage(),
+                    ]),
                 ),
             );
         }
@@ -437,6 +447,13 @@ final class GetUsersList
                     ],
                     level: Levels::ERROR,
                     previous: $e,
+                    extra: array_filter([
+                        'error' => ag(
+                            $errorContext,
+                            'error.message',
+                            fn() => $this->getBackendResponseReason((string) ag($errorContext, 'response.body', '')),
+                        ),
+                    ]),
                 ),
             );
         } catch (iException $e) {
@@ -455,6 +472,9 @@ final class GetUsersList
                     ],
                     level: Levels::ERROR,
                     previous: $e,
+                    extra: array_filter([
+                        'error' => $e->getMessage(),
+                    ]),
                 ),
             );
         }
@@ -518,6 +538,13 @@ final class GetUsersList
                     ],
                     level: Levels::ERROR,
                     previous: $e,
+                    extra: array_filter([
+                        'error' => ag(
+                            $errorContext,
+                            'error.message',
+                            fn() => $this->getBackendResponseReason((string) ag($errorContext, 'response.body', '')),
+                        ),
+                    ]),
                 ),
             );
         } catch (iException $e) {
@@ -536,6 +563,9 @@ final class GetUsersList
                     ],
                     level: Levels::ERROR,
                     previous: $e,
+                    extra: array_filter([
+                        'error' => $e->getMessage(),
+                    ]),
                 ),
             );
         }

--- a/src/Backends/Plex/Action/GetUsersList.php
+++ b/src/Backends/Plex/Action/GetUsersList.php
@@ -11,6 +11,7 @@ use App\Backends\Common\Levels;
 use App\Backends\Common\Response;
 use App\Libs\Container;
 use App\Libs\Enums\Http\Status;
+use App\Libs\Exceptions\AppExceptionInterface;
 use App\Libs\Exceptions\Backends\InvalidArgumentException;
 use App\Libs\Extends\RetryableHttpClient;
 use App\Libs\Options;
@@ -135,14 +136,26 @@ final class GetUsersList
             ->withHost('plex.tv')
             ->withPath('/api/v2/home/users/');
 
+        $logContext = [
+            'action' => $this->action,
+            'client' => $context->clientName,
+            'backend' => $context->backendName,
+            'user' => $context->userContext->name,
+            'url' => (string) $url,
+        ];
+
         if (null !== ($pin = ag($context->options, Options::PLEX_USER_PIN))) {
             $url = $url->withQuery(http_build_query(['pin' => $pin]));
+            $logContext['url'] = (string) $url;
         }
 
         $this->logger->debug("Requesting '{user}@{backend}' users list.", [
-            'user' => $context->userContext->name,
-            'backend' => $context->backendName,
-            'url' => (string) $url,
+            ...$logContext,
+            'event_name' => 'backend.request.started',
+            'subsystem' => 'backend.user',
+            'operation' => 'list',
+            'outcome' => 'started',
+            'http' => ['url' => (string) $url],
         ]);
 
         try {
@@ -151,14 +164,46 @@ final class GetUsersList
                     'Accept' => 'application/json',
                 ],
             ]);
-        } catch (InvalidArgumentException|iException $e) {
+        } catch (InvalidArgumentException $e) {
+            $errorContext = $e instanceof AppExceptionInterface && $e->hasContext() ? $e->getContext() : [];
+
             return new Response(
                 status: false,
                 error: new Error(
-                    message: $e->getMessage(),
+                    message: "Home users request to '{user}@{backend}' returned status {http.status_code}.",
                     context: [
-                        'user' => $context->userContext->name,
-                        'backend' => $context->backendName,
+                        ...$logContext,
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.user',
+                        'operation' => 'list',
+                        'outcome' => 'failed',
+                        'reason' => 'unexpected_status',
+                        'http' => [
+                            'status_code' => ag($errorContext, 'status_code'),
+                            'expected_status_codes' => [Status::OK->value],
+                            'url' => (string) $url,
+                        ],
+                        'response' => ag($errorContext, 'response', []),
+                        'token_type' => ag($errorContext, 'token_type'),
+                        'error' => ag($errorContext, 'error'),
+                    ],
+                    level: Levels::ERROR,
+                    previous: $e,
+                ),
+            );
+        } catch (iException $e) {
+            return new Response(
+                status: false,
+                error: new Error(
+                    message: "Failed to request home users from '{user}@{backend}'.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.client.request_failed',
+                        'subsystem' => 'backend.user',
+                        'operation' => 'list',
+                        'outcome' => 'failed',
+                        'http' => ['url' => (string) $url],
+                        ...exception_log($e),
                     ],
                     level: Levels::ERROR,
                     previous: $e,
@@ -208,7 +253,11 @@ final class GetUsersList
                 'user' => $context->userContext->name,
                 'backend' => $context->backendName,
                 'url' => (string) $url,
-                'trace' => $json,
+                'event_name' => 'backend.response.received',
+                'subsystem' => 'backend.user',
+                'operation' => 'list',
+                'outcome' => 'received',
+                'response' => ['body' => $json],
             ]);
         }
 
@@ -331,14 +380,26 @@ final class GetUsersList
             ->withHost('plex.tv')
             ->withPath('/api/users/');
 
+        $logContext = [
+            'action' => $this->action,
+            'client' => $context->clientName,
+            'backend' => $context->backendName,
+            'user' => $context->userContext->name,
+            'url' => (string) $url,
+        ];
+
         if (null !== ($pin = ag($context->options, Options::PLEX_USER_PIN))) {
             $url = $url->withQuery(http_build_query(['pin' => $pin]));
+            $logContext['url'] = (string) $url;
         }
 
         $this->logger->debug("Requesting '{user}@{backend}' external users list.", [
-            'user' => $context->userContext->name,
-            'backend' => $context->backendName,
-            'url' => (string) $url,
+            ...$logContext,
+            'event_name' => 'backend.request.started',
+            'subsystem' => 'backend.user',
+            'operation' => 'list_external',
+            'outcome' => 'started',
+            'http' => ['url' => (string) $url],
         ]);
 
         try {
@@ -351,14 +412,46 @@ final class GetUsersList
             if (true !== (bool) ag($opts, Options::GET_TOKENS) || count($users) < 1) {
                 return new Response(status: true, response: $users);
             }
-        } catch (InvalidArgumentException|iException $e) {
+        } catch (InvalidArgumentException $e) {
+            $errorContext = $e instanceof AppExceptionInterface && $e->hasContext() ? $e->getContext() : [];
+
             return new Response(
                 status: false,
                 error: new Error(
-                    message: $e->getMessage(),
+                    message: "External users request to '{user}@{backend}' returned status {http.status_code}.",
                     context: [
-                        'user' => $context->userContext->name,
-                        'backend' => $context->backendName,
+                        ...$logContext,
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.user',
+                        'operation' => 'list_external',
+                        'outcome' => 'failed',
+                        'reason' => 'unexpected_status',
+                        'http' => [
+                            'status_code' => ag($errorContext, 'status_code'),
+                            'expected_status_codes' => [Status::OK->value],
+                            'url' => (string) $url,
+                        ],
+                        'response' => ag($errorContext, 'response', []),
+                        'token_type' => ag($errorContext, 'token_type'),
+                        'error' => ag($errorContext, 'error'),
+                    ],
+                    level: Levels::ERROR,
+                    previous: $e,
+                ),
+            );
+        } catch (iException $e) {
+            return new Response(
+                status: false,
+                error: new Error(
+                    message: "Failed to request external users from '{user}@{backend}'.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.client.request_failed',
+                        'subsystem' => 'backend.user',
+                        'operation' => 'list_external',
+                        'outcome' => 'failed',
+                        'http' => ['url' => (string) $url],
+                        ...exception_log($e),
                     ],
                     level: Levels::ERROR,
                     previous: $e,
@@ -372,14 +465,26 @@ final class GetUsersList
             ->withHost('plex.tv')
             ->withPath(r('/api/servers/{backendId}/shared_servers', ['backendId' => $context->backendId]));
 
+        $logContext = [
+            'action' => $this->action,
+            'client' => $context->clientName,
+            'backend' => $context->backendName,
+            'user' => $context->userContext->name,
+            'url' => (string) $url,
+        ];
+
         if (null !== ($pin = ag($context->options, Options::PLEX_USER_PIN))) {
             $url = $url->withQuery(http_build_query(['pin' => $pin]));
+            $logContext['url'] = (string) $url;
         }
 
         $this->logger->debug("Requesting '{user}@{backend}' external users access-tokens.", [
-            'user' => $context->userContext->name,
-            'backend' => $context->backendName,
-            'url' => (string) $url,
+            ...$logContext,
+            'event_name' => 'backend.request.started',
+            'subsystem' => 'backend.auth',
+            'operation' => 'token.list_external',
+            'outcome' => 'started',
+            'http' => ['url' => (string) $url],
         ]);
 
         try {
@@ -388,14 +493,46 @@ final class GetUsersList
                     'Accept' => 'application/xml',
                 ],
             ]);
-        } catch (InvalidArgumentException|iException $e) {
+        } catch (InvalidArgumentException $e) {
+            $errorContext = $e instanceof AppExceptionInterface && $e->hasContext() ? $e->getContext() : [];
+
             return new Response(
                 status: false,
                 error: new Error(
-                    message: $e->getMessage(),
+                    message: "External user tokens request to '{user}@{backend}' returned status {http.status_code}.",
                     context: [
-                        'user' => $context->userContext->name,
-                        'backend' => $context->backendName,
+                        ...$logContext,
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.auth',
+                        'operation' => 'token.list_external',
+                        'outcome' => 'failed',
+                        'reason' => 'unexpected_status',
+                        'http' => [
+                            'status_code' => ag($errorContext, 'status_code'),
+                            'expected_status_codes' => [Status::OK->value],
+                            'url' => (string) $url,
+                        ],
+                        'response' => ag($errorContext, 'response', []),
+                        'token_type' => ag($errorContext, 'token_type'),
+                        'error' => ag($errorContext, 'error'),
+                    ],
+                    level: Levels::ERROR,
+                    previous: $e,
+                ),
+            );
+        } catch (iException $e) {
+            return new Response(
+                status: false,
+                error: new Error(
+                    message: "Failed to request external user tokens from '{user}@{backend}'.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.client.request_failed',
+                        'subsystem' => 'backend.auth',
+                        'operation' => 'token.list_external',
+                        'outcome' => 'failed',
+                        'http' => ['url' => (string) $url],
+                        ...exception_log($e),
                     ],
                     level: Levels::ERROR,
                     previous: $e,
@@ -441,9 +578,14 @@ final class GetUsersList
 
         if ($context->trace) {
             $this->logger->debug("Parsing '{user}@{backend}' external users list payload.", [
+                'user' => $context->userContext->name,
                 'backend' => $context->backendName,
                 'url' => (string) $url,
-                'trace' => $data,
+                'event_name' => 'backend.response.received',
+                'subsystem' => 'backend.user',
+                'operation' => 'list_external',
+                'outcome' => 'received',
+                'response' => ['body' => $data],
             ]);
         }
 
@@ -517,9 +659,14 @@ final class GetUsersList
 
         if ($context->trace) {
             $this->logger->debug("Parsing '{user}@{backend}' users list payload.", [
+                'user' => $context->userContext->name,
                 'backend' => $context->backendName,
                 'url' => (string) $url,
-                'trace' => $json,
+                'event_name' => 'backend.response.received',
+                'subsystem' => 'backend.auth',
+                'operation' => 'token.list_external',
+                'outcome' => 'received',
+                'response' => ['body' => $json],
             ]);
         }
 
@@ -601,23 +748,26 @@ final class GetUsersList
         } catch (Throwable) {
         }
 
-        throw new InvalidArgumentException(
-            r(
-                "Request for '{user}@{backend}' users list returned with unexpected '{status_code}' status code. {tokenType}{extra_msg}",
-                [
-                    'user' => $context->userContext->name,
-                    'backend' => $context->backendName,
-                    'status_code' => $response->getStatusCode(),
-                    'body' => $response->getContent(false),
-                    'extra_msg' => !$extra_msg ? '' : ". {$extra_msg}",
-                    'tokenType' => ag_exists(
-                        $context->options,
-                        Options::ADMIN_TOKEN,
-                    )
-                        ? 'user & admin token'
-                        : 'user token',
-                ],
-            ),
-        );
+        $errorContext = [
+            'action' => $this->action,
+            'client' => $context->clientName,
+            'backend' => $context->backendName,
+            'user' => $context->userContext->name,
+            'url' => (string) $url,
+            'status_code' => $response->getStatusCode(),
+            'response' => ['body' => $response->getContent(false)],
+            'token_type' => ag_exists($context->options, Options::ADMIN_TOKEN)
+                ? 'user_and_admin_token'
+                : 'user_token',
+        ];
+
+        if ('' !== $extra_msg) {
+            $errorContext['error'] = ['message' => $extra_msg];
+        }
+
+        $ex = new InvalidArgumentException("Plex request to '{user}@{backend}' returned status {status_code}.");
+        $ex->setContext($errorContext);
+
+        throw $ex;
     }
 }

--- a/src/Backends/Plex/Action/GetWebUrl.php
+++ b/src/Backends/Plex/Action/GetWebUrl.php
@@ -39,13 +39,18 @@ final class GetWebUrl
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Invalid Web url type '{type}' for '{client}: {user}@{backend}'.",
+                    message: "Cannot build a web URL for '{user}@{backend}': type '{type}' is unsupported.",
                     context: [
                         'action' => $this->action,
                         'client' => $context->clientName,
                         'backend' => $context->backendName,
                         'user' => $context->userContext->name,
                         'type' => $type,
+                        'event_name' => 'backend.request.skipped',
+                        'subsystem' => 'backend.web',
+                        'operation' => 'build_url',
+                        'outcome' => 'skipped',
+                        'reason' => 'unsupported_type',
                     ],
                     level: Levels::WARNING,
                 ),

--- a/src/Backends/Plex/Action/Import.php
+++ b/src/Backends/Plex/Action/Import.php
@@ -89,8 +89,12 @@ class Import
                     logContext: $logContext,
                 ),
                 error: fn(array $logContext = []) => fn(Throwable $e) => $this->logger->error(
-                    message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' library '{library.title}' request. '{error.message}' at '{error.file}:{error.line}'.",
+                    message: "Library request failed for '{user}@{backend}'.",
                     context: [
+                        'event_name' => 'backend.client.request_failed',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'request_library',
+                        'outcome' => 'failed',
                         'action' => $this->action,
                         'backend' => $context->backendName,
                         'client' => $context->clientName,
@@ -120,15 +124,25 @@ class Import
             $url = $context->backendUrl->withPath('/library/sections');
             $rContext['url'] = (string) $url;
 
-            $this->logger->debug("{action}: Requesting '{client}: {user}@{backend}' libraries.", $rContext);
+            $this->logger->debug("Requesting libraries from '{user}@{backend}' via {client}.", [
+                ...$rContext,
+                'event_name' => 'backend.request.started',
+                'subsystem' => 'backend.import',
+                'operation' => 'request_libraries',
+                'outcome' => 'started',
+            ]);
 
             $response = $this->http->request(Method::GET, (string) $url, $context->getHttpOptions());
 
             $payload = $response->getContent(false);
 
             if ($context->trace) {
-                $this->logger->debug("{action}: Processing '{client}: {user}@{backend}' libraries response.", [
+                $this->logger->debug("Received libraries response from '{user}@{backend}'.", [
                     ...$rContext,
+                    'event_name' => 'backend.response.received',
+                    'subsystem' => 'backend.import',
+                    'operation' => 'request_libraries',
+                    'outcome' => 'received',
                     'status_code' => $response->getStatusCode(),
                     'response' => [
                         'body' => $payload,
@@ -151,8 +165,15 @@ class Import
                 }
 
                 $this->logger->error(
-                    "{action}: Request for '{client}: {user}@{backend}' libraries returned with unexpected '{status_code}' status code.",
-                    $logContext,
+                    message: "Libraries request to '{user}@{backend}' returned status {status_code}.",
+                    context: [
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'request_libraries',
+                        'outcome' => 'failed',
+                        'reason' => 'unexpected_status',
+                        ...$logContext,
+                    ],
                 );
 
                 Message::add("{$context->backendName}.has_errors", true);
@@ -171,9 +192,14 @@ class Import
 
             if (empty($listDirs)) {
                 $this->logger->warning(
-                    message: "{action}: Request for '{client}: {user}@{backend}' libraries returned with empty list.",
+                    message: "Libraries response from '{user}@{backend}' was empty.",
                     context: [
                         ...$rContext,
+                        'event_name' => 'backend.response.completed',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'request_libraries',
+                        'outcome' => 'completed',
+                        'reason' => 'empty_list',
                         'response' => [
                             'key' => 'MediaContainer.Directory',
                             'body' => $json,
@@ -186,8 +212,15 @@ class Import
         } catch (ExceptionInterface $e) {
             $this->logger->error(
                 ...lw(
-                    message: "{action}: Request for '{client}: {user}@{backend}' libraries has failed. '{error.kind}' with message '{error.message}' at '{error.file}:{error.line}'.",
-                    context: [...$rContext, ...exception_log($e)],
+                    message: "Libraries request to '{user}@{backend}' failed.",
+                    context: [
+                        ...$rContext,
+                        'event_name' => 'backend.client.request_failed',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'request_libraries',
+                        'outcome' => 'failed',
+                        ...exception_log($e),
+                    ],
                     e: $e,
                 ),
             );
@@ -196,8 +229,15 @@ class Import
         } catch (JsonException $e) {
             $this->logger->error(
                 ...lw(
-                    message: "{action}: Request for '{client}: {user}@{backend}' libraries returned with invalid body. '{error.kind}' with message '{error.message}' at '{error.file}:{error.line}'.",
-                    context: [...$rContext, ...exception_log($e)],
+                    message: "Libraries response from '{user}@{backend}' could not be parsed.",
+                    context: [
+                        ...$rContext,
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'request_libraries',
+                        'outcome' => 'failed',
+                        ...exception_log($e),
+                    ],
                     e: $e,
                 ),
             );
@@ -206,8 +246,15 @@ class Import
         } catch (Throwable $e) {
             $this->logger->error(
                 ...lw(
-                    message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request for libraries. {error.message} at '{error.file}:{error.line}'.",
-                    context: [...$rContext, ...exception_log($e)],
+                    message: "Loading libraries from '{user}@{backend}' failed.",
+                    context: [
+                        ...$rContext,
+                        'event_name' => 'backend.operation.failed',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'load_libraries',
+                        'outcome' => 'failed',
+                        ...exception_log($e),
+                    ],
                     e: $e,
                 ),
             );
@@ -249,10 +296,34 @@ class Import
             ];
 
             if (true === in_array($libraryId, $ignoreIds ?? [], true)) {
+                $ignored++;
+                $this->logger->info(
+                    message: "Ignoring library '{library.title}' from '{user}@{backend}': excluded by selection.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'filter_library',
+                        'outcome' => 'ignored',
+                        'reason' => 'selected_excluded',
+                        ...$logContext,
+                    ],
+                );
                 continue;
             }
 
             if ($selectLibraryList && $inverseLibrarySelect === in_array($libraryId, $selectLibraryList, true)) {
+                $ignored++;
+                $this->logger->info(
+                    message: "Ignoring library '{library.title}' from '{user}@{backend}': excluded by selection.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'filter_library',
+                        'outcome' => 'ignored',
+                        'reason' => 'selected_excluded',
+                        ...$logContext,
+                    ],
+                );
                 continue;
             }
 
@@ -263,13 +334,30 @@ class Import
                     true,
                 )
             ) {
+                $unsupported++;
+                $this->logger->info(
+                    message: "Ignoring library '{library.title}' from '{user}@{backend}': type '{library.type}' is unsupported.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'filter_library',
+                        'outcome' => 'ignored',
+                        'reason' => 'unsupported_library_type',
+                        ...$logContext,
+                    ],
+                );
                 continue;
             }
 
             if (false === in_array(ag($logContext, 'library.agent'), PlexClient::SUPPORTED_AGENTS, true)) {
                 $this->logger->notice(
-                    message: "{action}: Ignoring '{client}: {user}@{backend}' - '{library.title}' Unsupported agent type. '{agent}'.",
+                    message: "Ignoring library '{library.title}' from '{user}@{backend}': unsupported agent '{agent}'.",
                     context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'filter_library',
+                        'outcome' => 'ignored',
+                        'reason' => 'unsupported_agent',
                         ...$logContext,
                         'agent' => ag($logContext, 'library.agent', '??'),
                     ],
@@ -295,8 +383,14 @@ class Import
             $logContext['library']['url'] = $url;
 
             $this->logger->debug(
-                message: "{action}: Requesting '{client}: {user}@{backend}' - '{library.title}' items count.",
-                context: $logContext,
+                message: "Requesting item count for library '{library.title}' from '{user}@{backend}'.",
+                context: [
+                    'event_name' => 'backend.request.started',
+                    'subsystem' => 'backend.import',
+                    'operation' => 'request_library_count',
+                    'outcome' => 'started',
+                    ...$logContext,
+                ],
             );
 
             try {
@@ -325,8 +419,14 @@ class Import
                     );
 
                     $this->logger->debug(
-                        message: "{action}: Requesting '{client}: {user}@{backend}' - '{library.title}' series count.",
-                        context: $logContextSub,
+                        message: "Requesting series count for library '{library.title}' from '{user}@{backend}'.",
+                        context: [
+                            'event_name' => 'backend.request.started',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'request_library_count',
+                            'outcome' => 'started',
+                            ...$logContextSub,
+                        ],
                     );
 
                     $requests[] = $this->http->request(
@@ -347,8 +447,16 @@ class Import
             } catch (ExceptionInterface $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Request for '{client}: {user}@{backend}' - '{library.title}' items count has failed. '{error.kind}' with message '{error.message}' at '{error.file}:{error.line}'.",
-                        context: [...$rContext, ...exception_log($e), ...$logContext],
+                        message: "Library count request failed for '{user}@{backend}'.",
+                        context: [
+                            'event_name' => 'backend.client.request_failed',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'request_library_count',
+                            'outcome' => 'failed',
+                            ...$rContext,
+                            ...$logContext,
+                            ...exception_log($e),
+                        ],
                         e: $e,
                     ),
                 );
@@ -356,8 +464,16 @@ class Import
             } catch (Throwable $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request for libraries. {error.message} at '{error.file}:{error.line}'.",
-                        context: [...$rContext, ...exception_log($e), ...$logContext],
+                        message: "Queueing library count requests failed for '{user}@{backend}'.",
+                        context: [
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'queue_library_requests',
+                            'outcome' => 'failed',
+                            ...$rContext,
+                            ...$logContext,
+                            ...exception_log($e),
+                        ],
                         e: $e,
                     ),
                 );
@@ -372,8 +488,13 @@ class Import
             try {
                 if (Status::OK !== Status::tryFrom($response->getStatusCode())) {
                     $this->logger->error(
-                        message: "{action}: Request for '{client}: {user}@{backend}' - '{library.title}' items count returned with unexpected '{status_code}' status code.",
+                        message: "Library count request for '{library.title}' on '{user}@{backend}' returned status {status_code}.",
                         context: [
+                            'event_name' => 'backend.response.failed',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'request_library_count',
+                            'outcome' => 'failed',
+                            'reason' => 'unexpected_status',
                             ...$logContext,
                             'status_code' => $response->getStatusCode(),
                         ],
@@ -385,8 +506,13 @@ class Import
 
                 if ($totalCount < 1) {
                     $this->logger->warning(
-                        message: "{action}: Request for '{client}: {user}@{backend}' - '{library.title}' items count returned with 0 or less.",
+                        message: "Ignoring library '{library.title}' from '{user}@{backend}': item count is empty.",
                         context: [
+                            'event_name' => 'backend.item.ignored',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'filter_library',
+                            'outcome' => 'ignored',
+                            'reason' => 'empty_library',
                             ...$logContext,
                             'response' => [
                                 'headers' => $response->getHeaders(),
@@ -404,8 +530,15 @@ class Import
             } catch (ExceptionInterface $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Request for '{client}: {user}@{backend}' - '{library.title}' total items has failed. '{error.kind}' '{error.message}' at '{error.file}:{error.line}'.",
-                        context: [...$logContext, ...exception_log($e)],
+                        message: "Reading library count response failed for '{library.title}' on '{user}@{backend}'.",
+                        context: [
+                            'event_name' => 'backend.client.request_failed',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'request_library_count',
+                            'outcome' => 'failed',
+                            ...$logContext,
+                            ...exception_log($e),
+                        ],
                         e: $e,
                     ),
                 );
@@ -413,8 +546,15 @@ class Import
             } catch (Throwable $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request for items count. {error.message} at '{error.file}:{error.line}'.",
-                        context: [...$logContext, ...exception_log($e)],
+                        message: "Parsing library count response failed for '{library.title}' on '{user}@{backend}'.",
+                        context: [
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'parse_library_count',
+                            'outcome' => 'failed',
+                            ...$logContext,
+                            ...exception_log($e),
+                        ],
                         e: $e,
                     ),
                 );
@@ -457,8 +597,15 @@ class Import
             if (false === array_key_exists('show_' . $libraryId, $total)) {
                 $ignored++;
                 $this->logger->warning(
-                    message: "{action}: Ignoring '{client}: {user}@{backend}' - '{library.title}'. No series items count was found.",
-                    context: $logContext,
+                    message: "Ignoring library '{library.title}' from '{user}@{backend}': series count is unavailable.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'filter_library',
+                        'outcome' => 'ignored',
+                        'reason' => 'missing_series_count',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
@@ -493,8 +640,14 @@ class Import
                     $logContext['library']['url'] = $url;
 
                     $this->logger->debug(
-                        message: "{action}: Requesting '{client}: {user}@{backend}' - '{library.title} {segment.number}/{segment.of}' series external ids.",
-                        context: $logContext,
+                        message: "Requesting series metadata for library '{library.title}' segment {segment.number}/{segment.of} from '{user}@{backend}'.",
+                        context: [
+                            'event_name' => 'backend.request.started',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'request_series_metadata',
+                            'outcome' => 'started',
+                            ...$logContext,
+                        ],
                     );
 
                     $requests[] = new Request(
@@ -513,8 +666,15 @@ class Import
                 } catch (Throwable $e) {
                     $this->logger->error(
                         ...lw(
-                            message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' '{library.title} {segment.number}/{segment.of}' series external ids request. {error.message} at '{error.file}:{error.line}'.",
-                            context: [...$logContext, ...exception_log($e)],
+                            message: "Queueing series metadata request for library '{library.title}' segment {segment.number}/{segment.of} from '{user}@{backend}' failed.",
+                            context: [
+                                'event_name' => 'backend.operation.failed',
+                                'subsystem' => 'backend.import',
+                                'operation' => 'queue_series_requests',
+                                'outcome' => 'failed',
+                                ...$logContext,
+                                ...exception_log($e),
+                            ],
                             e: $e,
                         ),
                     );
@@ -543,16 +703,30 @@ class Import
             if (true === in_array($libraryId, $ignoreIds ?? [], true)) {
                 $ignored++;
                 $this->logger->info(
-                    message: "{action}: Ignoring '{client}: {user}@{backend}' - '{library.title}'. Requested by user.",
-                    context: $logContext,
+                    message: "Ignoring library '{library.title}' from '{user}@{backend}': excluded by selection.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'filter_library',
+                        'outcome' => 'ignored',
+                        'reason' => 'selected_excluded',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
 
             if ($selectLibraryList && $inverseLibrarySelect === in_array($libraryId, $selectLibraryList, true)) {
                 $this->logger->info(
-                    message: "{action}: Excluding '{client}: {user}@{backend}' - '{library.title}'. Requested by user.",
-                    context: $logContext,
+                    message: "Ignoring library '{library.title}' from '{user}@{backend}': excluded by selection.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'filter_library',
+                        'outcome' => 'ignored',
+                        'reason' => 'selected_excluded',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
@@ -560,8 +734,15 @@ class Import
             if (!in_array(ag($logContext, 'library.type'), [PlexClient::TYPE_MOVIE, PlexClient::TYPE_SHOW], true)) {
                 $unsupported++;
                 $this->logger->info(
-                    message: "{action}: Ignoring '{client}: {user}@{backend}' - '{library.title}'. Library type '{library.type}' is not supported.",
-                    context: $logContext,
+                    message: "Ignoring library '{library.title}' from '{user}@{backend}': type '{library.type}' is unsupported.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'filter_library',
+                        'outcome' => 'ignored',
+                        'reason' => 'unsupported_library_type',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
@@ -569,8 +750,15 @@ class Import
             if (false === array_key_exists($libraryId, $total)) {
                 $ignored++;
                 $this->logger->warning(
-                    message: "{action}: Ignoring '{client}: {user}@{backend}' - '{library.title}'. No items count was found.",
-                    context: $logContext,
+                    message: "Ignoring library '{library.title}' from '{user}@{backend}': item count is unavailable.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'filter_library',
+                        'outcome' => 'ignored',
+                        'reason' => 'missing_item_count',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
@@ -606,8 +794,14 @@ class Import
                     $logContext['library']['url'] = $url;
 
                     $this->logger->debug(
-                        message: "{action}: Requesting '{client}: {user}@{backend}' - '{library.title} {segment.number}/{segment.of}' content list.",
-                        context: $logContext,
+                        message: "Requesting library items for '{library.title}' segment {segment.number}/{segment.of} from '{user}@{backend}'.",
+                        context: [
+                            'event_name' => 'backend.request.started',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'request_library',
+                            'outcome' => 'started',
+                            ...$logContext,
+                        ],
                     );
 
                     $requests[] = new Request(
@@ -626,8 +820,15 @@ class Import
                 } catch (Throwable $e) {
                     $this->logger->error(
                         ...lw(
-                            message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' - '{library.title} {segment.number}/{segment.of}' content list request. {error.message} at '{error.file}:{error.line}'.",
-                            context: [...$logContext, ...exception_log($e)],
+                            message: "Queueing library items request for '{library.title}' segment {segment.number}/{segment.of} from '{user}@{backend}' failed.",
+                            context: [
+                                'event_name' => 'backend.operation.failed',
+                                'subsystem' => 'backend.import',
+                                'operation' => 'queue_library_requests',
+                                'outcome' => 'failed',
+                                ...$logContext,
+                                ...exception_log($e),
+                            ],
                             e: $e,
                         ),
                     );
@@ -637,9 +838,14 @@ class Import
         }
 
         if (0 === count($requests)) {
-            $this->logger->warning("{action}: No requests for '{client}: {user}@{backend}' libraries were queued.", [
+            $this->logger->warning("No eligible library requests were queued for '{user}@{backend}'.", [
                 ...$rContext,
-                'context' => [
+                'event_name' => 'backend.request.skipped',
+                'subsystem' => 'backend.import',
+                'operation' => 'queue_library_requests',
+                'outcome' => 'skipped',
+                'reason' => 'no_eligible_requests',
+                'stats' => [
                     'total' => count($listDirs),
                     'ignored' => $ignored,
                     'unsupported' => $unsupported,
@@ -661,8 +867,13 @@ class Import
     {
         if (Status::OK !== Status::tryFrom($response->getStatusCode())) {
             $this->logger->error(
-                message: "{action}: Request for '{client}: {user}@{backend}' - '{library.title} {segment.number}/{segment.of}' content returned with unexpected '{status_code}' status code.",
+                message: "Library request for '{library.title}' segment {segment.number}/{segment.of} on '{user}@{backend}' returned status {status_code}.",
                 context: [
+                    'event_name' => 'backend.response.failed',
+                    'subsystem' => 'backend.import',
+                    'operation' => 'request_library',
+                    'outcome' => 'failed',
+                    'reason' => 'unexpected_status',
                     ...$logContext,
                     'status_code' => $response->getStatusCode(),
                 ],
@@ -672,14 +883,20 @@ class Import
 
         $start = microtime(true);
         $this->logger->info(
-            message: "{action}: Parsing '{client}: {user}@{backend}' - '{library.title} {segment.number}/{segment.of}' response.",
+            message: "Parsing library '{library.title}' segment {segment.number}/{segment.of} from '{user}@{backend}'.",
             context: [
+                'event_name' => 'backend.response.processing',
+                'subsystem' => 'backend.import',
+                'operation' => 'parse_library_response',
+                'outcome' => 'started',
                 ...$logContext,
                 'time' => [
                     'start' => $start,
                 ],
             ],
         );
+
+        $isParsed = false;
 
         try {
             $it = Items::fromIterable(
@@ -699,8 +916,13 @@ class Import
                 try {
                     if ($entity instanceof DecodingError) {
                         $this->logger->warning(
-                            message: "{action}: Failed to decode one item of '{client}: {user}@{backend}' - '{library.title} {segment.number}/{segment.of}' items. {error.message}",
+                            message: "Ignoring malformed item from library '{library.title}' segment {segment.number}/{segment.of} on '{user}@{backend}': {error.message}.",
                             context: [
+                                'event_name' => 'backend.item.ignored',
+                                'subsystem' => 'backend.import',
+                                'operation' => 'parse_item',
+                                'outcome' => 'ignored',
+                                'reason' => 'decode_error',
                                 ...$logContext,
                                 'error' => [
                                     'message' => $entity->getErrorMessage(),
@@ -714,35 +936,62 @@ class Import
                 } catch (Throwable $e) {
                     $this->logger->error(
                         ...lw(
-                            message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' parsing '{library.title} {segment.number}/{segment.of}' item response. {error.message} at '{error.file}:{error.line}'.",
-                            context: [...$logContext, ...exception_log($e), 'entity' => $entity],
+                            message: "Processing library item from '{library.title}' segment {segment.number}/{segment.of} on '{user}@{backend}' failed.",
+                            context: [
+                                'event_name' => 'backend.operation.failed',
+                                'subsystem' => 'backend.import',
+                                'operation' => 'process_item',
+                                'outcome' => 'failed',
+                                ...$logContext,
+                                'entity' => $entity,
+                                ...exception_log($e),
+                            ],
                             e: $e,
                         ),
                     );
                 }
             }
+
+            $isParsed = true;
         } catch (Throwable $e) {
             $this->logger->error(
                 ...lw(
-                    message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' parsing of '{library.title} {segment.number}/{segment.of}' response. {error.message} at '{error.file}:{error.line}'.",
-                    context: [...$logContext, ...exception_log($e)],
+                    message: "Parsing library '{library.title}' segment {segment.number}/{segment.of} on '{user}@{backend}' failed.",
+                    context: [
+                        'event_name' => 'backend.operation.failed',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'parse_library_response',
+                        'outcome' => 'failed',
+                        ...$logContext,
+                        ...exception_log($e),
+                    ],
                     e: $e,
                 ),
             );
         }
 
         $end = microtime(true);
-        $this->logger->info(
-            message: "Parsing '{client}: {user}@{backend}' - '{library.title} {segment.number}/{segment.of}' completed in '{time.duration}s'.",
-            context: [
-                ...$logContext,
-                'time' => [
-                    'start' => $start,
-                    'end' => $end,
-                    'duration' => round($end - $start, 2),
+
+        if (true === $isParsed) {
+            $duration = round($end - $start, 2);
+
+            $this->logger->info(
+                message: "Parsed library '{library.title}' segment {segment.number}/{segment.of} from '{user}@{backend}' in {duration_seconds}s.",
+                context: [
+                    'event_name' => 'backend.response.processing',
+                    'subsystem' => 'backend.import',
+                    'operation' => 'parse_library_response',
+                    'outcome' => 'completed',
+                    ...$logContext,
+                    'duration_seconds' => $duration,
+                    'time' => [
+                        'start' => $start,
+                        'end' => $end,
+                        'duration' => $duration,
+                    ],
                 ],
-            ],
-        );
+            );
+        }
 
         Message::increment('response.size', (int) $response->getInfo('size_download'));
     }
@@ -776,8 +1025,12 @@ class Import
 
         if ($context->trace) {
             $this->logger->debug(
-                message: "{action}: Processing '{client}: {user}@{backend}' - '{item.type}: {item.title} ({item.year})' payload.",
+                message: "Processing {item.type} '{item.title}' from '{user}@{backend}'.",
                 context: [
+                    'event_name' => 'backend.response.received',
+                    'subsystem' => 'backend.import',
+                    'operation' => 'process_item',
+                    'outcome' => 'received',
                     ...$logContext,
                     'response' => [
                         'body' => $item,
@@ -789,7 +1042,7 @@ class Import
         $showMetadata = $this->cacheShowMetadata(context: $context, guid: $guid, item: $item, logContext: $logContext);
 
         if ([] === ag($showMetadata, 'guids', [])) {
-            $message = "{action}: Ignoring '{client}: {user}@{backend}' - '{item.title}'. {item.type} has no valid/supported external ids.";
+            $message = "Ignoring {item.type} '{item.title}' from '{user}@{backend}': no supported external IDs.";
 
             if (empty($guids)) {
                 $message .= ' Most likely unmatched {item.type}.';
@@ -797,6 +1050,11 @@ class Import
 
             $this->logger->info($message, [
                 ...$logContext,
+                'event_name' => 'backend.item.ignored',
+                'subsystem' => 'backend.import',
+                'operation' => 'process_item',
+                'outcome' => 'ignored',
+                'reason' => 'missing_supported_guid',
                 'guids' => !empty($item['Guid']) ? $item['Guid'] : 'None',
             ]);
 
@@ -821,12 +1079,19 @@ class Import
 
         try {
             if ($context->trace) {
-                $this->logger->debug("{action}: Processing '{client}: {user}@{backend}' response payload.", [
-                    ...$logContext,
-                    'response' => [
-                        'body' => $item,
+                $this->logger->debug(
+                    message: "Processing {item.type} '{item.title}' from '{user}@{backend}'.",
+                    context: [
+                        'event_name' => 'backend.response.received',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'process_item',
+                        'outcome' => 'received',
+                        ...$logContext,
+                        'response' => [
+                            'body' => $item,
+                        ],
                     ],
-                ]);
+                );
             }
 
             Message::increment("{$context->backendName}.{$mappedType}.total");
@@ -851,7 +1116,7 @@ class Import
                         ]),
                         default => throw new InvalidArgumentException(
                             r(
-                                text: "{action}: Unexpected content type '{type}' was received from '{client}: {user}@{backend}'.",
+                                text: "Unexpected content type '{type}' was received from '{user}@{backend}'.",
                                 context: [...$logContext, 'type' => $type],
                             ),
                         ),
@@ -861,18 +1126,17 @@ class Import
             } catch (InvalidArgumentException $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Failed to parse '{client}: {user}@{backend}' item response. '{error.kind}' with '{error.message}' at '{error.file}:{error.line}' ",
+                        message: "Failed to parse item response from '{user}@{backend}'.",
                         context: [
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'parse_item',
+                            'outcome' => 'failed',
                             ...$logContext,
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
                             'response' => [
                                 'body' => $item,
                             ],
+                            ...exception_log($e),
                         ],
                         e: $e,
                     ),
@@ -882,8 +1146,13 @@ class Import
 
             if (null === ag($item, true === (bool) ag($item, 'viewCount', false) ? 'lastViewedAt' : 'addedAt')) {
                 $this->logger->debug(
-                    message: "{action}: Ignoring '{client}: {backend}' - '{item.id}: {item.title}'. No date '{date_key}' is set on object. '{body}'",
+                    message: "Ignoring {item.type} '#{item.id}: {item.title}' from '{backend}': missing date '{date_key}'.",
                     context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'process_item',
+                        'outcome' => 'ignored',
+                        'reason' => 'missing_date',
                         ...$logContext,
                         'date_key' => true === (bool) ag($item, 'viewCount', false) ? 'lastViewedAt' : 'addedAt',
                         'response' => [
@@ -917,15 +1186,17 @@ class Import
             } catch (Throwable $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Exception '{error.kind}' occurred during '{client}: {user}@{backend}' - '{library.title}' - '{item.id}: {item.title}' entity creation. '{error.message}' at '{error.file}:{error.line}'.",
+                        message: "Creating local entity for {item.type} '{item.title}' from '{user}@{backend}' failed.",
                         context: [
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.import',
+                            'operation' => 'create_entity',
+                            'outcome' => 'failed',
                             ...$logContext,
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
+                            'response' => [
+                                'body' => $item,
                             ],
+                            ...exception_log($e),
                         ],
                         e: $e,
                     ),
@@ -934,7 +1205,7 @@ class Import
             }
 
             if (!$entity->hasGuids() && !$entity->hasRelativeGuid()) {
-                $message = "{action}: Ignoring '{client}: {user}@{backend}' - '{item.title}'. No valid/supported external ids.";
+                $message = "Ignoring {item.type} '{item.title}' from '{user}@{backend}': no supported external IDs.";
 
                 if (null === ($item['Guid'] ?? null)) {
                     $item['Guid'] = [];
@@ -950,6 +1221,11 @@ class Import
 
                 $this->logger->info($message, [
                     ...$logContext,
+                    'event_name' => 'backend.item.ignored',
+                    'subsystem' => 'backend.import',
+                    'operation' => 'create_entity',
+                    'outcome' => 'ignored',
+                    'reason' => 'missing_supported_guid',
                     'guids' => !empty($item['Guid']) ? $item['Guid'] : 'None',
                 ]);
 
@@ -967,8 +1243,18 @@ class Import
         } catch (Throwable $e) {
             $this->logger->error(
                 ...lw(
-                    message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' - '{library.title}' - '{item.title}' item process. {error.message} at '{error.file}:{error.line}'.",
-                    context: [...$logContext, ...exception_log($e)],
+                    message: "Processing item response from '{user}@{backend}' failed.",
+                    context: [
+                        'event_name' => 'backend.operation.failed',
+                        'subsystem' => 'backend.import',
+                        'operation' => 'process_item',
+                        'outcome' => 'failed',
+                        ...$logContext,
+                        'response' => [
+                            'body' => $item,
+                        ],
+                        ...exception_log($e),
+                    ],
                     e: $e,
                 ),
             );

--- a/src/Backends/Plex/Action/ParseWebhook.php
+++ b/src/Backends/Plex/Action/ParseWebhook.php
@@ -115,7 +115,7 @@ final class ParseWebhook
             return new Response(status: false, extra: [
                 'http_code' => Status::BAD_REQUEST->value,
                 'message' => r(
-                    text: "Ignoring '{client}: {user}@{backend}' request. Invalid request, no payload.",
+                    text: "Ignoring backend request from '{user}@{backend}': payload is missing.",
                     context: $logContext,
                 ),
             ]);
@@ -258,8 +258,13 @@ final class ParseWebhook
                 return new Response(
                     status: false,
                     error: new Error(
-                        message: "{action}: Ignoring '{client}: {user}@{backend}' - '{title}' webhook event. No valid/supported external ids.",
+                        message: "Ignoring webhook item '{title}' from '{user}@{backend}': no supported GUIDs were found.",
                         context: [
+                            'event_name' => 'backend.item.ignored',
+                            'subsystem' => 'backend.webhook',
+                            'operation' => 'parse_webhook',
+                            'outcome' => 'ignored',
+                            'reason' => 'missing_supported_guid',
                             'title' => $entity->getName(),
                             ...$logContext,
                             'context' => [
@@ -286,22 +291,14 @@ final class ParseWebhook
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' webhook event parsing. {error.message} at '{error.file}:{error.line}'.",
+                    message: "Failed to parse webhook event from '{user}@{backend}'.",
                     context: [
-                        'error' => [
-                            'kind' => $e::class,
-                            'line' => $e->getLine(),
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
+                        'event_name' => 'backend.operation.failed',
+                        'subsystem' => 'backend.webhook',
+                        'operation' => 'parse_webhook',
+                        'outcome' => 'failed',
                         ...$logContext,
-                        'exception' => [
-                            'file' => $e->getFile(),
-                            'line' => $e->getLine(),
-                            'kind' => get_class($e),
-                            'message' => $e->getMessage(),
-                            'trace' => $e->getTrace(),
-                        ],
+                        ...exception_log($e),
                         'context' => [
                             'attributes' => $request->getAttributes(),
                             'payload' => $request->getParsedBody(),

--- a/src/Backends/Plex/Action/Progress.php
+++ b/src/Backends/Plex/Action/Progress.php
@@ -136,16 +136,30 @@ class Progress
 
             if ($context->backendName === $entity->via) {
                 $this->logger->info(
-                    message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. Event originated from this backend.",
-                    context: $logContext,
+                    message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': event originated from this backend.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.progress',
+                        'operation' => 'prepare_progress_update',
+                        'outcome' => 'ignored',
+                        'reason' => 'origin_backend',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
 
             if (null === ag($metadata, iState::COLUMN_ID, null)) {
                 $this->logger->warning(
-                    message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. No metadata was found.",
-                    context: $logContext,
+                    message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': backend metadata is missing.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.progress',
+                        'operation' => 'load_remote_state',
+                        'outcome' => 'ignored',
+                        'reason' => 'missing_backend_metadata',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
@@ -153,8 +167,15 @@ class Progress
             $senderDate = ag($entity->getExtra($entity->via), iState::COLUMN_EXTRA_DATE);
             if (null === $senderDate) {
                 $this->logger->warning(
-                    message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. The event originator did not set a date.",
-                    context: $logContext,
+                    message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': sender event date is missing.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.progress',
+                        'operation' => 'prepare_progress_update',
+                        'outcome' => 'ignored',
+                        'reason' => 'missing_event_date',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
@@ -165,12 +186,18 @@ class Progress
 
             if (false === $ignoreDate && null !== $datetime && make_date($datetime)->getTimestamp() > $senderDate) {
                 $this->logger->warning(
-                    message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. Event date '{event_date}' is older than backend local db item date '{local_date}'.",
+                    message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': event date is not newer than local backend history.",
                     context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.progress',
+                        'operation' => 'compare_dates',
+                        'outcome' => 'ignored',
+                        'reason' => 'date_not_newer_than_local_history',
                         ...$logContext,
-                        'event_date' => make_date($senderDate),
-                        'local_date' => make_date($datetime),
-                        'compare' => ['remote' => make_date($datetime), 'sender' => make_date($senderDate)],
+                        'comparison' => [
+                            'local' => make_date($datetime),
+                            'sender' => make_date($senderDate),
+                        ],
                     ],
                 );
                 continue;
@@ -179,9 +206,16 @@ class Progress
             $logContext['remote']['id'] = ag($metadata, iState::COLUMN_ID);
 
             if (array_key_exists($logContext['remote']['id'], $sessions)) {
-                $this->logger->notice(
-                    message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. The item is playing right now.",
-                    context: $logContext,
+                $this->logger->info(
+                    message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': item is active in another session.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.progress',
+                        'operation' => 'prepare_progress_update',
+                        'outcome' => 'ignored',
+                        'reason' => 'active_session',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
@@ -197,12 +231,15 @@ class Progress
 
                 if (false === $ignoreDate && make_date($remoteItem->updated)->getTimestamp() > $senderDate) {
                     $this->logger->info(
-                        message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. Event date '{event_date}' is older than backend remote item date '{remote_date}'.",
+                        message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': event date is not newer than backend state.",
                         context: [
+                            'event_name' => 'backend.item.ignored',
+                            'subsystem' => 'backend.progress',
+                            'operation' => 'compare_dates',
+                            'outcome' => 'ignored',
+                            'reason' => 'date_not_newer_than_remote_state',
                             ...$logContext,
-                            'event_date' => make_date($senderDate),
-                            'remote_date' => make_date($remoteItem->updated),
-                            'compare' => [
+                            'comparison' => [
                                 'remote' => make_date($remoteItem->updated),
                                 'sender' => make_date($senderDate),
                             ],
@@ -216,8 +253,15 @@ class Progress
                     $minThreshold = (int) Config::get('progress.minThreshold', 86_400);
                     if (false === ($allowUpdate >= $minThreshold && time() > ($entity->updated + $allowUpdate))) {
                         $this->logger->info(
-                            message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. The backend says the item is marked as watched.",
-                            context: $logContext,
+                            message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': backend item is already watched.",
+                            context: [
+                                'event_name' => 'backend.item.ignored',
+                                'subsystem' => 'backend.progress',
+                                'operation' => 'update_progress',
+                                'outcome' => 'ignored',
+                                'reason' => 'remote_marked_watched',
+                                ...$logContext,
+                            ],
                         );
                         continue;
                     }
@@ -225,22 +269,14 @@ class Progress
             } catch (\App\Libs\Exceptions\RuntimeException|RuntimeException|InvalidArgumentException $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' get {item.type} '#{item.id}: {item.title}' status. '{error.message}' at '{error.file}:{error.line}'.",
+                        message: "Failed to load backend state for {item.type} '#{item.id}: {item.title}' from '{user}@{backend}'.",
                         context: [
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.progress',
+                            'operation' => 'load_remote_state',
+                            'outcome' => 'failed',
                             ...$logContext,
-                            'exception' => [
-                                'file' => $e->getFile(),
-                                'line' => $e->getLine(),
-                                'kind' => get_class($e),
-                                'message' => $e->getMessage(),
-                                'trace' => $e->getTrace(),
-                            ],
+                            ...exception_log($e),
                         ],
                         e: $e,
                     ),
@@ -269,8 +305,12 @@ class Progress
                 $logContext['remote']['url'] = (string) $url;
 
                 $this->logger->debug(
-                    message: "{action}: Updating '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' watch progress to '{progress}'.",
+                    message: "Updating watch progress for {item.type} '#{item.id}: {item.title}' on '{user}@{backend}'.",
                     context: [
+                        'event_name' => 'backend.request.started',
+                        'subsystem' => 'backend.progress',
+                        'operation' => 'update_progress',
+                        'outcome' => 'started',
                         ...$logContext,
                         'progress' => format_duration($progressValue),
                         'time' => $progressValue,
@@ -293,8 +333,12 @@ class Progress
 
                                 if (false === in_array(Status::tryFrom($statusCode), [Status::OK, Status::NO_CONTENT], true)) {
                                     $this->logger->error(
-                                        message: "{action}: Request to change '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' watch progress returned with unexpected '{status_code}' status code.",
+                                        message: "Watch-progress update for {item.type} '#{item.id}: {item.title}' on '{user}@{backend}' returned status {status_code}.",
                                         context: [
+                                            'event_name' => 'backend.response.failed',
+                                            'subsystem' => 'backend.progress',
+                                            'operation' => 'update_progress',
+                                            'outcome' => 'failed',
                                             ...$requestContext,
                                             'status_code' => $statusCode,
                                         ],
@@ -304,8 +348,12 @@ class Progress
                                 }
 
                                 $this->logger->notice(
-                                    message: "{action}: Updated '{client}: {user}@{backend}' '#{item.id}: {item.title}' watch progress to '{progress}'.",
+                                    message: "Updated watch progress for '#{item.id}: {item.title}' on '{user}@{backend}'.",
                                     context: [
+                                        'event_name' => 'backend.state_update.completed',
+                                        'subsystem' => 'backend.progress',
+                                        'operation' => 'update_progress',
+                                        'outcome' => 'completed',
                                         ...$requestContext,
                                         'status_code' => $statusCode,
                                     ],
@@ -316,8 +364,12 @@ class Progress
                             error: function (Throwable $e) use ($requestContext): array {
                                 $this->logger->error(
                                     ...lw(
-                                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request to change watch progress of {item.type} '#{item.id}: {item.title}'. '{error.message}' at '{error.file}:{error.line}'.",
+                                        message: "Watch-progress request failed for {item.type} '#{item.id}: {item.title}' on '{user}@{backend}'.",
                                         context: [
+                                            'event_name' => 'backend.client.request_failed',
+                                            'subsystem' => 'backend.progress',
+                                            'operation' => 'update_progress',
+                                            'outcome' => 'failed',
                                             ...$requestContext,
                                             ...exception_log($e),
                                         ],
@@ -337,22 +389,14 @@ class Progress
             } catch (Throwable $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' change {item.type} '#{item.id}: {item.title}' watch progress. '{error.message}' at '{error.file}:{error.line}'.",
+                        message: "Failed to prepare watch-progress update for {item.type} '#{item.id}: {item.title}' on '{user}@{backend}'.",
                         context: [
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.progress',
+                            'operation' => 'prepare_progress_update',
+                            'outcome' => 'failed',
                             ...$logContext,
-                            'exception' => [
-                                'file' => $e->getFile(),
-                                'line' => $e->getLine(),
-                                'kind' => get_class($e),
-                                'message' => $e->getMessage(),
-                                'trace' => $e->getTrace(),
-                            ],
+                            ...exception_log($e),
                         ],
                         e: $e,
                     ),

--- a/src/Backends/Plex/Action/Proxy.php
+++ b/src/Backends/Plex/Action/Proxy.php
@@ -22,6 +22,10 @@ final class Proxy
 
     private string $action = 'plex.proxy';
 
+    /**
+     * @param iHttp&\App\Libs\Extends\HttpClient $http
+     * @param iLogger $logger
+     */
     public function __construct(
         protected readonly iHttp $http,
         protected readonly iLogger $logger,
@@ -59,8 +63,18 @@ final class Proxy
                 ];
 
                 $this->logger->debug(
-                    message: "{action}: proxying request via '{client}: {user}@{backend}'.",
-                    context: $logContext,
+                    message: "Proxying {http.method} request to '{user}@{backend}'.",
+                    context: [
+                        ...$logContext,
+                        'event_name' => 'backend.request.started',
+                        'subsystem' => 'backend.proxy',
+                        'operation' => 'proxy',
+                        'outcome' => 'started',
+                        'http' => [
+                            'method' => $method->value,
+                            'url' => $url,
+                        ],
+                    ],
                 );
 
                 $requestOpts = $context->getHttpOptions();

--- a/src/Backends/Plex/Action/Push.php
+++ b/src/Backends/Plex/Action/Push.php
@@ -95,8 +95,15 @@ final class Push
 
             if (null === ag($metadata, iState::COLUMN_ID)) {
                 $this->logger->warning(
-                    message: "{action}: Ignoring '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. No metadata was found.",
-                    context: $logContext,
+                    message: "Ignoring {item.type} '#{item.id}: {item.title}' for '{user}@{backend}': backend metadata is missing.",
+                    context: [
+                        'event_name' => 'backend.item.ignored',
+                        'subsystem' => 'backend.push',
+                        'operation' => 'load_remote_state',
+                        'outcome' => 'ignored',
+                        'reason' => 'missing_backend_metadata',
+                        ...$logContext,
+                    ],
                 );
                 continue;
             }
@@ -109,8 +116,14 @@ final class Push
                 $logContext['remote']['url'] = (string) $url;
 
                 $this->logger->debug(
-                    message: "{action}: Requesting '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' metadata.",
-                    context: $logContext,
+                    message: "Loading backend state for {item.type} '#{item.id}: {item.title}' from '{user}@{backend}'.",
+                    context: [
+                        'event_name' => 'backend.request.started',
+                        'subsystem' => 'backend.push',
+                        'operation' => 'load_remote_state',
+                        'outcome' => 'started',
+                        ...$logContext,
+                    ],
                 );
 
                 $requests[] = $this->http->request(
@@ -123,22 +136,14 @@ final class Push
             } catch (Throwable $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Exception '{error.kind}' unhandled during '{client}: {user}@{backend}' request for {item.type} '#{item.id}: {item.title}' metadata. {error.message} at '{error.file}:{error.line}'.",
+                        message: "Failed to load backend state for {item.type} '#{item.id}: {item.title}' from '{user}@{backend}'.",
                         context: [
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
+                            'event_name' => 'backend.client.request_failed',
+                            'subsystem' => 'backend.push',
+                            'operation' => 'load_remote_state',
+                            'outcome' => 'failed',
                             ...$logContext,
-                            'exception' => [
-                                'file' => $e->getFile(),
-                                'line' => $e->getLine(),
-                                'kind' => get_class($e),
-                                'message' => $e->getMessage(),
-                                'trace' => $e->getTrace(),
-                            ],
+                            ...exception_log($e),
                         ],
                         e: $e,
                     ),
@@ -154,8 +159,15 @@ final class Push
             try {
                 if (null === ($id = ag($response->getInfo('user_data'), 'id'))) {
                     $this->logger->error(
-                        message: "{action}: Unable to get entity object id for '{client}: {user}@{backend}'.",
-                        context: $logContext,
+                        message: "Push response for '{user}@{backend}' is missing the local entity reference.",
+                        context: [
+                            'event_name' => 'backend.response.failed',
+                            'subsystem' => 'backend.push',
+                            'operation' => 'load_remote_state',
+                            'outcome' => 'failed',
+                            'reason' => 'missing_entity_reference',
+                            ...$logContext,
+                        ],
                     );
                     continue;
                 }
@@ -167,13 +179,28 @@ final class Push
                 if (Status::OK !== Status::tryFrom($response->getStatusCode())) {
                     if (Status::NOT_FOUND === Status::tryFrom($response->getStatusCode())) {
                         $this->logger->warning(
-                            message: "{action}: Request for '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' metadata returned with (404: Not Found) status code.",
-                            context: [...$logContext, 'status_code' => $response->getStatusCode()],
+                            message: "Backend state for {item.type} '#{item.id}: {item.title}' was not found on '{user}@{backend}'.",
+                            context: [
+                                'event_name' => 'backend.response.failed',
+                                'subsystem' => 'backend.push',
+                                'operation' => 'load_remote_state',
+                                'outcome' => 'failed',
+                                'reason' => 'not_found',
+                                ...$logContext,
+                                'status_code' => $response->getStatusCode(),
+                            ],
                         );
                     } else {
                         $this->logger->error(
-                            message: "{action}: Request for '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' metadata returned with unexpected '{status_code}' status code.",
-                            context: [...$logContext, 'status_code' => $response->getStatusCode()],
+                            message: "Backend state request for {item.type} '#{item.id}: {item.title}' on '{user}@{backend}' returned status {status_code}.",
+                            context: [
+                                'event_name' => 'backend.response.failed',
+                                'subsystem' => 'backend.push',
+                                'operation' => 'load_remote_state',
+                                'outcome' => 'failed',
+                                ...$logContext,
+                                'status_code' => $response->getStatusCode(),
+                            ],
                         );
                     }
 
@@ -188,8 +215,15 @@ final class Push
 
                 if ($context->trace) {
                     $this->logger->debug(
-                        message: "{action}: Parsing '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' payload.",
-                        context: [...$logContext, 'response' => ['body' => $body]],
+                        message: "Parsing backend state for {item.type} '#{item.id}: {item.title}' from '{user}@{backend}'.",
+                        context: [
+                            'event_name' => 'backend.response.received',
+                            'subsystem' => 'backend.push',
+                            'operation' => 'load_remote_state',
+                            'outcome' => 'received',
+                            ...$logContext,
+                            'response' => ['body' => $body],
+                        ],
                     );
                 }
 
@@ -197,18 +231,35 @@ final class Push
 
                 if (empty($json)) {
                     $this->logger->error(
-                        message: "{action}: Ignoring '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}'. Returned with unexpected body.",
-                        context: [...$logContext, 'response' => ['body' => $body]],
+                        message: "Backend state for {item.type} '#{item.id}: {item.title}' from '{user}@{backend}' returned an empty payload.",
+                        context: [
+                            'event_name' => 'backend.response.failed',
+                            'subsystem' => 'backend.push',
+                            'operation' => 'load_remote_state',
+                            'outcome' => 'failed',
+                            'reason' => 'empty_response_body',
+                            ...$logContext,
+                            'response' => ['body' => $body],
+                        ],
                     );
                     continue;
                 }
 
                 $isWatched = 0 === (int) ag($json, 'viewCount', 0) ? 0 : 1;
+                $playState = 1 === $isWatched ? 'Played' : 'Unplayed';
 
                 if ($entity->watched === $isWatched) {
                     $this->logger->info(
-                        message: "{action}: Ignoring '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}'. Play state is identical.",
-                        context: $logContext,
+                        message: "Ignoring {item.type} '#{item.id}: {item.title}' from '{user}@{backend}': play state is already '{play_state}'.",
+                        context: [
+                            'event_name' => 'backend.item.ignored',
+                            'subsystem' => 'backend.push',
+                            'operation' => 'update_state',
+                            'outcome' => 'ignored',
+                            'reason' => 'state_unchanged',
+                            ...$logContext,
+                            'play_state' => $playState,
+                        ],
                     );
                     continue;
                 }
@@ -218,8 +269,17 @@ final class Push
 
                     if (null === ($date = ag($json, $dateKey))) {
                         $this->logger->error(
-                            message: "{action}: Ignoring '{client}: {user}@{backend}' {item.type} '{item.title}'. No {date_key} is set on backend object.",
-                            context: ['date_key' => $dateKey, ...$logContext, 'response' => ['body' => $json]],
+                            message: "Ignoring {item.type} '#{item.id}: {item.title}' from '{user}@{backend}': missing backend date '{date_key}'.",
+                            context: [
+                                'event_name' => 'backend.item.ignored',
+                                'subsystem' => 'backend.push',
+                                'operation' => 'update_state',
+                                'outcome' => 'ignored',
+                                'reason' => 'missing_date',
+                                'date_key' => $dateKey,
+                                ...$logContext,
+                                'response' => ['body' => $json],
+                            ],
                         );
                         continue;
                     }
@@ -230,8 +290,13 @@ final class Push
 
                     if ($date->getTimestamp() >= ($entity->updated + $timeExtra)) {
                         $this->logger->notice(
-                            message: "{action}: Ignoring '{client}: {user}@{backend}' {item.type} '{item.title}'. Database date is older than backend date.",
+                            message: "Ignoring {item.type} '#{item.id}: {item.title}' from '{user}@{backend}': backend date is newer than local state.",
                             context: [
+                                'event_name' => 'backend.item.ignored',
+                                'subsystem' => 'backend.push',
+                                'operation' => 'update_state',
+                                'outcome' => 'ignored',
+                                'reason' => 'backend_date_newer',
                                 ...$logContext,
                                 'comparison' => [
                                     'database' => make_date($entity->updated),
@@ -257,12 +322,18 @@ final class Push
                         ),
                     );
 
-                $logContext['remote']['url'] = $url;
+                $logContext['remote']['url'] = (string) $url;
                 $requestContext = $logContext + ['play_state' => $entity->isWatched() ? 'Played' : 'Unplayed'];
 
                 $this->logger->debug(
-                    message: "{action}: Queuing request to change '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' play state to '{play_state}'.",
-                    context: $requestContext,
+                    message: "Updating play state for {item.type} '#{item.id}: {item.title}' on '{user}@{backend}' to '{play_state}'.",
+                    context: [
+                        'event_name' => 'backend.request.started',
+                        'subsystem' => 'backend.push',
+                        'operation' => 'update_state',
+                        'outcome' => 'started',
+                        ...$requestContext,
+                    ],
                 );
 
                 if (false === (bool) ag($context->options, Options::DRY_RUN)) {
@@ -276,8 +347,12 @@ final class Push
 
                                 if (Status::OK !== Status::tryFrom($statusCode)) {
                                     $this->logger->error(
-                                        message: "{action}: Request to change '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' play state returned with unexpected '{status_code}' status code.",
+                                        message: "Play-state update for {item.type} '#{item.id}: {item.title}' on '{user}@{backend}' returned status {status_code}.",
                                         context: [
+                                            'event_name' => 'backend.response.failed',
+                                            'subsystem' => 'backend.push',
+                                            'operation' => 'update_state',
+                                            'outcome' => 'failed',
                                             ...$requestContext,
                                             'status_code' => $statusCode,
                                         ],
@@ -287,8 +362,14 @@ final class Push
                                 }
 
                                 $this->logger->notice(
-                                    message: "{action}: Updated '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' play state to '{play_state}'.",
-                                    context: $requestContext,
+                                    message: "Updated play state for {item.type} '#{item.id}: {item.title}' on '{user}@{backend}' to '{play_state}'.",
+                                    context: [
+                                        'event_name' => 'backend.state_update.completed',
+                                        'subsystem' => 'backend.push',
+                                        'operation' => 'update_state',
+                                        'outcome' => 'completed',
+                                        ...$requestContext,
+                                    ],
                                 );
 
                                 return [];
@@ -296,8 +377,12 @@ final class Push
                             error: function (Throwable $e) use ($requestContext): array {
                                 $this->logger->error(
                                     ...lw(
-                                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request to change play state of {item.type} '#{item.id}: {item.title}'. '{error.message}' at '{error.file}:{error.line}'.",
+                                        message: "Play-state request failed for {item.type} '#{item.id}: {item.title}' on '{user}@{backend}'.",
                                         context: [
+                                            'event_name' => 'backend.client.request_failed',
+                                            'subsystem' => 'backend.push',
+                                            'operation' => 'update_state',
+                                            'outcome' => 'failed',
                                             ...$requestContext,
                                             ...exception_log($e),
                                         ],
@@ -317,22 +402,14 @@ final class Push
             } catch (Throwable $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' push play state. {error.message} at '{error.file}:{error.line}'.",
+                        message: "Failed to prepare play-state update for {item.type} '#{item.id}: {item.title}' on '{user}@{backend}'.",
                         context: [
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.push',
+                            'operation' => 'prepare_state_update',
+                            'outcome' => 'failed',
                             ...$logContext,
-                            'exception' => [
-                                'file' => $e->getFile(),
-                                'line' => $e->getLine(),
-                                'kind' => get_class($e),
-                                'message' => $e->getMessage(),
-                                'trace' => $e->getTrace(),
-                            ],
+                            ...exception_log($e),
                         ],
                         e: $e,
                     ),

--- a/src/Backends/Plex/Action/SearchQuery.php
+++ b/src/Backends/Plex/Action/SearchQuery.php
@@ -28,6 +28,12 @@ final class SearchQuery
 
     private string $action = 'plex.searchQuery';
 
+    /**
+     * @param iHttp&\App\Libs\Extends\HttpClient $http
+     * @param iLogger $logger
+     * @param iDB $db
+     * @param PlexGuid $plexGuid
+     */
     public function __construct(
         protected iHttp $http,
         protected iLogger $logger,
@@ -90,7 +96,14 @@ final class SearchQuery
             'url' => (string) $url,
         ];
 
-        $this->logger->debug("{action}: Searching '{client}: {user}@{backend}' libraries for '{query}'.", $logContext);
+        $this->logger->debug("Searching '{user}@{backend}' for '{query}'.", [
+            ...$logContext,
+            'event_name' => 'backend.request.started',
+            'subsystem' => 'backend.search',
+            'operation' => 'query',
+            'outcome' => 'started',
+            'http' => ['url' => (string) $url],
+        ]);
 
         $response = $this->http->request(
             method: Method::GET,
@@ -105,10 +118,19 @@ final class SearchQuery
             return new Response(
                 status: false,
                 error: new Error(
-                    message: "{action}: Search request for '{query}' in '{client}: {user}@{backend}' returned with unexpected '{status_code}' status code.",
+                    message: "Search request for '{query}' on '{user}@{backend}' returned status {http.status_code}.",
                     context: [
                         ...$logContext,
-                        'status_code' => $response->getStatusCode(),
+                        'event_name' => 'backend.response.failed',
+                        'subsystem' => 'backend.search',
+                        'operation' => 'query',
+                        'outcome' => 'failed',
+                        'reason' => 'unexpected_status',
+                        'http' => [
+                            'status_code' => $response->getStatusCode(),
+                            'expected_status_codes' => [Status::OK->value],
+                            'url' => (string) $url,
+                        ],
                     ],
                     level: Levels::ERROR,
                 ),
@@ -123,8 +145,15 @@ final class SearchQuery
 
         if ($context->trace) {
             $this->logger->debug(
-                message: "{action}: Parsing Searching '{client}: {user}@{backend}' libraries for '{query}' payload.",
-                context: [...$logContext, 'response' => ['body' => $json]],
+                message: "Processing search response from '{user}@{backend}' for '{query}'.",
+                context: [
+                    ...$logContext,
+                    'event_name' => 'backend.response.received',
+                    'subsystem' => 'backend.search',
+                    'operation' => 'query',
+                    'outcome' => 'received',
+                    'response' => ['body' => $json],
+                ],
             );
         }
 
@@ -144,8 +173,15 @@ final class SearchQuery
                     $entity = $this->createEntity($context, $plexGuid, $item, $opts);
                 } catch (Throwable $e) {
                     $this->logger->error(
-                        message: "{action}: Failed to map '{client}: {user}@{backend}' item to entity. {error}",
-                        context: [...$logContext, 'error' => $e->getMessage()],
+                        message: "Failed to map search result from '{user}@{backend}' to a local entity.",
+                        context: [
+                            ...$logContext,
+                            'event_name' => 'backend.operation.failed',
+                            'subsystem' => 'backend.search',
+                            'operation' => 'map_result',
+                            'outcome' => 'failed',
+                            ...exception_log($e),
+                        ],
                     );
                     continue;
                 }

--- a/src/Backends/Plex/Action/UpdateState.php
+++ b/src/Backends/Plex/Action/UpdateState.php
@@ -69,8 +69,13 @@ final class UpdateState
 
                     if (true === (bool) ag($context->options, Options::DRY_RUN, false)) {
                         $this->logger->notice(
-                            message: "{action}: Would mark '{client}: {user}@{backend}' {item.type} '{item.title}' as '{item.play_state}'.",
+                            message: "Would update play state for {item.type} '{item.title}' on '{user}@{backend}' to '{item.play_state}'.",
                             context: [
+                                'event_name' => 'backend.request.skipped',
+                                'subsystem' => 'backend.restore',
+                                'operation' => 'update_state',
+                                'outcome' => 'skipped',
+                                'reason' => 'dry_run',
                                 ...$rContext,
                                 'item' => [
                                     'id' => $itemId,
@@ -90,28 +95,44 @@ final class UpdateState
                             http_build_query(['identifier' => 'com.plexapp.plugins.library', 'key' => $itemId]),
                         );
 
+                    $requestContext = [
+                        ...$rContext,
+                        'play_state' => $entity->isWatched() ? 'played' : 'unplayed',
+                        'item' => [
+                            'id' => $itemId,
+                            'title' => $entity->getName(),
+                            'type' => $entity->type === iState::TYPE_EPISODE ? 'episode' : 'movie',
+                            'state' => $entity->isWatched() ? 'played' : 'unplayed',
+                        ],
+                        'url' => (string) $url,
+                    ];
+
+                    $this->logger->debug(
+                        message: "Updating play state for {item.type} '{item.title}' on '{user}@{backend}' to '{play_state}'.",
+                        context: [
+                            'event_name' => 'backend.request.started',
+                            'subsystem' => 'backend.restore',
+                            'operation' => 'update_state',
+                            'outcome' => 'started',
+                            ...$requestContext,
+                        ],
+                    );
+
                     $queue->add(
                         new Request(
                             method: Method::GET,
                             url: $url,
                             options: $context->getHttpOptions(),
-                            success: function (ResponseInterface $response) use ($entity, $itemId, $rContext): array {
-                                $requestContext = [
-                                    ...$rContext,
-                                    'play_state' => $entity->isWatched() ? 'played' : 'unplayed',
-                                    'item' => [
-                                        'id' => $itemId,
-                                        'title' => $entity->getName(),
-                                        'type' => $entity->type === iState::TYPE_EPISODE ? 'episode' : 'movie',
-                                        'state' => $entity->isWatched() ? 'played' : 'unplayed',
-                                    ],
-                                ];
-
+                            success: function (ResponseInterface $response) use ($requestContext): array {
                                 $statusCode = $response->getStatusCode();
                                 if (Status::OK !== Status::tryFrom($statusCode)) {
                                     $this->logger->error(
-                                        message: "{action}: Failed to change '{client}: {user}@{backend}' - '{item.title}' play state. Invalid HTTP '{status_code}' status code returned.",
+                                        message: "Play-state update for {item.type} '{item.title}' on '{user}@{backend}' returned status {status_code}.",
                                         context: [
+                                            'event_name' => 'backend.response.failed',
+                                            'subsystem' => 'backend.restore',
+                                            'operation' => 'update_state',
+                                            'outcome' => 'failed',
                                             ...$requestContext,
                                             'status_code' => $statusCode,
                                         ],
@@ -121,25 +142,28 @@ final class UpdateState
                                 }
 
                                 $this->logger->notice(
-                                    message: "{action}: Changed '{client}: {user}@{backend}' - '{item.title}' play state to '{play_state}'.",
-                                    context: $requestContext,
+                                    message: "Updated play state for {item.type} '{item.title}' on '{user}@{backend}' to '{play_state}'.",
+                                    context: [
+                                        'event_name' => 'backend.state_update.completed',
+                                        'subsystem' => 'backend.restore',
+                                        'operation' => 'update_state',
+                                        'outcome' => 'completed',
+                                        ...$requestContext,
+                                    ],
                                 );
 
                                 return [];
                             },
-                            error: function (Throwable $e) use ($entity, $itemId, $rContext): array {
+                            error: function (Throwable $e) use ($requestContext): array {
                                 $this->logger->error(
                                     ...lw(
-                                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' restore play state of {item.type} '{item.title}'. '{error.message}' at '{error.file}:{error.line}'.",
+                                        message: "Play-state request failed for {item.type} '{item.title}' on '{user}@{backend}'.",
                                         context: [
-                                            ...$rContext,
-                                            'play_state' => $entity->isWatched() ? 'played' : 'unplayed',
-                                            'item' => [
-                                                'id' => $itemId,
-                                                'title' => $entity->getName(),
-                                                'type' => $entity->type === iState::TYPE_EPISODE ? 'episode' : 'movie',
-                                                'state' => $entity->isWatched() ? 'played' : 'unplayed',
-                                            ],
+                                            'event_name' => 'backend.client.request_failed',
+                                            'subsystem' => 'backend.restore',
+                                            'operation' => 'update_state',
+                                            'outcome' => 'failed',
+                                            ...$requestContext,
                                             ...exception_log($e),
                                         ],
                                         e: $e,
@@ -149,16 +173,7 @@ final class UpdateState
                                 return [];
                             },
                             extras: [
-                                'context' => [
-                                    ...$rContext,
-                                    'play_state' => $entity->isWatched() ? 'played' : 'unplayed',
-                                    'item' => [
-                                        'id' => $itemId,
-                                        'title' => $entity->getName(),
-                                        'type' => $entity->type === iState::TYPE_EPISODE ? 'episode' : 'movie',
-                                        'state' => $entity->isWatched() ? 'played' : 'unplayed',
-                                    ],
-                                ],
+                                'context' => $requestContext,
                                 iHttp::class => $this->http,
                             ],
                         ),

--- a/src/Backends/Plex/PlexClient.php
+++ b/src/Backends/Plex/PlexClient.php
@@ -863,15 +863,33 @@ class PlexClient implements iClient
                     }
                 }
 
+                $reason = null;
+
+                if (false !== ($xml = @simplexml_load_string($payload))) {
+                    $xmlData = json_decode(json_encode($xml, JSON_INVALID_UTF8_IGNORE), true);
+
+                    if (is_array($xmlData)) {
+                        $reason = ag($xmlData, ['error', 'errors.error']);
+
+                        if (is_array($reason)) {
+                            $reason = array_shift($reason);
+                        }
+                    }
+                }
+
+                if (!is_string($reason) || '' === trim($reason)) {
+                    $reason = array_to_string([
+                        'with_admin' => true === ag($opts, 'with_admin'),
+                        'payload' => $payload,
+                    ]);
+                }
+
                 throw new RuntimeException(
                     r(
-                        text: 'Failed to load Plex servers list: plex.tv returned status {status_code}. {context}',
+                        text: 'Failed to load Plex servers list: plex.tv returned status {status_code}. {error}',
                         context: [
                             'status_code' => $response->getStatusCode(),
-                            'context' => array_to_string([
-                                'with_admin' => true === ag($opts, 'with_admin'),
-                                'payload' => $payload,
-                            ]),
+                            'error' => $reason,
                         ],
                     ),
                     $response->getStatusCode(),
@@ -893,7 +911,11 @@ class PlexClient implements iClient
             );
         }
 
-        $xml = simplexml_load_string($payload);
+        $xml = @simplexml_load_string($payload);
+
+        if (false === $xml) {
+            throw new RuntimeException('Failed to parse Plex servers list response.');
+        }
 
         $list = [];
 
@@ -1056,12 +1078,28 @@ class PlexClient implements iClient
      */
     private function throwError(Response $response, string $className = RuntimeException::class, int $code = 0): void
     {
+        $message = ag($response->extra, 'message', null);
+
+        if (null === $message && null !== $response->error) {
+            $message = ag($response->error->extra, 'message', null);
+        }
+
+        if (!is_string($message) || '' === trim($message)) {
+            $message = $response->error?->format() ?? 'The backend request failed.';
+        }
+
+        $reason = ag($response->extra, 'error', null);
+
+        if (null === $reason && null !== $response->error) {
+            $reason = ag($response->error->extra, 'error', null);
+        }
+
+        if (is_string($reason) && '' !== trim($reason) && false === str_contains($message, $reason)) {
+            $message = trim($message . ' ' . $reason);
+        }
+
         throw new $className(
-            message: ag(
-                $response->extra,
-                'message',
-                static fn() => $response->error?->format() ?? 'The backend request failed.',
-            ),
+            message: $message,
             code: $code,
             previous: $response->error?->previous,
         );

--- a/src/Backends/Plex/PlexClient.php
+++ b/src/Backends/Plex/PlexClient.php
@@ -865,7 +865,7 @@ class PlexClient implements iClient
 
                 throw new RuntimeException(
                     r(
-                        text: "PlexClient: Request for servers list returned with unexpected '{status_code}' status code. {context}",
+                        text: 'Failed to load Plex servers list: plex.tv returned status {status_code}. {context}',
                         context: [
                             'status_code' => $response->getStatusCode(),
                             'context' => array_to_string([
@@ -880,7 +880,7 @@ class PlexClient implements iClient
         } catch (TransportExceptionInterface $e) {
             throw new RuntimeException(
                 r(
-                    text: "PlexClient: Exception '{kind}' was thrown unhandled during request for plex servers list, likely network related error. {error} at '{file}:{line}'.",
+                    text: 'Failed to load Plex servers list because the request could not be completed.',
                     context: [
                         'kind' => $e::class,
                         'error' => $e->getMessage(),
@@ -898,7 +898,7 @@ class PlexClient implements iClient
         $list = [];
 
         if (false === $xml->Device) {
-            throw new RuntimeException('PlexClient: No backends were associated with the given token.');
+            throw new RuntimeException('No Plex servers were associated with the provided token.');
         }
 
         foreach ($xml->Device as $device) {
@@ -1019,7 +1019,7 @@ class PlexClient implements iClient
         } catch (TransportExceptionInterface $e) {
             throw new RuntimeException(
                 r(
-                    text: "PlexClient: Exception '{kind}' was thrown unhandled during request for plex servers list, likely network related error. {error} at '{file}:{line}'.",
+                    text: 'Failed to validate the Plex token because the request could not be completed.',
                     context: [
                         'kind' => $e::class,
                         'error' => $e->getMessage(),
@@ -1060,7 +1060,7 @@ class PlexClient implements iClient
             message: ag(
                 $response->extra,
                 'message',
-                static fn() => $response->error?->format() ?? 'An unexpected error occurred.',
+                static fn() => $response->error?->format() ?? 'The backend request failed.',
             ),
             code: $code,
             previous: $response->error?->previous,

--- a/src/Backends/Plex/PlexGuid.php
+++ b/src/Backends/Plex/PlexGuid.php
@@ -541,8 +541,10 @@ final class PlexGuid implements iGuid
                     }
 
                     if (true === $log) {
-                        $this->logger->warning(
-                            "External id conflict for '#{item_id}' from '{user}@{backend}': multiple {guid_source} ids reported.",
+                        $guidValues = [$guid[$this->guidMapper[$key]], $value];
+
+                        $this->logger->info(
+                            "External id conflict for '#{item_id}: {item_title}' from '{user}@{backend}': multiple {guid_source} ids reported: '{guid_values_text}'.",
                             [
                                 'event_name' => 'guid.external_id.conflict',
                                 'subsystem' => 'guid',
@@ -554,8 +556,10 @@ final class PlexGuid implements iGuid
                                 'backend' => $this->context->backendName,
                                 'item_id' => $id,
                                 'guid_source' => $key,
-                                'guid_values' => [$guid[$this->guidMapper[$key]], $value],
+                                'guid_values' => $guidValues,
                                 ...$context,
+                                'item_title' => (string) ag($context, 'item.title', 'unknown title'),
+                                'guid_values_text' => implode("', '", $guidValues),
                             ],
                         );
                     }

--- a/src/Backends/Plex/PlexGuid.php
+++ b/src/Backends/Plex/PlexGuid.php
@@ -96,16 +96,14 @@ final class PlexGuid implements iGuid
                 $this->parseGUIDFile($file);
             }
         } catch (Throwable $e) {
-            $this->logger->error("Failed to read or parse '{guid}' file. Error '{error}'.", [
-                'guid' => $file,
-                'error' => $e->getMessage(),
-                'exception' => [
-                    'message' => $e->getMessage(),
-                    'code' => $e->getCode(),
-                    'file' => $e->getFile(),
-                    'line' => $e->getLine(),
-                    'trace' => $e->getTrace(),
-                ],
+            $this->logger->error("Failed to parse GUID mapping file '{file}' for {client}.", [
+                'event_name' => 'guid.file.parse_failed',
+                'subsystem' => 'guid',
+                'operation' => 'load_config',
+                'outcome' => 'failed',
+                'client' => $this->clientName(),
+                'file' => $file,
+                ...exception_log($e),
             ]);
         }
     }
@@ -128,7 +126,19 @@ final class PlexGuid implements iGuid
         }
 
         if (filesize($file) < 1) {
-            $this->logger->info("The external GUID mapping file '{file}' is empty.", ['file' => $file]);
+            $this->logger->info("GUID mapping file '{file}' is empty.", [
+                'event_name' => 'guid.mapping.ignored',
+                'subsystem' => 'guid',
+                'operation' => 'load_config',
+                'outcome' => 'ignored',
+                'reason' => 'empty_file',
+                'reason_label' => 'mapping file is empty',
+                'client' => $this->clientName(),
+                'mapping_key' => null,
+                'mapping_from' => null,
+                'mapping_to' => null,
+                'file' => $file,
+            ]);
             return;
         }
 
@@ -176,8 +186,18 @@ final class PlexGuid implements iGuid
 
         foreach ($mapping as $key => $map) {
             if (false === is_array($map)) {
-                $this->logger->warning("Ignoring 'links.{key}'. Value must be an object. '{given}' is given.", [
-                    'key' => $key,
+                $this->logger->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                    'event_name' => 'guid.mapping.ignored',
+                    'subsystem' => 'guid',
+                    'operation' => 'parse_config',
+                    'outcome' => 'ignored',
+                    'reason' => 'invalid_link_value',
+                    'reason_label' => 'value must be an object',
+                    'client' => $this->clientName(),
+                    'mapping_key' => 'links.' . $key,
+                    'mapping_from' => null,
+                    'mapping_to' => null,
+                    'file' => $file,
                     'given' => get_debug_type($map),
                 ]);
                 continue;
@@ -190,9 +210,19 @@ final class PlexGuid implements iGuid
             if (null !== ($replace = ag($map, 'options.replace', null))) {
                 if (false === is_array($replace)) {
                     $this->logger->warning(
-                        "Ignoring 'links.{key}'. options.replace value must be an object. '{given}' is given.",
+                        "Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.",
                         [
-                            'key' => $key,
+                            'event_name' => 'guid.mapping.ignored',
+                            'subsystem' => 'guid',
+                            'operation' => 'parse_config',
+                            'outcome' => 'ignored',
+                            'reason' => 'invalid_replace_value',
+                            'reason_label' => 'options.replace must be an object',
+                            'client' => $this->clientName(),
+                            'mapping_key' => 'links.' . $key,
+                            'mapping_from' => null,
+                            'mapping_to' => null,
+                            'file' => $file,
                             'given' => get_debug_type($replace),
                         ],
                     );
@@ -204,17 +234,37 @@ final class PlexGuid implements iGuid
 
                 if (empty($from) || false === is_string($from)) {
                     $this->logger->warning(
-                        "Ignoring 'links.{key}'. options.replace.from field is empty or not a string.",
+                        "Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.",
                         [
-                            'key' => $key,
+                            'event_name' => 'guid.mapping.ignored',
+                            'subsystem' => 'guid',
+                            'operation' => 'parse_config',
+                            'outcome' => 'ignored',
+                            'reason' => 'invalid_replace_from',
+                            'reason_label' => 'options.replace.from must be a non-empty string',
+                            'client' => $this->clientName(),
+                            'mapping_key' => 'links.' . $key,
+                            'mapping_from' => true === is_string($from) ? $from : null,
+                            'mapping_to' => true === is_string($to) ? $to : null,
+                            'file' => $file,
                         ],
                     );
                     continue;
                 }
 
                 if (false === is_string($to)) {
-                    $this->logger->warning("Ignoring 'links.{key}'. options.replace.to field is not a string.", [
-                        'key' => $key,
+                    $this->logger->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                        'event_name' => 'guid.mapping.ignored',
+                        'subsystem' => 'guid',
+                        'operation' => 'parse_config',
+                        'outcome' => 'ignored',
+                        'reason' => 'invalid_replace_to',
+                        'reason_label' => 'options.replace.to must be a string',
+                        'client' => $this->clientName(),
+                        'mapping_key' => 'links.' . $key,
+                        'mapping_from' => true === is_string($from) ? $from : null,
+                        'mapping_to' => true === is_string($to) ? $to : null,
+                        'file' => $file,
                     ]);
                     continue;
                 }
@@ -224,8 +274,18 @@ final class PlexGuid implements iGuid
 
             if (null !== ($mapper = ag($map, 'map', null))) {
                 if (false === is_array($mapper)) {
-                    $this->logger->warning("Ignoring 'links.{key}'. map value must be an object. '{given}' is given.", [
-                        'key' => $key,
+                    $this->logger->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                        'event_name' => 'guid.mapping.ignored',
+                        'subsystem' => 'guid',
+                        'operation' => 'parse_config',
+                        'outcome' => 'ignored',
+                        'reason' => 'invalid_map_value',
+                        'reason_label' => 'map must be an object',
+                        'client' => $this->clientName(),
+                        'mapping_key' => 'links.' . $key,
+                        'mapping_from' => null,
+                        'mapping_to' => null,
+                        'file' => $file,
                         'given' => get_debug_type($mapper),
                     ]);
                     continue;
@@ -235,34 +295,72 @@ final class PlexGuid implements iGuid
                 $to = ag($mapper, 'to', null);
 
                 if (empty($from) || false === is_string($from)) {
-                    $this->logger->warning("Ignoring 'links.{key}'. map.from field is empty or not a string.", [
-                        'key' => $key,
+                    $this->logger->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                        'event_name' => 'guid.mapping.ignored',
+                        'subsystem' => 'guid',
+                        'operation' => 'parse_config',
+                        'outcome' => 'ignored',
+                        'reason' => 'invalid_map_from',
+                        'reason_label' => 'map.from must be a non-empty string',
+                        'client' => $this->clientName(),
+                        'mapping_key' => 'links.' . $key,
+                        'mapping_from' => true === is_string($from) ? $from : null,
+                        'mapping_to' => true === is_string($to) ? $to : null,
+                        'file' => $file,
                     ]);
                     continue;
                 }
 
                 if (empty($to) || false === is_string($to)) {
-                    $this->logger->warning("Ignoring 'links.{key}'. map.to field is empty or not a string.", [
-                        'key' => $key,
+                    $this->logger->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                        'event_name' => 'guid.mapping.ignored',
+                        'subsystem' => 'guid',
+                        'operation' => 'parse_config',
+                        'outcome' => 'ignored',
+                        'reason' => 'invalid_map_to',
+                        'reason_label' => 'map.to must be a non-empty string',
+                        'client' => $this->clientName(),
+                        'mapping_key' => 'links.' . $key,
+                        'mapping_from' => true === is_string($from) ? $from : null,
+                        'mapping_to' => true === is_string($to) ? $to : null,
+                        'file' => $file,
                     ]);
                     continue;
                 }
 
                 if (false === str_starts_with($to, 'guid_')) {
                     $this->logger->warning(
-                        "Ignoring 'links.{key}'. map.to '{to}' field does not starts with 'guid_'.",
+                        "Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.",
                         [
-                            'key' => $key,
-                            'to' => $to,
+                            'event_name' => 'guid.mapping.ignored',
+                            'subsystem' => 'guid',
+                            'operation' => 'parse_config',
+                            'outcome' => 'ignored',
+                            'reason' => 'invalid_guid_type_name',
+                            'reason_label' => "map.to must start with 'guid_'",
+                            'client' => $this->clientName(),
+                            'mapping_key' => 'links.' . $key,
+                            'mapping_from' => $from,
+                            'mapping_to' => $to,
+                            'file' => $file,
                         ],
                     );
                     continue;
                 }
 
                 if (false === in_array($to, $supported, true)) {
-                    $this->logger->warning("Ignoring 'links.{key}'. map.to field is not a supported GUID type.", [
-                        'key' => $key,
-                        'to' => $to,
+                    $this->logger->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                        'event_name' => 'guid.mapping.ignored',
+                        'subsystem' => 'guid',
+                        'operation' => 'parse_config',
+                        'outcome' => 'ignored',
+                        'reason' => 'unsupported_guid_type',
+                        'reason_label' => 'map.to is not a supported GUID type',
+                        'client' => $this->clientName(),
+                        'mapping_key' => 'links.' . $key,
+                        'mapping_from' => $from,
+                        'mapping_to' => $to,
+                        'file' => $file,
                     ]);
                     continue;
                 }
@@ -273,9 +371,18 @@ final class PlexGuid implements iGuid
                 }
 
                 if (true === in_array($from, $this->guidLegacy, true)) {
-                    $this->logger->warning("Ignoring 'links.{key}'. map.from already exists.", [
-                        'key' => $key,
-                        'from' => $from,
+                    $this->logger->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                        'event_name' => 'guid.mapping.ignored',
+                        'subsystem' => 'guid',
+                        'operation' => 'parse_config',
+                        'outcome' => 'ignored',
+                        'reason' => 'duplicate_map_from',
+                        'reason_label' => 'map.from already exists',
+                        'client' => $this->clientName(),
+                        'mapping_key' => 'links.' . $key,
+                        'mapping_from' => $from,
+                        'mapping_to' => $to,
+                        'file' => $file,
                     ]);
                     continue;
                 }
@@ -373,9 +480,19 @@ final class PlexGuid implements iGuid
 
                 if (false === str_contains($val, '://')) {
                     if (true === $log) {
-                        $this->logger->info("PlexGuid: Unable to parse '{backend}: {agent}' identifier.", [
+                        $this->logger->info("Ignoring external id '{guid_source}:{guid_value}' for '#{item_id}' from '{user}@{backend}': {reason_label}.", [
+                            'event_name' => 'guid.external_id.ignored',
+                            'subsystem' => 'guid',
+                            'operation' => 'parse',
+                            'outcome' => 'ignored',
+                            'reason' => 'unrecognized_format',
+                            'reason_label' => 'identifier format is unrecognized',
+                            'client' => $this->context->clientName,
+                            'user' => $this->context->userContext->name,
                             'backend' => $this->context->backendName,
-                            'agent' => $val,
+                            'item_id' => $id,
+                            'guid_source' => before($val, '://'),
+                            'guid_value' => after($val, '://'),
                             ...$context,
                         ]);
                     }
@@ -392,11 +509,20 @@ final class PlexGuid implements iGuid
                 if (true === is_ignored_id($this->context->userContext, $bName, $type, $key, $value, $id)) {
                     if (true === $log) {
                         $this->logger->debug(
-                            "PlexGuid: Ignoring '{client}: {backend}' external id '{source}' for {item.type} '{item.id}: {item.title}' as requested.",
+                            "Ignoring external id '{guid_source}:{guid_value}' for '#{item_id}' from '{user}@{backend}': {reason_label}.",
                             [
+                                'event_name' => 'guid.external_id.ignored',
+                                'subsystem' => 'guid',
+                                'operation' => 'parse',
+                                'outcome' => 'ignored',
+                                'reason' => 'user_ignored',
+                                'reason_label' => 'external id is ignored by user config',
                                 'client' => $this->context->clientName,
+                                'user' => $this->context->userContext->name,
                                 'backend' => $bName,
-                                'source' => $val,
+                                'item_id' => $id,
+                                'guid_source' => $key,
+                                'guid_value' => $value,
                                 'guid' => [
                                     'source' => $key,
                                     'value' => $value,
@@ -416,12 +542,19 @@ final class PlexGuid implements iGuid
 
                     if (true === $log) {
                         $this->logger->warning(
-                            "PlexGuid: '{client}: {backend}' reported multiple ids for same data source '{key}: {ids}' for {item.type} '{item.id}: {item.title}'.",
+                            "External id conflict for '#{item_id}' from '{user}@{backend}': multiple {guid_source} ids reported.",
                             [
+                                'event_name' => 'guid.external_id.conflict',
+                                'subsystem' => 'guid',
+                                'operation' => 'parse',
+                                'outcome' => 'ignored',
+                                'reason' => 'multiple_ids',
                                 'client' => $this->context->clientName,
+                                'user' => $this->context->userContext->name,
                                 'backend' => $this->context->backendName,
-                                'key' => $key,
-                                'ids' => sprintf('%s, %s', $guid[$this->guidMapper[$key]], $value),
+                                'item_id' => $id,
+                                'guid_source' => $key,
+                                'guid_values' => [$guid[$this->guidMapper[$key]], $value],
                                 ...$context,
                             ],
                         );
@@ -440,12 +573,20 @@ final class PlexGuid implements iGuid
             } catch (Throwable $e) {
                 if (true === $log) {
                     $this->logger->info(
-                        message: "{class}: Ignoring '{user}@{backend}' invalid GUID '{agent}' for {item.type} '{item.id}: {item.title}'.",
+                        message: "Ignoring external id '{guid_source}:{guid_value}' for '#{item_id}' from '{user}@{backend}': {reason_label}.",
                         context: [
-                            'class' => after_last(self::class, '\\'),
+                            'event_name' => 'guid.external_id.ignored',
+                            'subsystem' => 'guid',
+                            'operation' => 'parse',
+                            'outcome' => 'ignored',
+                            'reason' => 'invalid_guid',
+                            'reason_label' => 'external id is invalid',
+                            'client' => $this->context->clientName,
                             'user' => $this->context->userContext->name,
                             'backend' => $this->context->backendName,
-                            'agent' => $val,
+                            'item_id' => $id,
+                            'guid_source' => before($val, '://'),
+                            'guid_value' => after($val, '://'),
                             ...$context,
                             ...exception_log($e),
                         ],
@@ -504,25 +645,23 @@ final class PlexGuid implements iGuid
         } catch (Throwable $e) {
             if (true === $log) {
                 $this->logger->error(
-                    message: "PlexGuid: Exception '{error.kind}' was thrown unhandled during '{client}: {backend}' parsing legacy agent '{agent}' identifier. Error '{error.message}' at '{error.file}:{error.line}.",
+                    message: "Failed to parse legacy GUID '{agent}' from '{backend}'.",
                     context: [
+                        'event_name' => 'guid.external_id.ignored',
+                        'subsystem' => 'guid',
+                        'operation' => 'parse_legacy_agent',
+                        'outcome' => 'ignored',
+                        'reason' => 'legacy_parse_failed',
+                        'reason_label' => 'legacy GUID parsing failed',
+                        'user' => $this->context->userContext->name,
+                        'item_id' => ag($context, 'item.id'),
+                        'guid_source' => before($guid, '://'),
+                        'guid_value' => after($guid, '://'),
                         'backend' => $this->context->backendName,
                         'client' => $this->context->clientName,
-                        'error' => [
-                            'kind' => $e::class,
-                            'line' => $e->getLine(),
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
                         'agent' => $guid,
-                        'exception' => [
-                            'file' => $e->getFile(),
-                            'line' => $e->getLine(),
-                            'kind' => get_class($e),
-                            'message' => $e->getMessage(),
-                            'trace' => $e->getTrace(),
-                        ],
                         ...$context,
+                        ...exception_log($e),
                     ],
                 );
             }
@@ -571,25 +710,23 @@ final class PlexGuid implements iGuid
         } catch (Throwable $e) {
             if (true === $log) {
                 $this->logger->error(
-                    message: "PlexGuid: Exception '{error.kind}' was thrown unhandled during '{client}: {backend}' parsing NFO agent '{agent}' identifier. Error '{error.message}' at '{error.file}:{error.line}.",
+                    message: "Failed to parse NFO GUID '{agent}' from '{backend}'.",
                     context: [
+                        'event_name' => 'guid.external_id.ignored',
+                        'subsystem' => 'guid',
+                        'operation' => 'parse_nfo_agent',
+                        'outcome' => 'ignored',
+                        'reason' => 'nfo_parse_failed',
+                        'reason_label' => 'NFO GUID parsing failed',
+                        'user' => $this->context->userContext->name,
+                        'item_id' => ag($context, 'item.id'),
+                        'guid_source' => before($guid, '://'),
+                        'guid_value' => after($guid, '://'),
                         'backend' => $this->context->backendName,
                         'client' => $this->context->clientName,
-                        'error' => [
-                            'kind' => $e::class,
-                            'line' => $e->getLine(),
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
                         'agent' => $guid,
-                        'exception' => [
-                            'file' => $e->getFile(),
-                            'line' => $e->getLine(),
-                            'kind' => get_class($e),
-                            'message' => $e->getMessage(),
-                            'trace' => $e->getTrace(),
-                        ],
                         ...$context,
+                        ...exception_log($e),
                     ],
                 );
             }
@@ -612,5 +749,10 @@ final class PlexGuid implements iGuid
             'guidLocal' => $this->guidLocal,
             'guidReplacer' => $this->guidReplacer,
         ];
+    }
+
+    private function clientName(): string
+    {
+        return $this->context->clientName ?? PlexClient::CLIENT_NAME;
     }
 }

--- a/src/Backends/Plex/PlexValidateContext.php
+++ b/src/Backends/Plex/PlexValidateContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Backends\Plex;
 
+use App\Backends\Common\CommonTrait;
 use App\Backends\Common\Context;
 use App\Backends\Plex\Action\GetUser;
 use App\Libs\Container;
@@ -11,6 +12,7 @@ use App\Libs\Enums\Http\Status;
 use App\Libs\Exceptions\Backends\InvalidContextException;
 use App\Libs\Options;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -18,6 +20,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface as iHttp;
 
 final readonly class PlexValidateContext
 {
+    use CommonTrait;
+
     public function __construct(
         private iHttp $http,
     ) {}
@@ -113,17 +117,39 @@ final readonly class PlexValidateContext
                 'error' => $e->getMessage(),
             ]), previous: $e);
         } catch (ClientExceptionInterface $e) {
-            throw new InvalidContextException(r('Got non 200 response. {error}', [
-                'error' => $e->getMessage(),
-            ]), previous: $e);
+            throw $this->httpException('Got non 200 response.', $e);
         } catch (RedirectionExceptionInterface $e) {
-            throw new InvalidContextException(r('Redirection recursion detected. {error}', [
-                'error' => $e->getMessage(),
-            ]), previous: $e);
+            throw $this->httpException('Redirection recursion detected.', $e);
         } catch (ServerExceptionInterface $e) {
-            throw new InvalidContextException(r('Backend responded with 5xx error. {error}', [
-                'error' => $e->getMessage(),
-            ]), previous: $e);
+            throw $this->httpException('Backend responded with 5xx error.', $e);
         }
+    }
+
+    /**
+     * Build a context-rich backend validation exception from an HTTP exception.
+     */
+    private function httpException(string $message, HttpExceptionInterface $e): InvalidContextException
+    {
+        $response = $e->getResponse();
+        $body = $response->getContent(false);
+        $reason = $this->getBackendResponseReason($body) ?? $e->getMessage();
+
+        $ex = new InvalidContextException(r('{message} Backend responded with {status_code}. {error}', [
+            'message' => $message,
+            'status_code' => $response->getStatusCode(),
+            'error' => $reason,
+        ]), previous: $e);
+
+        $ex->setContext([
+            'http' => [
+                'status_code' => $response->getStatusCode(),
+            ],
+            'response' => [
+                'body' => $body,
+                'reason' => $reason,
+            ],
+        ]);
+
+        return $ex;
     }
 }

--- a/src/Cli.php
+++ b/src/Cli.php
@@ -88,6 +88,15 @@ class Cli extends Application
 
         $definition->addOption(
             new InputOption(
+                'jsonl',
+                null,
+                InputOption::VALUE_NONE,
+                'Emit console output as JSONL. <comment>Not all commands support this option.</comment>',
+            ),
+        );
+
+        $definition->addOption(
+            new InputOption(
                 'output',
                 'o',
                 InputOption::VALUE_REQUIRED,

--- a/src/Command.php
+++ b/src/Command.php
@@ -71,6 +71,12 @@ class Command extends BaseCommand
             Config::save('logs.context', true);
         }
 
+        if ($input->hasOption('jsonl') && true === $input->getOption('jsonl')) {
+            Config::save('console.output', 'jsonl');
+        } else {
+            Config::remove('console.output');
+        }
+
         if (!$input->hasOption('profile') || !$input->getOption('profile')) {
             return $this->runCommand($input, $output);
         }

--- a/src/Command.php
+++ b/src/Command.php
@@ -8,6 +8,7 @@ use App\Backends\Common\ClientInterface as iClient;
 use App\Libs\Config;
 use App\Libs\ConfigFile;
 use App\Libs\Exceptions\RuntimeException;
+use App\Libs\Extends\JsonlFormatter;
 use App\Libs\Stream;
 use App\Listeners\ProcessProfileEvent;
 use Closure;
@@ -154,17 +155,26 @@ class Command extends BaseCommand
      */
     protected function single(Closure $closure, iOutput $output, array $opts = []): int
     {
+        $lockName = get_app_version() . ':' . $this->getName();
+
         try {
-            if (!$this->lock(get_app_version() . ':' . $this->getName())) {
-                $message = r("The command/task '{name}' is already running in another process.", [
-                    'name' => $this->getName(),
+            if (!$this->lock($lockName)) {
+                $message = r("Command '{command}' is already running.", [
+                    'command' => $this->getName(),
                 ]);
 
                 $output->writeln("<error>{$message}</error>");
 
                 if (null !== ($logger = ag($opts, iLogger::class))) {
                     assert($logger instanceof iLogger, 'Expected logger instance for task lock logging.');
-                    $logger->log(ag($opts, Level::class, Level::Notice), $message);
+                    $logger->log(ag($opts, Level::class, Level::Notice), $message, [
+                        'event_name' => 'cli.command.locked',
+                        'subsystem' => 'cli',
+                        'operation' => 'lock',
+                        'outcome' => 'locked',
+                        'command' => $this->getName(),
+                        'lock_name' => $lockName,
+                    ]);
                 }
 
                 return self::SUCCESS;
@@ -220,6 +230,25 @@ class Command extends BaseCommand
      */
     protected function displayContent(array $content, iOutput $output, string $mode = 'json'): void
     {
+        if ('jsonl' === Config::get('console.output')) {
+            $output->writeln(rtrim(new JsonlFormatter()->formatValues(
+                channel: 'cli',
+                level: Level::Info,
+                message: 'Command output ready.',
+                context: [
+                    'event_name' => 'cli.command.output',
+                    'subsystem' => 'cli',
+                    'operation' => 'display',
+                    'outcome' => 'completed',
+                    'command' => $this->getName(),
+                    'output_mode' => $mode,
+                    'data' => $content,
+                ],
+            ), "\r\n"));
+
+            return;
+        }
+
         switch ($mode) {
             case 'json':
                 $output->writeln(

--- a/src/Commands/Backend/RestoreCommand.php
+++ b/src/Commands/Backend/RestoreCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Commands\Backend;
 
+use App\Backends\Common\ClientInterface as iClient;
 use App\Command;
 use App\Libs\Attributes\DI\Inject;
 use App\Libs\Attributes\Route\Cli;
@@ -190,10 +191,17 @@ class RestoreCommand extends Command
             }
 
             $this->logger->warning(
-                "Exporting to '{user}@{backend}' is disabled, However, the check was bypass due to [-i, --ignore] flag being used.",
+                "Restore target '{user}@{backend}' has export disabled; continuing because bypass was requested.",
                 [
+                    'event_name' => 'backend.restore.export_disabled_bypassed',
+                    'subsystem' => 'backend.restore',
+                    'operation' => 'validate_target',
+                    'outcome' => 'warning',
+                    'command' => self::ROUTE,
                     'backend' => $name,
                     'user' => $userContext->name,
+                    'execute' => (bool) $input->getOption('execute'),
+                    'reason' => 'bypass_requested',
                 ],
             );
         }
@@ -233,37 +241,6 @@ class RestoreCommand extends Command
             }
         }
 
-        $this->logger->notice("Loading '{user}@{backend}' restore data.", [
-            'backend' => $name,
-            'user' => $userContext->name,
-            'memory' => [
-                'now' => get_memory_usage(),
-                'peak' => get_peak_memory_usage(),
-            ],
-        ]);
-
-        $start = microtime(true);
-        $mapper->loadData();
-
-        $this->logger->notice(
-            "SYSTEM: Loading restore data of '{user}@{backend}' completed in '{duration}'s. Memory usage '{memory.now}'.",
-            [
-                'backend' => $name,
-                'user' => $userContext->name,
-                'memory' => [
-                    'now' => get_memory_usage(),
-                    'peak' => get_peak_memory_usage(),
-                ],
-                'duration' => round(microtime(true) - $start, 4),
-            ],
-        );
-
-        if (false === $input->getOption('execute')) {
-            $this->logger->notice(
-                "No changes will be committed to backend. To execute the changes pass '--execute' flag option.",
-            );
-        }
-
         $opts = [
             Options::IGNORE_DATE => true,
             Options::DEBUG_TRACE => true === $input->getOption('trace'),
@@ -275,14 +252,40 @@ class RestoreCommand extends Command
         }
 
         $backend['options'] = array_replace_recursive($backend['options'] ?? [], $opts);
-        $backend = make_backend(backend: $backend, name: $name, options: [
-            UserContext::class => $userContext,
-        ]);
+        $backend = $this->makeBackend(backend: $backend, name: $name, userContext: $userContext);
+        $client = $backend->getContext()->clientName;
 
-        $this->logger->notice("Starting '{user}@{backend}' restore process.", [
+        $this->logger->notice("Loading restore data for '{user}@{backend}' from '{path}'.", [
+            'event_name' => 'backend.restore.data.loading',
+            'subsystem' => 'backend.restore',
+            'operation' => 'load_data',
+            'outcome' => 'started',
+            'command' => self::ROUTE,
             'backend' => $name,
             'user' => $userContext->name,
+            'client' => $client,
+            'path' => $file,
         ]);
+
+        $start = microtime(true);
+        $mapper->loadData();
+
+        $this->logger->notice(
+            "Loaded {item_count} restore items for '{user}@{backend}'.",
+            [
+                'event_name' => 'backend.restore.data.loaded',
+                'subsystem' => 'backend.restore',
+                'operation' => 'load_data',
+                'outcome' => 'completed',
+                'command' => self::ROUTE,
+                'backend' => $name,
+                'user' => $userContext->name,
+                'client' => $client,
+                'path' => $file,
+                'item_count' => $mapper->getObjectsCount(),
+                'duration_seconds' => round(microtime(true) - $start, 4),
+            ],
+        );
 
         if (false === ($syncRequests = $input->getOption('sync-requests'))) {
             $syncRequests = (bool) Config::get('http.default.sync_requests', false);
@@ -292,64 +295,114 @@ class RestoreCommand extends Command
             $syncRequests = false;
         }
 
+        $this->logger->notice("Comparing restore data for '{user}@{backend}'.", [
+            'event_name' => 'backend.restore.compare.started',
+            'subsystem' => 'backend.restore',
+            'operation' => 'compare',
+            'outcome' => 'started',
+            'command' => self::ROUTE,
+            'backend' => $name,
+            'user' => $userContext->name,
+            'client' => $client,
+            'local_count' => $mapper->getObjectsCount(),
+        ]);
+
         $requests = $backend->export($mapper, $this->queue, null);
 
         $start = microtime(true);
-        $this->logger->notice("SYSTEM: Sending '{total}' play state comparison requests for '{user}@{backend}'.", [
-            'backend' => $name,
-            'total' => count($requests),
-            'user' => $userContext->name,
-        ]);
+        $this->sendRequests($requests, $syncRequests);
 
-        send_requests(requests: $requests, client: $this->http, sync: $syncRequests, logger: $this->logger);
+        $changeCount = (int) Message::get("{$userContext->name}.{$name}.export", 0);
 
-        $this->logger->notice("SYSTEM: Completed '{total}' requests in '{duration}'s for '{user}@{backend}'.", [
+        $this->logger->notice("Restore comparison for '{user}@{backend}' found {change_count} changes.", [
+            'event_name' => 'backend.restore.compare.completed',
+            'subsystem' => 'backend.restore',
+            'operation' => 'compare',
+            'outcome' => 'completed',
+            'command' => self::ROUTE,
             'backend' => $name,
-            'total' => count($requests),
             'user' => $userContext->name,
-            'duration' => round(microtime(true) - $start, 4),
+            'client' => $client,
+            'local_count' => $mapper->getObjectsCount(),
+            'remote_count' => count($requests),
+            'change_count' => $changeCount,
+            'duration_seconds' => round(microtime(true) - $start, 4),
         ]);
 
         $total = count($this->queue->getQueue());
 
-        if ($total >= 1) {
-            $this->logger->notice("SYSTEM: Sending '{total}' change state requests for '{user}@{backend}'.", [
+        if ($changeCount < 1) {
+            $this->logger->notice("No restore differences found for '{user}@{backend}'.", [
+                'event_name' => 'backend.restore.no_difference',
+                'subsystem' => 'backend.restore',
+                'operation' => 'compare',
+                'outcome' => 'completed',
+                'command' => self::ROUTE,
                 'backend' => $name,
                 'user' => $userContext->name,
-                'total' => $total,
-            ]);
-        }
-
-        if ((int) Message::get("{$userContext->name}.{$name}.export", 0) < 1) {
-            $this->logger->notice("SYSTEM: No difference detected between backup file and '{user}@{backend}'.", [
-                'backend' => $name,
-                'user' => $userContext->name,
+                'client' => $client,
             ]);
         }
 
         if ($total < 1 || false === $input->getOption('execute')) {
+            if (false === $input->getOption('execute')) {
+                $this->logger->notice("Restore cancelled for '{user}@{backend}': dry-run mode is enabled.", [
+                    'event_name' => 'backend.restore.cancelled',
+                    'subsystem' => 'backend.restore',
+                    'operation' => 'commit',
+                    'outcome' => 'cancelled',
+                    'command' => self::ROUTE,
+                    'backend' => $name,
+                    'user' => $userContext->name,
+                    'reason' => 'dry_run',
+                    'reason_label' => 'dry-run mode is enabled',
+                ]);
+            }
+
             return self::SUCCESS;
         }
 
-        send_requests(
-            requests: $this->queue->getQueue(),
-            client: $this->http,
-            sync: $syncRequests,
-            logger: $this->logger,
-        );
+        $this->sendRequests($this->queue->getQueue(), $syncRequests);
 
         $this->logger->notice(
-            "SYSTEM: Sent '{total}' change play state requests to '{client}: {user}@{backend}' in '{duration}'s.",
+            "Sent {request_count} restore play-state requests to '{user}@{backend}' via {client}.",
             [
-                'total' => $total,
+                'event_name' => 'backend.restore.changes.sent',
+                'subsystem' => 'backend.restore',
+                'operation' => 'commit',
+                'outcome' => 'completed',
+                'command' => self::ROUTE,
+                'request_count' => $total,
                 'backend' => $name,
                 'user' => $userContext->name,
-                'client' => $backend->getContext()->clientName,
-                'duration' => round(microtime(true) - $opStart, 4),
+                'client' => $client,
+                'duration_seconds' => round(microtime(true) - $opStart, 4),
             ],
         );
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Create backend client instance.
+     *
+     * @param array<string,mixed> $backend
+     */
+    protected function makeBackend(array $backend, string $name, UserContext $userContext): iClient
+    {
+        return make_backend(backend: $backend, name: $name, options: [
+            UserContext::class => $userContext,
+        ]);
+    }
+
+    /**
+     * Send queued backend requests.
+     *
+     * @param array<array-key,mixed> $requests
+     */
+    protected function sendRequests(array $requests, bool $syncRequests): void
+    {
+        send_requests(requests: $requests, client: $this->http, sync: $syncRequests, logger: $this->logger);
     }
 
     /**

--- a/src/Commands/Events/DispatchCommand.php
+++ b/src/Commands/Events/DispatchCommand.php
@@ -8,6 +8,7 @@ use App\Command;
 use App\Libs\Attributes\Route\Cli;
 use App\Libs\Config;
 use App\Libs\Events\DataEvent;
+use App\Libs\Extends\JsonlFormatter;
 use App\Libs\Extends\ProxyHandler;
 use App\Libs\Options;
 use App\Model\Events\Event;
@@ -163,14 +164,22 @@ final class DispatchCommand extends Command
         $capturedHandlers = null;
 
         try {
-            $message = "[event:{id}] Dispatching Event: '{event}' queued at '{date}'.";
+            $message = "Dispatching Event: '{event}' queued at '{date}'.";
             $log_data = [
                 'id' => $event->id,
                 'event' => $event->event,
                 'date' => make_date($event->created_at),
             ];
 
-            $event->logs[] = r($message, $log_data);
+            $event->logs[] = new JsonlFormatter()->formatValues(
+                channel: 'event',
+                level: Level::Notice,
+                message: r($message, $log_data),
+                context: [
+                    'event_id' => (string) $event->id,
+                    'event' => $event->event,
+                ],
+            );
 
             if (count($event->event_data) > 0) {
                 $log_data['data'] = $event->event_data;
@@ -207,7 +216,15 @@ final class DispatchCommand extends Command
 
             $this->replayRecords($capturedHandlers, $capturedRecords);
 
-            $event->logs[] = r("Event '{event}' was dispatched.", ['event' => $event->event]);
+            $event->logs[] = new JsonlFormatter()->formatValues(
+                channel: 'event',
+                level: Level::Notice,
+                message: r("Event '{event}' was dispatched.", ['event' => $event->event]),
+                context: [
+                    'event_id' => (string) $event->id,
+                    'event' => $event->event,
+                ],
+            );
 
             $this->repo->save($event);
         } catch (Throwable $e) {
@@ -219,8 +236,17 @@ final class DispatchCommand extends Command
                 'error' => $e->getMessage(),
             ]);
 
-            $event->logs[] = $errorLog;
-            array_push($event->logs, ...$e->getTrace());
+            $event->logs[] = new JsonlFormatter()->formatValues(
+                channel: 'event',
+                level: Level::Error,
+                message: $errorLog,
+                context: [
+                    'event_id' => (string) $event->id,
+                    'event' => $event->event,
+                    'exception' => $e,
+                    'trace' => $e->getTrace(),
+                ],
+            );
             $event->status = Status::FAILED;
             $event->updated_at = (string) make_date();
             $this->repo->save($event);
@@ -319,9 +345,33 @@ final class DispatchCommand extends Command
             return null;
         }
 
+        $log = trim($log);
+
+        if ('' === $log) {
+            return null;
+        }
+
+        if (true === JsonlFormatter::isJsonlRecord($log)) {
+            $payload = json_decode($log, true);
+
+            if (true === is_array($payload)) {
+                $level = trim(strtoupper((string) ag($payload, 'level', '')));
+
+                if ('' === $level) {
+                    return null;
+                }
+
+                try {
+                    return MonologLogger::toMonologLevel($level);
+                } catch (Throwable) {
+                    return null;
+                }
+            }
+        }
+
         $levelRegex = '/^(?:\[[^\]]+]\s*)?(?:[a-z0-9_.-]+\.)?(?<level>EMERGENCY|ALERT|CRITICAL|ERROR|WARNING|NOTICE|INFO|DEBUG):\s*/i';
 
-        if (1 !== preg_match($levelRegex, trim($log), $matches)) {
+        if (1 !== preg_match($levelRegex, $log, $matches)) {
             return null;
         }
 

--- a/src/Commands/Events/DispatchCommand.php
+++ b/src/Commands/Events/DispatchCommand.php
@@ -28,6 +28,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Throwable;
 
+use function exception_log;
+
 #[Cli(command: self::ROUTE)]
 final class DispatchCommand extends Command
 {
@@ -125,7 +127,14 @@ final class DispatchCommand extends Command
         }
 
         if (count($events) < 1) {
-            $this->logger->debug('No pending queued events found.');
+            $this->logger->debug('No pending events found.', [
+                'event_name' => 'events.dispatch.none_pending',
+                'subsystem' => 'events.dispatch',
+                'operation' => 'dispatch',
+                'outcome' => 'completed',
+                'queue_count' => 0,
+                'visible_level' => strtolower($visibleLevel->name),
+            ]);
             return self::SUCCESS;
         }
 
@@ -162,18 +171,23 @@ final class DispatchCommand extends Command
         $capturedHandlers = null;
 
         try {
-            $message = "Dispatching Event: '{event}' queued at '{date}'.";
-            $log_data = [
+            $startedAt = make_date();
+            $logData = [
                 'event_id' => (string) $event->id,
-                'event' => $event->event,
-                'date' => make_date($event->created_at),
+                'queued_event' => $event->event,
+                'queued_at' => make_date($event->created_at)->format(DATE_ATOM),
+                'attempt' => $event->attempts + 1,
+                'event_name' => 'events.dispatch.started',
+                'subsystem' => 'events.dispatch',
+                'operation' => 'dispatch',
+                'outcome' => 'started',
             ];
 
             $event->logs[] = new JsonlFormatter()->formatValues(
                 channel: 'event',
                 level: Level::Notice,
-                message: r($message, $log_data),
-                context: $log_data,
+                message: r("Dispatching queued event '{queued_event}' from {queued_at}.", $logData),
+                context: $logData,
             );
 
             $event->status = Status::RUNNING;
@@ -203,18 +217,30 @@ final class DispatchCommand extends Command
             $event->updated_at = (string) make_date();
 
             if ($this->isVisible(array_slice($event->logs, $logCount), $visibleLevel)) {
-                $this->logger->notice($message, $log_data);
+                $this->logger->notice("Dispatching queued event '{queued_event}' from {queued_at}.", $logData);
             }
 
             $this->replayRecords($capturedHandlers, $capturedRecords);
 
+            $duration = max(0, make_date($event->updated_at)->getTimestamp() - $startedAt->getTimestamp());
+
             $event->logs[] = new JsonlFormatter()->formatValues(
                 channel: 'event',
                 level: Level::Notice,
-                message: r("Event '{event}' was dispatched.", ['event' => $event->event]),
+                message: r("Dispatched queued event '{queued_event}' in {duration_seconds}s.", [
+                    'queued_event' => $event->event,
+                    'duration_seconds' => $duration,
+                ]),
                 context: [
                     'event_id' => (string) $event->id,
-                    'event' => $event->event,
+                    'queued_event' => $event->event,
+                    'duration_seconds' => $duration,
+                    'attempt' => $event->attempts,
+                    'status' => strtolower($event->status->name),
+                    'event_name' => 'events.dispatch.completed',
+                    'subsystem' => 'events.dispatch',
+                    'operation' => 'dispatch',
+                    'outcome' => 'completed',
                 ],
             );
 
@@ -223,31 +249,29 @@ final class DispatchCommand extends Command
             $this->restoreLogger($capturedHandlers);
             $this->replayRecords($capturedHandlers, $capturedRecords);
 
-            $errorLog = r("Failed to dispatch event: '{event}'. {error}", [
-                'event' => ag($event, 'event'),
-                'error' => $e->getMessage(),
-            ]);
+            $errorLog = "Failed to dispatch queued event '{queued_event}'.";
+            $errorContext = [
+                'event_id' => (string) $event->id,
+                'queued_event' => $event->event,
+                'attempt' => $event->attempts,
+                'event_name' => 'events.dispatch.failed',
+                'subsystem' => 'events.dispatch',
+                'operation' => 'dispatch',
+                'outcome' => 'failed',
+                ...exception_log($e),
+            ];
 
             $event->logs[] = new JsonlFormatter()->formatValues(
                 channel: 'event',
                 level: Level::Error,
-                message: $errorLog,
-                context: [
-                    'event_id' => (string) $event->id,
-                    'event' => $event->event,
-                    'exception' => $e,
-                    'trace' => $e->getTrace(),
-                ],
+                message: r($errorLog, $errorContext),
+                context: $errorContext,
             );
             $event->status = Status::FAILED;
             $event->updated_at = (string) make_date();
             $this->repo->save($event);
 
-            $this->logger->error('[event:{event_id}] {message}', [
-                'event_id' => (string) $event->id,
-                'message' => $errorLog,
-                'trace' => $e->getTrace(),
-            ]);
+            $this->logger->error($errorLog, $errorContext);
         }
     }
 
@@ -397,27 +421,39 @@ final class DispatchCommand extends Command
 
                 try {
                     queue_event($payload['event'], $payload['data'], $payload['opts']);
-                    $this->logger->info("Queued '{event}' event. it was saved to cache due to failure to persist it.", [
-                        'event' => $payload['event'],
+                    $this->logger->info("Requeued cached event '{queued_event}'.", [
+                        'queued_event' => $payload['event'],
+                        'attempt' => (int) ag($payload, 'opts.' . self::CACHE_UNLOAD_ATTEMPTS, 0),
+                        'event_name' => 'events.cache.requeued',
+                        'subsystem' => 'events.cache',
+                        'operation' => 'requeue',
+                        'outcome' => 'queued',
                     ]);
                 } catch (Throwable) {
                     $attempts = max(0, (int) ag($payload, 'opts.' . self::CACHE_UNLOAD_ATTEMPTS, 0)) + 1;
                     $payload['opts'][self::CACHE_UNLOAD_ATTEMPTS] = $attempts;
                     $logContext = [
-                        'event' => $payload['event'],
-                        'attempts' => $attempts,
+                        'queued_event' => $payload['event'],
+                        'attempt' => $attempts,
+                        'event_name' => 'events.cache.dropped',
+                        'subsystem' => 'events.cache',
+                        'operation' => 'requeue',
+                        'outcome' => 'failed',
                     ];
 
                     if ($attempts < self::MAX_UNLOAD_ATTEMPTS) {
                         $remaining[] = $payload;
-                        $this->logger->error("Failed to re-queue '{event}' event.", $logContext);
+                        $this->logger->warning("Failed to requeue cached event '{queued_event}'; will retry.", [
+                            ...$logContext,
+                            'reason' => 'requeue_failed',
+                        ]);
                         continue;
                     }
 
-                    $this->logger->error(
-                        "Failed to re-queue '{event}' event after '{attempts}' unload attempts. Dropping cached event.",
-                        $logContext,
-                    );
+                    $this->logger->error("Dropped cached event '{queued_event}' after repeated requeue failures.", [
+                        ...$logContext,
+                        'reason' => 'max_attempts_reached',
+                    ]);
                 }
             }
 

--- a/src/Commands/Events/DispatchCommand.php
+++ b/src/Commands/Events/DispatchCommand.php
@@ -77,7 +77,7 @@ final class DispatchCommand extends Command
 
         if (null !== ($id = $input->getOption('id'))) {
             if (null === ($event = $this->repo->findById($id))) {
-                $this->logger->error(r("Event with id '{id}' not found.", ['id' => $id]));
+                $this->logger->error("Event with id '{event_id}' not found.", ['event_id' => $id]);
                 return self::FAILURE;
             }
 
@@ -110,9 +110,9 @@ final class DispatchCommand extends Command
 
             if ($created > $now) {
                 $this->logger->debug(
-                    "Event '{id}: {event}' is delayed by '{delay}s' seconds. Waiting for '{wait}s' seconds.",
+                    "Event '{event_id}: {event}' is delayed by '{delay}s' seconds. Waiting for '{wait}s' seconds.",
                     [
-                        'id' => $event->id,
+                        'event_id' => (string) $event->id,
                         'event' => $event->event,
                         'delay' => $delay,
                         'wait' => $created - $now,
@@ -125,9 +125,7 @@ final class DispatchCommand extends Command
         }
 
         if (count($events) < 1) {
-            if ('-v' === env('WS_CRON_DISPATCH_ARGS', '-v')) {
-                $this->logger->debug('No pending queued events found.');
-            }
+            $this->logger->debug('No pending queued events found.');
             return self::SUCCESS;
         }
 
@@ -135,17 +133,17 @@ final class DispatchCommand extends Command
 
         foreach ($events as $event) {
             if (null === ($newState = $this->repo->findById($event->id))) {
-                $this->logger->notice("The event '{id}' was deleted while the dispatcher was running", [
-                    'id' => $event->id,
+                $this->logger->notice("The event '{event_id}' was deleted while the dispatcher was running", [
+                    'event_id' => (string) $event->id,
                 ]);
                 continue;
             }
 
             if ($newState->status !== Status::PENDING) {
                 $this->logger->notice(
-                    "The event '{id}' was changed to '{status}' while the dispatcher was running. Ignoring event.",
+                    "The event '{event_id}' was changed to '{status}' while the dispatcher was running. Ignoring event.",
                     [
-                        'id' => $event->id,
+                        'event_id' => (string) $event->id,
                         'status' => $newState->status->name,
                     ],
                 );
@@ -166,7 +164,7 @@ final class DispatchCommand extends Command
         try {
             $message = "Dispatching Event: '{event}' queued at '{date}'.";
             $log_data = [
-                'id' => $event->id,
+                'event_id' => (string) $event->id,
                 'event' => $event->event,
                 'date' => make_date($event->created_at),
             ];
@@ -175,15 +173,9 @@ final class DispatchCommand extends Command
                 channel: 'event',
                 level: Level::Notice,
                 message: r($message, $log_data),
-                context: [
-                    'event_id' => (string) $event->id,
-                    'event' => $event->event,
-                ],
+                context: $log_data,
             );
 
-            if (count($event->event_data) > 0) {
-                $log_data['data'] = $event->event_data;
-            }
             $event->status = Status::RUNNING;
             $event->updated_at = (string) make_date();
             $event->attempts += 1;
@@ -251,8 +243,8 @@ final class DispatchCommand extends Command
             $event->updated_at = (string) make_date();
             $this->repo->save($event);
 
-            $this->logger->error('[event:{id}] {message}', [
-                'id' => $event->id,
+            $this->logger->error('[event:{event_id}] {message}', [
+                'event_id' => (string) $event->id,
                 'message' => $errorLog,
                 'trace' => $e->getTrace(),
             ]);
@@ -405,20 +397,26 @@ final class DispatchCommand extends Command
 
                 try {
                     queue_event($payload['event'], $payload['data'], $payload['opts']);
-                    $this->logger->info("Queued '{event}' event. it was saved to cache due to failure to persist it.", $payload);
+                    $this->logger->info("Queued '{event}' event. it was saved to cache due to failure to persist it.", [
+                        'event' => $payload['event'],
+                    ]);
                 } catch (Throwable) {
                     $attempts = max(0, (int) ag($payload, 'opts.' . self::CACHE_UNLOAD_ATTEMPTS, 0)) + 1;
                     $payload['opts'][self::CACHE_UNLOAD_ATTEMPTS] = $attempts;
+                    $logContext = [
+                        'event' => $payload['event'],
+                        'attempts' => $attempts,
+                    ];
 
                     if ($attempts < self::MAX_UNLOAD_ATTEMPTS) {
                         $remaining[] = $payload;
-                        $this->logger->error("Failed to re-queue '{event}' event.", $payload);
+                        $this->logger->error("Failed to re-queue '{event}' event.", $logContext);
                         continue;
                     }
 
                     $this->logger->error(
                         "Failed to re-queue '{event}' event after '{attempts}' unload attempts. Dropping cached event.",
-                        array_replace($payload, ['attempts' => $attempts]),
+                        $logContext,
                     );
                 }
             }

--- a/src/Commands/State/BackupCommand.php
+++ b/src/Commands/State/BackupCommand.php
@@ -212,9 +212,20 @@ class BackupCommand extends Command
     protected function process(iInput $input): int
     {
         $mapperOpts = [];
+        $dryRun = true === (bool) $input->getOption('dry-run');
+        $keep = true === (bool) $input->getOption('keep');
+        $noEnhance = true === (bool) $input->getOption('no-enhance');
+        $noCompression = true === (bool) $input->getOption('no-compress');
 
-        if ($input->getOption('dry-run')) {
-            $this->logger->notice('SYSTEM: Dry run mode. No changes will be committed.');
+        if (true === $dryRun) {
+            $this->logger->notice('Dry run enabled; no backup files will be written.', [
+                'event_name' => 'state.backup.dry_run.enabled',
+                'subsystem' => 'state.backup',
+                'operation' => 'backup',
+                'outcome' => 'started',
+                'command' => self::ROUTE,
+                'dry_run' => true,
+            ]);
             $mapperOpts[Options::DRY_RUN] = true;
         }
 
@@ -232,18 +243,94 @@ class BackupCommand extends Command
                 select_users($input->getOption('user')),
             );
         } catch (RuntimeException $e) {
-            $this->logger->error($e->getMessage());
+            $this->logger->error('Backup setup failed while loading selected users.', [
+                'event_name' => 'state.backup.failed',
+                'subsystem' => 'state.backup',
+                'operation' => 'backup',
+                'outcome' => 'failed',
+                'command' => self::ROUTE,
+                ...exception_log($e),
+            ]);
+
             return self::FAILURE;
         }
 
-        $this->logger->notice("Using WatchState version - '{version}'.", ['version' => get_app_version()]);
+        $totalStart = microtime(true);
+
+        $this->logger->notice('Using WatchState {version.full}.', [
+            'event_name' => 'app.version',
+            'subsystem' => 'app',
+            'operation' => 'version',
+            'outcome' => 'resolved',
+            'command' => self::ROUTE,
+            'version' => [
+                'full' => get_full_version(),
+            ],
+        ]);
+
+        $this->logger->notice('Backup started for {user_count} users.', [
+            'event_name' => 'state.backup.started',
+            'subsystem' => 'state.backup',
+            'operation' => 'backup',
+            'outcome' => 'started',
+            'command' => self::ROUTE,
+            'user_count' => count($users),
+            'dry_run' => $dryRun,
+            'keep' => $keep,
+            'no_enhance' => $noEnhance,
+            'no_compress' => $noCompression,
+        ]);
+
         foreach ($users as $userContext) {
+            $userStart = microtime(true);
+
             try {
+                $this->logger->notice("Backing up play states for '{user}'.", [
+                    'event_name' => 'state.backup.user.started',
+                    'subsystem' => 'state.backup',
+                    'operation' => 'backup',
+                    'outcome' => 'started',
+                    'command' => self::ROUTE,
+                    'user' => $userContext->name,
+                    'memory' => [
+                        'now' => get_memory_usage(),
+                        'peak' => get_peak_memory_usage(),
+                    ],
+                ]);
+
                 $this->process_backup($input, $userContext);
+
+                $this->logger->notice("Completed backup for '{user}' in {duration_seconds}s.", [
+                    'event_name' => 'state.backup.user.completed',
+                    'subsystem' => 'state.backup',
+                    'operation' => 'backup',
+                    'outcome' => 'completed',
+                    'command' => self::ROUTE,
+                    'user' => $userContext->name,
+                    'duration_seconds' => round(microtime(true) - $userStart, 4),
+                    'memory' => [
+                        'now' => get_memory_usage(),
+                        'peak' => get_peak_memory_usage(),
+                    ],
+                ]);
             } finally {
                 $userContext->mapper->reset();
             }
         }
+
+        $this->logger->notice('Backup completed for {user_count} users in {duration_seconds}s.', [
+            'event_name' => 'state.backup.completed',
+            'subsystem' => 'state.backup',
+            'operation' => 'backup',
+            'outcome' => 'completed',
+            'command' => self::ROUTE,
+            'user_count' => count($users),
+            'duration_seconds' => round(microtime(true) - $totalStart, 4),
+            'dry_run' => $dryRun,
+            'keep' => $keep,
+            'no_enhance' => $noEnhance,
+            'no_compress' => $noCompression,
+        ]);
 
         return self::SUCCESS;
     }
@@ -253,28 +340,49 @@ class BackupCommand extends Command
         $list = [];
 
         $selected = $input->getOption('select-backend');
+        $excludeSelected = true === (bool) $input->getOption('exclude');
         $isCustom = !empty($selected) && count($selected) > 0;
         $supported = Config::get('supported', []);
+        $selection = [
+            'mode' => $this->resolveSelectionMode((array) $selected, $excludeSelected),
+            'backends' => array_values(array_filter(
+                array_map(trim(...), array_map('strval', (array) $selected)),
+                static fn(string $item): bool => '' !== $item,
+            )),
+        ];
 
         $noCompression = $input->getOption('no-compress');
 
         foreach ($userContext->config->getAll() as $backendName => $backend) {
             $type = strtolower(ag($backend, 'type', 'unknown'));
 
-            if ($isCustom && $input->getOption('exclude') === $this->in_array($selected, $backendName)) {
-                $this->logger->info("SYSTEM: Ignoring '{user}@{backend}' as requested.", [
+            if ($isCustom && $excludeSelected === $this->in_array($selected, $backendName)) {
+                $this->logger->info("Skipping '{user}@{backend}': excluded by selection.", [
+                    'event_name' => 'state.backup.backend.skipped',
+                    'subsystem' => 'state.backup',
+                    'operation' => 'select_backend',
+                    'outcome' => 'skipped',
+                    'command' => self::ROUTE,
                     'user' => $userContext->name,
                     'backend' => $backendName,
+                    'reason' => 'selected_excluded',
+                    'selection' => $selection,
                 ]);
                 continue;
             }
 
             if (!isset($supported[$type])) {
-                $this->logger->error("SYSTEM: Ignoring '{user}@{backend}'. Unexpected type '{type}'.", [
+                $this->logger->warning("Skipping '{user}@{backend}': backend type '{backend_type}' is unsupported.", [
+                    'event_name' => 'state.backup.backend.skipped',
+                    'subsystem' => 'state.backup',
+                    'operation' => 'select_backend',
+                    'outcome' => 'skipped',
+                    'command' => self::ROUTE,
                     'user' => $userContext->name,
-                    'type' => $type,
+                    'backend_type' => $type,
                     'backend' => $backendName,
                     'types' => implode(', ', array_keys($supported)),
+                    'reason' => 'unsupported_type',
                 ]);
                 continue;
             }
@@ -282,26 +390,45 @@ class BackupCommand extends Command
             if (true !== (bool) ag($backend, 'import.enabled')) {
                 if ($isCustom) {
                     $this->logger->notice(
-                        "SYSTEM: The backend '{user}@{backend}' has import disabled, However the check is skipped due to --select-backend.",
+                        "Backing up disabled import backend '{user}@{backend}' because it was explicitly selected.",
                         [
+                            'event_name' => 'state.backup.backend.forced',
+                            'subsystem' => 'state.backup',
+                            'operation' => 'select_backend',
+                            'outcome' => 'forced',
+                            'command' => self::ROUTE,
                             'user' => $userContext->name,
                             'backend' => $backendName,
+                            'reason' => 'explicitly_selected',
+                            'import_enabled' => false,
                         ],
                     );
                 } else {
-                    $this->logger->info("SYSTEM: Ignoring '{user}@{backend}'. Import disabled.", [
+                    $this->logger->info("Skipping '{user}@{backend}': import is disabled.", [
+                        'event_name' => 'state.backup.backend.skipped',
+                        'subsystem' => 'state.backup',
+                        'operation' => 'select_backend',
+                        'outcome' => 'skipped',
+                        'command' => self::ROUTE,
                         'user' => $userContext->name,
                         'backend' => $backendName,
+                        'reason' => 'import_disabled',
                     ]);
                     continue;
                 }
             }
 
             if (null === ($url = ag($backend, 'url')) || false === is_valid_url($url)) {
-                $this->logger->error("SYSTEM: Ignoring '{user}@{backend}'. Invalid URL '{url}'.", [
+                $this->logger->warning("Skipping '{user}@{backend}': URL '{url}' is invalid.", [
+                    'event_name' => 'state.backup.backend.skipped',
+                    'subsystem' => 'state.backup',
+                    'operation' => 'select_backend',
+                    'outcome' => 'skipped',
+                    'command' => self::ROUTE,
                     'user' => $userContext->name,
                     'url' => $url ?? 'None',
                     'backend' => $backendName,
+                    'reason' => 'invalid_url',
                 ]);
                 continue;
             }
@@ -312,13 +439,29 @@ class BackupCommand extends Command
 
         if (empty($list)) {
             $this->logger->warning(
-                $isCustom ? '[-s, --select-backend] flag did not match any backend.' : 'No backends were found.',
+                $isCustom ? "No backup backends matched selection for '{user}'." : "No backup backends were available for '{user}'.",
+                [
+                    'event_name' => 'state.backup.backend.none_selected',
+                    'subsystem' => 'state.backup',
+                    'operation' => 'select_backend',
+                    'outcome' => 'skipped',
+                    'command' => self::ROUTE,
+                    'user' => $userContext->name,
+                    'reason' => $isCustom ? 'selection_no_match' : 'no_backends',
+                    'selection' => $selection,
+                ],
             );
+
             return;
         }
 
         if (true !== $input->getOption('no-enhance')) {
-            $this->logger->notice("SYSTEM: Preloading '{user}@{mapper}' data.", [
+            $this->logger->notice("Preloading local state database for '{user}'.", [
+                'event_name' => 'state.backup.preload.started',
+                'subsystem' => 'state.backup',
+                'operation' => 'preload',
+                'outcome' => 'started',
+                'command' => self::ROUTE,
                 'user' => $userContext->name,
                 'mapper' => after_last($userContext->mapper::class, '\\'),
                 'memory' => [
@@ -330,10 +473,15 @@ class BackupCommand extends Command
             $start = microtime(true);
             $userContext->mapper->loadData();
 
-            $this->logger->notice("SYSTEM: Preloading '{user}@{mapper}' data completed in '{duration}s'.", [
+            $this->logger->notice("Preloaded local state database for '{user}' in {duration_seconds}s.", [
+                'event_name' => 'state.backup.preload.completed',
+                'subsystem' => 'state.backup',
+                'operation' => 'preload',
+                'outcome' => 'completed',
+                'command' => self::ROUTE,
                 'user' => $userContext->name,
                 'mapper' => after_last($userContext->mapper::class, '\\'),
-                'duration' => round(microtime(true) - $start, 4),
+                'duration_seconds' => round(microtime(true) - $start, 4),
                 'memory' => [
                     'now' => get_memory_usage(),
                     'peak' => get_peak_memory_usage(),
@@ -364,9 +512,16 @@ class BackupCommand extends Command
                 UserContext::class => $userContext,
             ])->setLogger($this->logger);
 
-            $this->logger->notice("SYSTEM: Backing up '{user}@{backend}' play state.", [
+            $this->logger->notice("Backing up play state for '{user}@{backend}'.", [
+                'event_name' => 'state.backup.backend.started',
+                'subsystem' => 'state.backup',
+                'operation' => 'backup_backend',
+                'outcome' => 'started',
+                'command' => self::ROUTE,
                 'user' => $userContext->name,
                 'backend' => $name,
+                'dry_run' => true === (bool) $input->getOption('dry-run'),
+                'no_enhance' => true === (bool) $input->getOption('no-enhance'),
             ]);
 
             $fileName = $input->getOption('file');
@@ -389,11 +544,21 @@ class BackupCommand extends Command
                     'date' => make_date()->format('Ymd'),
                 ]);
 
+                $directory = dirname($fileName);
+                if (false === is_dir($directory) && false === @mkdir($directory, 0o755, true) && false === is_dir($directory)) {
+                    throw new RuntimeException(r("Unable to create backup directory '{path}'.", ['path' => $directory]));
+                }
+
                 if (false === file_exists($fileName)) {
                     touch($fileName);
                 }
 
-                $this->logger->notice("SYSTEM: '{user}@{backend}' is using '{file}' as backup target.", [
+                $this->logger->notice("Writing backup for '{user}@{backend}' to '{file}'.", [
+                    'event_name' => 'state.backup.file.selected',
+                    'subsystem' => 'state.backup',
+                    'operation' => 'select_file',
+                    'outcome' => 'completed',
+                    'command' => self::ROUTE,
                     'user' => $userContext->name,
                     'file' => realpath($fileName),
                     'backend' => $name,
@@ -423,11 +588,17 @@ class BackupCommand extends Command
         }
 
         $start = microtime(true);
-        $this->logger->notice("SYSTEM: Waiting on '{total}' {sync}requests for '{user}: {backends}' backends.", [
+        $this->logger->notice("Waiting for {request_count} backup requests for '{user}'.", [
+            'event_name' => 'state.backup.requests.started',
+            'subsystem' => 'state.backup',
+            'operation' => 'send_requests',
+            'outcome' => 'started',
+            'command' => self::ROUTE,
             'user' => $userContext->name,
-            'total' => number_format(count($queue)),
-            'backends' => implode(', ', array_keys($list)),
-            'sync' => $syncRequests ? 'sync ' : '',
+            'request_count' => count($queue),
+            'backend_count' => count($list),
+            'backends' => array_keys($list),
+            'sync_requests' => $syncRequests,
             'memory' => [
                 'now' => get_memory_usage(),
                 'peak' => get_peak_memory_usage(),
@@ -449,9 +620,15 @@ class BackupCommand extends Command
 
                 if (false === $noCompression) {
                     $file = $backend['fp']->getMetadata('uri');
-                    $this->logger->notice("SYSTEM: Compressing '{user}@{backend}' backup file '{file}'.", [
+                    $this->logger->notice("Compressing backup archive for '{user}@{backend}' to '{archive}'.", [
+                        'event_name' => 'state.backup.file.compressing',
+                        'subsystem' => 'state.backup',
+                        'operation' => 'compress_file',
+                        'outcome' => 'started',
+                        'command' => self::ROUTE,
                         'backend' => $b,
                         'file' => $file,
+                        'archive' => $file . '.zip',
                         'user' => $userContext->name,
                     ]);
 
@@ -466,10 +643,18 @@ class BackupCommand extends Command
             }
         }
 
-        $this->logger->notice("SYSTEM: Backup operation for '{user}: {backends}' backends finished in '{duration}s'.", [
+        $this->logger->notice("Completed backup requests for '{user}' in {duration_seconds}s.", [
+            'event_name' => 'state.backup.requests.completed',
+            'subsystem' => 'state.backup',
+            'operation' => 'send_requests',
+            'outcome' => 'completed',
+            'command' => self::ROUTE,
             'user' => $userContext->name,
-            'backends' => implode(', ', array_keys($list)),
-            'duration' => round(microtime(true) - $start, 4),
+            'request_count' => count($queue),
+            'backend_count' => count($list),
+            'backends' => array_keys($list),
+            'duration_seconds' => round(microtime(true) - $start, 4),
+            'sync_requests' => $syncRequests,
             'memory' => [
                 'now' => get_memory_usage(),
                 'peak' => get_peak_memory_usage(),
@@ -480,5 +665,22 @@ class BackupCommand extends Command
     private function in_array(array $list, string $search): bool
     {
         return array_any($list, static fn($item) => str_starts_with($search, $item));
+    }
+
+    /**
+     * @param array<int|string,mixed> $selected
+     */
+    private function resolveSelectionMode(array $selected, bool $exclude): string
+    {
+        $selected = array_values(array_filter(
+            array_map(trim(...), array_map('strval', $selected)),
+            static fn(string $item): bool => '' !== $item,
+        ));
+
+        if ([] === $selected) {
+            return 'all';
+        }
+
+        return true === $exclude ? 'exclude' : 'include';
     }
 }

--- a/src/Commands/State/ExportCommand.php
+++ b/src/Commands/State/ExportCommand.php
@@ -9,7 +9,6 @@ use App\Command;
 use App\Libs\Attributes\DI\Inject;
 use App\Libs\Attributes\Route\Cli;
 use App\Libs\Config;
-use App\Libs\Database\DatabaseInterface;
 use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Exceptions\RuntimeException;
 use App\Libs\Extends\RetryableHttpClient;
@@ -139,9 +138,20 @@ class ExportCommand extends Command
         }
 
         $mapperOpts = $dbOpts = [];
+        $dryRun = true === (bool) $input->getOption('dry-run');
+        $forceFullRequested = true === (bool) $input->getOption('force-full');
 
-        if ($input->getOption('dry-run')) {
+        if (true === $dryRun) {
             $mapperOpts[Options::DRY_RUN] = true;
+
+            $this->logger->notice('Dry run enabled; no changes will be committed to backends.', [
+                'event_name' => 'state.export.dry_run.enabled',
+                'subsystem' => 'state.export',
+                'operation' => 'export',
+                'outcome' => 'started',
+                'command' => self::ROUTE,
+                'dry_run' => true,
+            ]);
         }
 
         if ($input->getOption('trace')) {
@@ -183,28 +193,74 @@ class ExportCommand extends Command
         }
 
         $selected = $input->getOption('select-backend');
+        $excludeSelected = true === (bool) $input->getOption('exclude');
         $isCustom = !empty($selected) && count($selected) > 0;
         $supported = Config::get('supported', []);
+        $selection = [
+            'mode' => $this->resolveSelectionMode((array) $selected, $excludeSelected),
+            'backends' => array_values(array_filter(
+                array_map(trim(...), array_map('strval', (array) $selected)),
+                static fn(string $item): bool => '' !== $item,
+            )),
+        ];
+        $totalStart = microtime(true);
 
-        if (true === $input->getOption('dry-run')) {
-            $this->logger->notice('Dry run mode. No changes will be committed to backends.');
-        }
+        $this->logger->notice('Using WatchState {version.full}.', [
+            'event_name' => 'app.version',
+            'subsystem' => 'app',
+            'operation' => 'version',
+            'outcome' => 'resolved',
+            'command' => self::ROUTE,
+            'version' => [
+                'full' => get_full_version(),
+            ],
+        ]);
 
-        $this->logger->notice('SYSTEM: Using WatchState {full_version}', [
-            'full_version' => get_full_version(),
+        $this->logger->notice('Export started for {user_count} users.', [
+            'event_name' => 'state.export.started',
+            'subsystem' => 'state.export',
+            'operation' => 'export',
+            'outcome' => 'started',
+            'command' => self::ROUTE,
+            'user_count' => count($users),
+            'dry_run' => $dryRun,
+            'force_full' => $forceFullRequested,
+            'selection' => $selection,
         ]);
 
         foreach ($users as $userContext) {
+            $userStart = microtime(true);
+
+            $this->logger->notice("Exporting play states for '{user}'.", [
+                'event_name' => 'state.export.user.started',
+                'subsystem' => 'state.export',
+                'operation' => 'export',
+                'outcome' => 'started',
+                'command' => self::ROUTE,
+                'user' => $userContext->name,
+                'memory' => [
+                    'now' => get_memory_usage(),
+                    'peak' => get_peak_memory_usage(),
+                ],
+            ]);
+
             try {
                 $backends = $export = $push = $entities = [];
 
                 foreach ($userContext->config->getAll() as $backendName => $backend) {
                     $type = strtolower(ag($backend, 'type', 'unknown'));
 
-                    if ($isCustom && $input->getOption('exclude') === $this->in_array($selected, $backendName)) {
-                        $this->logger->info("SYSTEM: Ignoring '{user}@{backend}'. As requested.", [
+                    if ($isCustom && $excludeSelected === $this->in_array($selected, $backendName)) {
+                        $this->logger->info("Skipping '{user}@{backend}': excluded by selection.", [
+                            'event_name' => 'state.export.backend.skipped',
+                            'subsystem' => 'state.export',
+                            'operation' => 'select_backend',
+                            'outcome' => 'skipped',
+                            'command' => self::ROUTE,
                             'user' => $userContext->name,
                             'backend' => $backendName,
+                            'reason' => 'selected_excluded',
+                            'selection' => $selection,
                         ]);
                         continue;
                     }
@@ -212,39 +268,64 @@ class ExportCommand extends Command
                     if (true !== (bool) ag($backend, 'export.enabled')) {
                         if ($isCustom) {
                             $this->logger->warning(
-                                "SYSTEM: Exporting to a export disabled backend '{user}@{backend}' as requested.",
+                                "Exporting to disabled backend '{user}@{backend}' because it was explicitly selected.",
                                 [
+                                    'event_name' => 'state.export.backend.forced',
+                                    'subsystem' => 'state.export',
+                                    'operation' => 'select_backend',
+                                    'outcome' => 'forced',
+                                    'command' => self::ROUTE,
                                     'user' => $userContext->name,
                                     'backend' => $backendName,
+                                    'reason' => 'explicitly_selected',
+                                    'export_enabled' => false,
                                 ],
                             );
                         } else {
-                            $this->logger->info("SYSTEM: Ignoring '{user}@{backend}'. Export disabled.", [
+                            $this->logger->info("Skipping '{user}@{backend}': export is disabled.", [
+                                'event_name' => 'state.export.backend.skipped',
+                                'subsystem' => 'state.export',
+                                'operation' => 'select_backend',
+                                'outcome' => 'skipped',
+                                'command' => self::ROUTE,
                                 'user' => $userContext->name,
                                 'backend' => $backendName,
+                                'reason' => 'export_disabled',
                             ]);
                             continue;
                         }
                     }
 
                     if (!isset($supported[$type])) {
-                        $this->logger->error(
-                            "SYSTEM: Ignoring '{user}@{backend}'. Unexpected type '{type}'.",
+                        $this->logger->warning(
+                            "Skipping '{user}@{backend}': backend type '{backend_type}' is unsupported.",
                             [
-                                'type' => $type,
+                                'event_name' => 'state.export.backend.skipped',
+                                'subsystem' => 'state.export',
+                                'operation' => 'select_backend',
+                                'outcome' => 'skipped',
+                                'command' => self::ROUTE,
+                                'backend_type' => $type,
                                 'backend' => $backendName,
                                 'user' => $userContext->name,
                                 'types' => implode(', ', array_keys($supported)),
+                                'reason' => 'unsupported_type',
                             ],
                         );
                         continue;
                     }
 
                     if (null === ($url = ag($backend, 'url')) || false === is_valid_url($url)) {
-                        $this->logger->error("SYSTEM: Ignoring '{user}@{backend}'. Invalid URL '{url}'.", [
+                        $this->logger->warning("Skipping '{user}@{backend}': URL '{url}' is invalid.", [
+                            'event_name' => 'state.export.backend.skipped',
+                            'subsystem' => 'state.export',
+                            'operation' => 'select_backend',
+                            'outcome' => 'skipped',
+                            'command' => self::ROUTE,
                             'url' => $url ?? 'None',
                             'backend' => $backendName,
                             'user' => $userContext->name,
+                            'reason' => 'invalid_url',
                         ]);
                         continue;
                     }
@@ -254,11 +335,21 @@ class ExportCommand extends Command
                 }
 
                 if (empty($backends)) {
-                    $message = $isCustom ? '[-s, --select-backend] flag did not match any backend.' : 'No backends were found.';
-                    $this->logger->warning("{message}. For '{user}'.", [
-                        'message' => $message,
-                        'user' => $userContext->name,
-                    ]);
+                    $this->logger->warning(
+                        true === $isCustom
+                            ? "No selected backends matched for '{user}'."
+                            : "No export backends were available for '{user}'.",
+                        [
+                            'event_name' => 'state.export.backend.none_selected',
+                            'subsystem' => 'state.export',
+                            'operation' => 'select_backend',
+                            'outcome' => 'skipped',
+                            'command' => self::ROUTE,
+                            'user' => $userContext->name,
+                            'reason' => true === $isCustom ? 'selection_no_match' : 'no_backends',
+                            'selection' => $selection,
+                        ],
+                    );
                     continue;
                 }
 
@@ -299,10 +390,17 @@ class ExportCommand extends Command
                     foreach ($backends as $backend) {
                         if (null === ($lastSync = ag($backend, 'export.lastSync', null))) {
                             $this->logger->info(
-                                "SYSTEM: Using export mode for '{user}@{backend}'. No export last Sync date found.",
+                                "Using export mode for '{user}@{backend}': no export cursor was found.",
                                 [
+                                    'event_name' => 'state.export.backend.mode_selected',
+                                    'subsystem' => 'state.export',
+                                    'operation' => 'select_mode',
+                                    'outcome' => 'completed',
+                                    'command' => self::ROUTE,
                                     'user' => $userContext->name,
                                     'backend' => ag($backend, 'name'),
+                                    'mode' => 'export',
+                                    'reason' => 'missing_export_cursor',
                                 ],
                             );
 
@@ -312,10 +410,17 @@ class ExportCommand extends Command
 
                         if (null === ag($backend, 'import.lastSync', null)) {
                             $this->logger->warning(
-                                "SYSTEM: Using export mode for '{user}@{backend}'. The backend metadata not imported. You need to run import to populate the database.",
+                                "Using export mode for '{user}@{backend}': import metadata has not been populated yet.",
                                 [
+                                    'event_name' => 'state.export.backend.mode_selected',
+                                    'subsystem' => 'state.export',
+                                    'operation' => 'select_mode',
+                                    'outcome' => 'completed',
+                                    'command' => self::ROUTE,
                                     'user' => $userContext->name,
                                     'backend' => ag($backend, 'name'),
+                                    'mode' => 'export',
+                                    'reason' => 'missing_import_cursor',
                                 ],
                             );
 
@@ -330,27 +435,43 @@ class ExportCommand extends Command
 
                     $lastSync = make_date($minDate);
 
-                    $this->logger->notice("SYSTEM: Loading '{user}' database items that has changed since '{date}'.", [
-                        'date' => (string) $lastSync,
+                    $this->logger->notice("Loading local changes for '{user}' since {since}.", [
+                        'event_name' => 'state.export.changes.loading',
+                        'subsystem' => 'state.export',
+                        'operation' => 'load_changes',
+                        'outcome' => 'started',
+                        'command' => self::ROUTE,
+                        'since' => (string) $lastSync,
                         'user' => $userContext->name,
                     ]);
 
                     $entities = $userContext->db->getAll($lastSync);
 
                     if (count($entities) < 1 && count($export) < 1) {
-                        $this->logger->notice("SYSTEM: No play state changes detected since '{date}' for '{user}'.", [
-                            'date' => (string) $lastSync,
+                        $this->logger->notice("No play-state changes detected for '{user}' since {since}.", [
+                            'event_name' => 'state.export.no_changes',
+                            'subsystem' => 'state.export',
+                            'operation' => 'load_changes',
+                            'outcome' => 'completed',
+                            'command' => self::ROUTE,
+                            'since' => (string) $lastSync,
                             'user' => $userContext->name,
+                            'change_count' => 0,
                         ]);
                         continue;
                     }
 
                     if (count($entities) >= 1) {
                         $this->logger->info(
-                            "SYSTEM: Checking '{total}' media items for push mode compatibility for '{user}'.",
+                            "Checking {item_count} media items for push mode compatibility for '{user}'.",
                             (static function () use ($entities, $input, $userContext): array {
                                 $context = [
-                                    'total' => number_format(count($entities)),
+                                    'event_name' => 'state.export.push.compatibility.started',
+                                    'subsystem' => 'state.export',
+                                    'operation' => 'check_push_compatibility',
+                                    'outcome' => 'started',
+                                    'command' => self::ROUTE,
+                                    'item_count' => count($entities),
                                     'user' => $userContext->name,
                                 ];
 
@@ -381,16 +502,22 @@ class ExportCommand extends Command
 
                                     if (null === $addedDate || false === ctype_digit($addedDate)) {
                                         $this->logger->info(
-                                            "SYSTEM: Ignoring '{item.id}: {item.title}' for '{user}@{backend}' received invalid added_at '{added_at}' date.",
+                                            "Skipping push compatibility for '{user}@{backend}' item '#{item.id}: {item.title}': added_at '{added_at}' is invalid.",
                                             [
+                                                'event_name' => 'state.export.push.item.skipped',
+                                                'subsystem' => 'state.export',
+                                                'operation' => 'check_push_compatibility',
+                                                'outcome' => 'skipped',
+                                                'command' => self::ROUTE,
                                                 'user' => $userContext->name,
-                                                'type' => get_debug_type($addedDate),
                                                 'backend' => $name,
                                                 'item' => [
                                                     'id' => $entity->id,
                                                     'title' => $entity->getName(),
                                                 ],
                                                 'added_at' => $addedDate,
+                                                'added_at_type' => get_debug_type($addedDate),
+                                                'reason' => 'invalid_added_at',
                                                 'data' => $input->getOption('trace') ? $entity->getAll() : [],
                                             ],
                                         );
@@ -399,8 +526,13 @@ class ExportCommand extends Command
 
                                     if ($lastSync > ($addedDate + $extraMargin)) {
                                         $this->logger->info(
-                                            "SYSTEM: Ignoring '{item.id}: {item.title}' for '{user}@{backend}' waiting period for metadata expired.",
+                                            "Skipping push compatibility for '{user}@{backend}' item '#{item.id}: {item.title}': metadata wait period expired.",
                                             [
+                                                'event_name' => 'state.export.push.item.skipped',
+                                                'subsystem' => 'state.export',
+                                                'operation' => 'check_push_compatibility',
+                                                'outcome' => 'skipped',
+                                                'command' => self::ROUTE,
                                                 'user' => $userContext->name,
                                                 'backend' => $name,
                                                 'item' => [
@@ -413,6 +545,7 @@ class ExportCommand extends Command
                                                     'last_sync_at' => make_date($lastSync),
                                                     'diff' => $lastSync - ($addedDate + $extraMargin),
                                                 ],
+                                                'reason' => 'metadata_wait_expired',
                                             ],
                                         );
 
@@ -424,14 +557,21 @@ class ExportCommand extends Command
                                     }
 
                                     $this->logger->info(
-                                        "SYSTEM: Using export mode for '{user}@{backend}'. Backend local database entries did not have metadata for '{item.id}: {item.title}'.",
+                                        "Using export mode for '{user}@{backend}': local state for '#{item.id}: {item.title}' is missing backend metadata.",
                                         [
+                                            'event_name' => 'state.export.backend.mode_selected',
+                                            'subsystem' => 'state.export',
+                                            'operation' => 'select_mode',
+                                            'outcome' => 'completed',
+                                            'command' => self::ROUTE,
                                             'user' => $userContext->name,
                                             'backend' => $name,
+                                            'mode' => 'export',
                                             'item' => [
                                                 'id' => $entity->id,
                                                 'title' => $entity->getName(),
                                             ],
+                                            'reason' => 'missing_backend_metadata',
                                         ],
                                     );
 
@@ -447,21 +587,37 @@ class ExportCommand extends Command
                 } else {
                     $export = $backends;
                     $this->logger->notice(
-                        "SYSTEM: Not possible to use push mode when '-f, --force-full' flag is used.",
+                        "Push mode is unavailable when '--force-full' is used.",
+                        [
+                            'event_name' => 'state.export.push.unavailable',
+                            'subsystem' => 'state.export',
+                            'operation' => 'select_mode',
+                            'outcome' => 'skipped',
+                            'command' => self::ROUTE,
+                            'user' => $userContext->name,
+                            'reason' => 'force_full_requested',
+                        ],
                     );
                 }
 
                 $this->logger->notice(
-                    "SYSTEM: '{user}' Using push mode for '{push.total}' backends and export mode for '{export.total}' backends.",
+                    "Using push mode for {push_count} backends and export mode for {export_count} backends for '{user}'.",
                     [
+                        'event_name' => 'state.export.mode.selected',
+                        'subsystem' => 'state.export',
+                        'operation' => 'select_mode',
+                        'outcome' => 'completed',
+                        'command' => self::ROUTE,
                         'user' => $userContext->name,
+                        'push_count' => count($push),
+                        'export_count' => count($export),
                         'push' => [
                             'total' => count($push),
-                            'list' => implode(', ', array_keys($push)),
+                            'list' => array_keys($push),
                         ],
                         'export' => [
                             'total' => count($export),
-                            'list' => implode(', ', array_keys($export)),
+                            'list' => array_keys($export),
                         ],
                     ],
                 );
@@ -483,9 +639,18 @@ class ExportCommand extends Command
                 $total = count($this->queue->getQueue());
 
                 if ($total >= 1) {
-                    $this->logger->notice("SYSTEM: Sending '{total}' change play state requests for '{user}'.", [
-                        'total' => $total,
+                    $requestStart = microtime(true);
+
+                    $this->logger->notice("Waiting for {request_count} export requests for '{user}'.", [
+                        'event_name' => 'state.export.requests.started',
+                        'subsystem' => 'state.export',
+                        'operation' => 'send_requests',
+                        'outcome' => 'started',
+                        'command' => self::ROUTE,
+                        'phase' => 'write',
+                        'request_count' => $total,
                         'user' => $userContext->name,
+                        'sync_requests' => $syncRequests,
                     ]);
 
                     send_requests(
@@ -495,51 +660,100 @@ class ExportCommand extends Command
                         logger: $this->logger,
                     );
 
-                    $this->logger->notice("SYSTEM: Sent '{total}' change play state requests for '{user}'.", [
-                        'total' => $total,
+                    $this->logger->notice("Completed {request_count} export requests for '{user}' in {duration_seconds}s.", [
+                        'event_name' => 'state.export.requests.completed',
+                        'subsystem' => 'state.export',
+                        'operation' => 'send_requests',
+                        'outcome' => 'completed',
+                        'command' => self::ROUTE,
+                        'phase' => 'write',
+                        'request_count' => $total,
                         'user' => $userContext->name,
+                        'sync_requests' => $syncRequests,
+                        'duration_seconds' => round(microtime(true) - $requestStart, 4),
                     ]);
                 } else {
-                    $this->logger->notice("SYSTEM: No play state changes detected '{user}'.", [
+                    $this->logger->notice("No play-state changes detected for '{user}'.", [
+                        'event_name' => 'state.export.no_changes',
+                        'subsystem' => 'state.export',
+                        'operation' => 'send_requests',
+                        'outcome' => 'completed',
+                        'command' => self::ROUTE,
                         'user' => $userContext->name,
+                        'change_count' => 0,
                     ]);
                 }
 
-                if (true === $input->getOption('dry-run')) {
-                    continue;
-                }
+                if (false === $dryRun) {
+                    foreach ($backends as $backend) {
+                        if (null === ($name = ag($backend, 'name'))) {
+                            continue;
+                        }
 
-                foreach ($backends as $backend) {
-                    if (null === ($name = ag($backend, 'name'))) {
-                        continue;
-                    }
-
-                    if (false === (bool) Message::get("{$name}.has_errors", false)) {
-                        $userContext->config->set("{$name}.export.lastSync", time());
-                    } else {
-                        $this->logger->warning(
-                            "SYSTEM: Not updating '{user}@{backend}' export last sync date. There was errors recorded during the operation.",
-                            [
+                        if (false === (bool) Message::get("{$name}.has_errors", false)) {
+                            $lastSyncAt = time();
+                            $userContext->config->set("{$name}.export.lastSync", $lastSyncAt);
+                            $this->logger->notice("Updated export cursor for '{user}@{backend}' to {last_sync_at}.", [
+                                'event_name' => 'state.export.cursor.updated',
+                                'subsystem' => 'state.export',
+                                'operation' => 'update_cursor',
+                                'outcome' => 'completed',
+                                'command' => self::ROUTE,
                                 'backend' => $name,
                                 'user' => $userContext->name,
-                            ],
-                        );
+                                'last_sync_at' => (string) make_date($lastSyncAt),
+                                'mode' => 'mixed',
+                            ]);
+                        } else {
+                            $this->logger->warning(
+                                "Skipping export cursor update for '{user}@{backend}': errors were recorded during export.",
+                                [
+                                    'event_name' => 'state.export.cursor.skipped',
+                                    'subsystem' => 'state.export',
+                                    'operation' => 'update_cursor',
+                                    'outcome' => 'skipped',
+                                    'command' => self::ROUTE,
+                                    'backend' => $name,
+                                    'user' => $userContext->name,
+                                    'mode' => 'mixed',
+                                    'reason' => 'backend_errors_recorded',
+                                ],
+                            );
+                        }
                     }
+
+                    $userContext->config->persist();
                 }
 
-                $userContext->config->persist();
+                $this->logger->info("Exporting play states for '{user}' completed in {duration_seconds}s.", [
+                    'event_name' => 'state.export.user.completed',
+                    'subsystem' => 'state.export',
+                    'operation' => 'export',
+                    'outcome' => 'completed',
+                    'command' => self::ROUTE,
+                    'user' => $userContext->name,
+                    'duration_seconds' => round(microtime(true) - $userStart, 4),
+                    'backends' => array_keys($backends),
+                    'memory' => [
+                        'now' => get_memory_usage(),
+                        'peak' => get_peak_memory_usage(),
+                    ],
+                ]);
             } catch (Throwable $e) {
                 $this->logger->error(
-                    "SYSTEM: Unhandled exception '{error.kind}' was thrown during '{user}' export operation. '{error.message}' at '{error.file}:{error.line}'.",
-                    [
-                        'error' => [
-                            'kind' => $e::class,
-                            'line' => $e->getLine(),
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
+                    ...lw(
+                        message: "Export failed for '{user}'.",
+                        context: [
+                            'event_name' => 'state.export.failed',
+                            'subsystem' => 'state.export',
+                            'operation' => 'export',
+                            'outcome' => 'failed',
+                            'command' => self::ROUTE,
+                            'user' => $userContext->name,
+                            ...exception_log($e),
                         ],
-                        'user' => $userContext->name,
-                    ],
+                        e: $e,
+                    ),
                 );
             } finally {
                 $this->queue->reset();
@@ -547,8 +761,27 @@ class ExportCommand extends Command
             }
         }
 
-        $this->logger->notice('SYSTEM: Using WatchState {full_version}', [
-            'full_version' => get_full_version(),
+        $this->logger->notice('Export completed for {user_count} users in {duration_seconds}s.', [
+            'event_name' => 'state.export.completed',
+            'subsystem' => 'state.export',
+            'operation' => 'export',
+            'outcome' => 'completed',
+            'command' => self::ROUTE,
+            'user_count' => count($users),
+            'duration_seconds' => round(microtime(true) - $totalStart, 4),
+            'dry_run' => $dryRun,
+            'force_full' => $forceFullRequested,
+        ]);
+
+        $this->logger->notice('Using WatchState {version.full}.', [
+            'event_name' => 'app.version',
+            'subsystem' => 'app',
+            'operation' => 'version',
+            'outcome' => 'resolved',
+            'command' => self::ROUTE,
+            'version' => [
+                'full' => get_full_version(),
+            ],
         ]);
 
         return self::SUCCESS;
@@ -565,9 +798,19 @@ class ExportCommand extends Command
      */
     protected function push(UserContext $userContext, array $backends, array $entities): int
     {
-        $this->logger->notice("Push mode started for '{user}: {backends}'.", [
+        $start = microtime(true);
+        $backendNames = array_keys($backends);
+
+        $this->logger->notice('Pushing {item_count} local changes to {backend_count} backends for \'{user}\'.', [
+            'event_name' => 'state.export.push.started',
+            'subsystem' => 'state.export',
+            'operation' => 'push',
+            'outcome' => 'started',
+            'command' => self::ROUTE,
             'user' => $userContext->name,
-            'backends' => implode(', ', array_keys($backends)),
+            'item_count' => count($entities),
+            'backend_count' => count($backendNames),
+            'backends' => $backendNames,
         ]);
 
         foreach ($backends as $backend) {
@@ -579,10 +822,21 @@ class ExportCommand extends Command
             );
         }
 
-        $this->logger->notice("Push mode ended for '{user}: {backends}'.", [
-            'user' => $userContext->name,
-            'backends' => implode(', ', array_keys($backends)),
-        ]);
+        $this->logger->notice(
+            'Pushed {item_count} local changes to {backend_count} backends for \'{user}\' in {duration_seconds}s.',
+            [
+                'event_name' => 'state.export.push.completed',
+                'subsystem' => 'state.export',
+                'operation' => 'push',
+                'outcome' => 'completed',
+                'command' => self::ROUTE,
+                'user' => $userContext->name,
+                'item_count' => count($entities),
+                'backend_count' => count($backendNames),
+                'backends' => $backendNames,
+                'duration_seconds' => round(microtime(true) - $start, 4),
+            ],
+        );
 
         return self::SUCCESS;
     }
@@ -602,14 +856,34 @@ class ExportCommand extends Command
         bool $isFull,
         bool $syncRequests = false,
     ): void {
-        $this->logger->notice("Export mode started for '{user}@{backends}'.", [
+        $start = microtime(true);
+        $backendNames = array_keys($backends);
+
+        $this->logger->notice('Running export mode for {backend_count} backends for \'{user}\'.', [
+            'event_name' => 'state.export.export_mode.started',
+            'subsystem' => 'state.export',
+            'operation' => 'export_mode',
+            'outcome' => 'started',
+            'command' => self::ROUTE,
             'user' => $userContext->name,
-            'backends' => implode(', ', array_keys($backends)),
+            'backend_count' => count($backendNames),
+            'backends' => $backendNames,
+            'dry_run' => $inDryMode,
+            'force_full' => $isFull,
+            'memory' => [
+                'now' => get_memory_usage(),
+                'peak' => get_peak_memory_usage(),
+            ],
         ]);
 
         $this->logger->notice(
-            message: "SYSTEM: Preloading user '{user}: {mapper}' data. Memory usage '{memory.now}'.",
+            message: "Preloading local state database for '{user}'.",
             context: [
+                'event_name' => 'state.export.preload.started',
+                'subsystem' => 'state.export',
+                'operation' => 'preload',
+                'outcome' => 'started',
+                'command' => self::ROUTE,
                 'user' => $userContext->name,
                 'mapper' => after_last($userContext->mapper::class, '\\'),
                 'memory' => [
@@ -623,11 +897,20 @@ class ExportCommand extends Command
         $userContext->mapper->reset()->loadData();
 
         $this->logger->notice(
-            message: "SYSTEM: Preloading user '{user}: {mapper}' data completed in '{duration}s'. Memory usage '{memory.now}'.",
+            message: "Preloaded local state database for '{user}' in {duration_seconds}s.",
             context: [
+                'event_name' => 'state.export.preload.completed',
+                'subsystem' => 'state.export',
+                'operation' => 'preload',
+                'outcome' => 'completed',
+                'command' => self::ROUTE,
                 'user' => $userContext->name,
                 'mapper' => after_last($userContext->mapper::class, '\\'),
-                'duration' => round(microtime(true) - $time, 4),
+                'duration_seconds' => round(microtime(true) - $time, 4),
+                'stats' => [
+                    'pointers' => count($userContext->mapper->getPointersList()),
+                    'objects' => $userContext->mapper->getObjectsCount(),
+                ],
                 'memory' => [
                     'now' => get_memory_usage(),
                     'peak' => get_peak_memory_usage(),
@@ -645,16 +928,31 @@ class ExportCommand extends Command
             $after = true === $isFull ? null : ag($backend, 'export.lastSync', null);
 
             if (null === $after) {
-                $this->logger->notice("SYSTEM: Exporting play state to '{user}@{backend}'.", [
+                $this->logger->notice("Exporting full play-state snapshot to '{user}@{backend}'.", [
+                    'event_name' => 'state.export.backend.started',
+                    'subsystem' => 'state.export',
+                    'operation' => 'export_backend',
+                    'outcome' => 'started',
+                    'command' => self::ROUTE,
                     'backend' => $name,
                     'user' => $userContext->name,
+                    'since' => 'Beginning',
+                    'mode' => 'export',
+                    'dry_run' => $inDryMode,
                 ]);
             } else {
                 $after = make_date($after);
-                $this->logger->notice("SYSTEM: Exporting play state changes since '{date}' to '{user}@{backend}'.", [
+                $this->logger->notice("Exporting play-state changes since {since} to '{user}@{backend}'.", [
+                    'event_name' => 'state.export.backend.started',
+                    'subsystem' => 'state.export',
+                    'operation' => 'export_backend',
+                    'outcome' => 'started',
+                    'command' => self::ROUTE,
                     'backend' => $name,
                     'user' => $userContext->name,
-                    'date' => (string) $after,
+                    'since' => (string) $after,
+                    'mode' => 'export',
+                    'dry_run' => $inDryMode,
                 ]);
             }
 
@@ -662,38 +960,99 @@ class ExportCommand extends Command
             array_push($requests, ...$backend['class']->export($userContext->mapper, $this->queue, $after));
 
             if (false === $inDryMode) {
-                if (true === (bool) Message::get("{$name}.has_errors")) {
-                    $this->logger->warning(
-                        "SYSTEM: Not updating '{user}@{backend}' export last sync date. There was errors recorded during the operation.",
-                        [
-                            'backend' => $name,
-                            'user' => $userContext->name,
-                        ],
-                    );
-                } else {
+                if (false === (bool) Message::get("{$name}.has_errors")) {
                     $userContext->config->set("{$name}.export.lastSync", time());
                 }
             }
         }
 
-        $start = microtime(true);
-        $this->logger->notice("SYSTEM: Sending '{total}' play state comparison {sync}requests for '{user}'.", [
-            'total' => count($requests),
-            'user' => $userContext->name,
-            'sync' => true === $syncRequests ? 'sync ' : '',
-        ]);
+        if (count($requests) < 1) {
+            $this->logger->notice("No export comparison requests were needed for '{user}'.", [
+                'event_name' => 'state.export.requests.completed',
+                'subsystem' => 'state.export',
+                'operation' => 'send_requests',
+                'outcome' => 'completed',
+                'command' => self::ROUTE,
+                'phase' => 'compare',
+                'request_count' => 0,
+                'user' => $userContext->name,
+                'sync_requests' => $syncRequests,
+            ]);
+        } else {
+            $requestStart = microtime(true);
 
-        send_requests(requests: $requests, client: $this->http, sync: $syncRequests, logger: $this->logger);
+            $this->logger->notice("Waiting for {request_count} export comparison requests for '{user}'.", [
+                'event_name' => 'state.export.requests.started',
+                'subsystem' => 'state.export',
+                'operation' => 'send_requests',
+                'outcome' => 'started',
+                'command' => self::ROUTE,
+                'phase' => 'compare',
+                'request_count' => count($requests),
+                'user' => $userContext->name,
+                'sync_requests' => $syncRequests,
+            ]);
 
-        $this->logger->notice("Export mode ended for '{user}: {backends}' in '{duration}'s.", [
-            'user' => $userContext->name,
-            'backends' => implode(', ', array_keys($backends)),
-            'duration' => round(microtime(true) - $start, 4),
-        ]);
+            send_requests(requests: $requests, client: $this->http, sync: $syncRequests, logger: $this->logger);
+
+            $this->logger->notice(
+                "Completed {request_count} export comparison requests for '{user}' in {duration_seconds}s.",
+                [
+                    'event_name' => 'state.export.requests.completed',
+                    'subsystem' => 'state.export',
+                    'operation' => 'send_requests',
+                    'outcome' => 'completed',
+                    'command' => self::ROUTE,
+                    'phase' => 'compare',
+                    'request_count' => count($requests),
+                    'user' => $userContext->name,
+                    'sync_requests' => $syncRequests,
+                    'duration_seconds' => round(microtime(true) - $requestStart, 4),
+                ],
+            );
+        }
+
+        $this->logger->notice(
+            "Export mode completed for {backend_count} backends for '{user}' in {duration_seconds}s.",
+            [
+                'event_name' => 'state.export.export_mode.completed',
+                'subsystem' => 'state.export',
+                'operation' => 'export_mode',
+                'outcome' => 'completed',
+                'command' => self::ROUTE,
+                'user' => $userContext->name,
+                'backend_count' => count($backendNames),
+                'backends' => $backendNames,
+                'duration_seconds' => round(microtime(true) - $start, 4),
+                'dry_run' => $inDryMode,
+                'force_full' => $isFull,
+                'memory' => [
+                    'now' => get_memory_usage(),
+                    'peak' => get_peak_memory_usage(),
+                ],
+            ],
+        );
     }
 
     private function in_array(array $list, string $search): bool
     {
         return array_any($list, static fn($item) => str_starts_with($search, $item));
+    }
+
+    /**
+     * @param array<int|string,mixed> $selected
+     */
+    private function resolveSelectionMode(array $selected, bool $exclude): string
+    {
+        $selected = array_values(array_filter(
+            array_map(trim(...), array_map('strval', $selected)),
+            static fn(string $item): bool => '' !== $item,
+        ));
+
+        if ([] === $selected) {
+            return 'all';
+        }
+
+        return true === $exclude ? 'exclude' : 'include';
     }
 }

--- a/src/Commands/State/ImportCommand.php
+++ b/src/Commands/State/ImportCommand.php
@@ -24,8 +24,6 @@ use App\Libs\UserContext;
 use Monolog\Level;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface as iLogger;
-use Symfony\Component\Console\Helper\Table;
-use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -169,14 +167,31 @@ class ImportCommand extends Command
         }
 
         $mapperOpts = $dbOpts = [];
+        $dryRun = true === (bool) $input->getOption('dry-run');
+        $forceFullRequested = true === (bool) $input->getOption('force-full');
 
-        if ($input->getOption('dry-run')) {
-            $this->logger->notice('Dry run mode. No changes will be committed.');
+        if (true === $dryRun) {
+            $this->logger->notice('Dry run enabled; no changes will be committed.', [
+                'event_name' => 'state.import.dry_run.enabled',
+                'subsystem' => 'state.import',
+                'operation' => 'import',
+                'outcome' => 'started',
+                'command' => self::ROUTE,
+                'dry_run' => true,
+            ]);
             $mapperOpts[Options::DRY_RUN] = true;
         }
 
         if (true === (bool) Config::get('guid.disable.episode', false)) {
-            $this->logger->notice('Mapper: Matching episodes via GUID is disabled.');
+            $this->logger->notice('Episode GUID matching is disabled for this import run.', [
+                'event_name' => 'state.import.mapper_guid_disabled',
+                'subsystem' => 'state.import',
+                'operation' => 'configure_mapper',
+                'outcome' => 'completed',
+                'command' => self::ROUTE,
+                'mapper' => after_last($this->mapper::class, '\\'),
+                'reason' => 'config_disabled',
+            ]);
         }
 
         if ($input->getOption('trace')) {
@@ -231,22 +246,54 @@ class ImportCommand extends Command
         $hasLibrarySelect = count($selectLibrary) > 0;
         $inverseLibrarySelect = true === $input->getOption('exclude-library');
         $supported = Config::get('supported', []);
+        $selection = [
+            'mode' => $this->resolveSelectionMode((array) $selected, true === (bool) $input->getOption('exclude')),
+            'backends' => array_values(array_filter(
+                array_map(trim(...), array_map('strval', (array) $selected)),
+                static fn(string $item): bool => '' !== $item,
+            )),
+        ];
 
         $totalStartTime = microtime(true);
 
-        $this->logger->notice('SYSTEM: Using WatchState {full_version}', [
-            'full_version' => get_full_version(),
+        $this->logger->notice('Using WatchState {version.full}.', [
+            'event_name' => 'app.version',
+            'subsystem' => 'app',
+            'operation' => 'version',
+            'outcome' => 'resolved',
+            'command' => self::ROUTE,
+            'version' => [
+                'full' => get_full_version(),
+            ],
         ]);
 
-        $this->logger->notice("SYSTEM: Starting import process for '{total}' users", ['total' => count($users)]);
+        $this->logger->notice('Import started for {user_count} users.', [
+            'event_name' => 'state.import.started',
+            'subsystem' => 'state.import',
+            'operation' => 'import',
+            'outcome' => 'started',
+            'command' => self::ROUTE,
+            'user_count' => count($users),
+            'dry_run' => $dryRun,
+            'force_full' => $forceFullRequested,
+            'selection' => $selection,
+        ]);
 
         foreach ($users as $userContext) {
             $list = [];
             $userStart = microtime(true);
 
-            $this->logger->notice("SYSTEM: Importing user '{user}' play states.", [
+            $this->logger->notice("Importing play states for '{user}'.", [
+                'event_name' => 'state.import.user.started',
+                'subsystem' => 'state.import',
+                'operation' => 'import',
+                'outcome' => 'started',
+                'command' => self::ROUTE,
                 'user' => $userContext->name,
-                'backends' => implode(', ', array_keys($list)),
+                'memory' => [
+                    'now' => get_memory_usage(),
+                    'peak' => get_peak_memory_usage(),
+                ],
             ]);
 
             foreach ($userContext->config->getAll() as $backendName => $backend) {
@@ -254,9 +301,16 @@ class ImportCommand extends Command
                 $metadata = false;
 
                 if ($isCustom && $input->getOption('exclude') === $this->in_array($selected, $backendName)) {
-                    $this->logger->info("SYSTEM: Ignoring '{user}@{backend}'. as requested.", [
+                    $this->logger->info("Skipping '{user}@{backend}': excluded by selection.", [
+                        'event_name' => 'state.import.backend.skipped',
+                        'subsystem' => 'state.import',
+                        'operation' => 'select_backend',
+                        'outcome' => 'skipped',
+                        'command' => self::ROUTE,
                         'user' => $userContext->name,
                         'backend' => $backendName,
+                        'reason' => 'selected_excluded',
+                        'selection' => $selection,
                     ]);
                     continue;
                 }
@@ -279,36 +333,61 @@ class ImportCommand extends Command
                 if (true !== $metadata && true !== (bool) ag($backend, 'import.enabled')) {
                     if ($isCustom) {
                         $this->logger->warning(
-                            message: "SYSTEM: Importing from import disabled '{user}@{backend}' As requested.",
+                            message: "Importing from disabled backend '{user}@{backend}' because it was explicitly selected.",
                             context: [
+                                'event_name' => 'state.import.backend.forced',
+                                'subsystem' => 'state.import',
+                                'operation' => 'select_backend',
+                                'outcome' => 'forced',
+                                'command' => self::ROUTE,
                                 'user' => $userContext->name,
                                 'backend' => $backendName,
+                                'reason' => 'explicitly_selected',
+                                'import_enabled' => false,
                             ],
                         );
                     } else {
-                        $this->logger->info("SYSTEM: Ignoring '{user}@{backend}'. Import disabled.", [
+                        $this->logger->info("Skipping '{user}@{backend}': import is disabled.", [
+                            'event_name' => 'state.import.backend.skipped',
+                            'subsystem' => 'state.import',
+                            'operation' => 'select_backend',
+                            'outcome' => 'skipped',
+                            'command' => self::ROUTE,
                             'user' => $userContext->name,
                             'backend' => $backendName,
+                            'reason' => 'import_disabled',
                         ]);
                         continue;
                     }
                 }
 
                 if (!isset($supported[$type])) {
-                    $this->logger->error("SYSTEM: Ignoring '{user}@{backend}'. Unexpected type '{type}'.", [
+                    $this->logger->warning("Skipping '{user}@{backend}': backend type '{backend_type}' is unsupported.", [
+                        'event_name' => 'state.import.backend.skipped',
+                        'subsystem' => 'state.import',
+                        'operation' => 'select_backend',
+                        'outcome' => 'skipped',
+                        'command' => self::ROUTE,
                         'user' => $userContext->name,
-                        'type' => $type,
+                        'backend_type' => $type,
                         'backend' => $backendName,
                         'types' => implode(', ', array_keys($supported)),
+                        'reason' => 'unsupported_type',
                     ]);
                     continue;
                 }
 
                 if (null === ($url = ag($backend, 'url')) || false === is_valid_url($url)) {
-                    $this->logger->error("SYSTEM: Ignoring '{user}@{backend}'. Invalid URL '{url}'.", [
+                    $this->logger->warning("Skipping '{user}@{backend}': URL '{url}' is invalid.", [
+                        'event_name' => 'state.import.backend.skipped',
+                        'subsystem' => 'state.import',
+                        'operation' => 'select_backend',
+                        'outcome' => 'skipped',
+                        'command' => self::ROUTE,
                         'user' => $userContext->name,
                         'url' => $url ?? 'None',
                         'backend' => $backendName,
+                        'reason' => 'invalid_url',
                     ]);
                     continue;
                 }
@@ -320,9 +399,18 @@ class ImportCommand extends Command
             if (empty($list)) {
                 $this->logger->warning(
                     $isCustom
-                        ? r("[-s, --select-backend] flag did not match any backend for '{user}'.", [
-                            'user' => $userContext->name,
-                        ]) : 'No backends were found.',
+                        ? "No selected backends matched for '{user}'."
+                        : "No import backends were available for '{user}'.",
+                    [
+                        'event_name' => 'state.import.backend.none_selected',
+                        'subsystem' => 'state.import',
+                        'operation' => 'select_backend',
+                        'outcome' => 'skipped',
+                        'command' => self::ROUTE,
+                        'user' => $userContext->name,
+                        'reason' => true === $isCustom ? 'selection_no_match' : 'no_backends',
+                        'selection' => $selection,
+                    ],
                 );
                 continue;
             }
@@ -331,8 +419,13 @@ class ImportCommand extends Command
             $queue = [];
 
             $this->logger->notice(
-                message: "SYSTEM: Preloading user '{user}: {mapper}' data. Memory usage '{memory.now}'.",
+                message: "Preloading local state database for '{user}'.",
                 context: [
+                    'event_name' => 'state.import.preload.started',
+                    'subsystem' => 'state.import',
+                    'operation' => 'preload',
+                    'outcome' => 'started',
+                    'command' => self::ROUTE,
                     'user' => $userContext->name,
                     'mapper' => after_last($userContext->mapper::class, '\\'),
                     'memory' => [
@@ -346,11 +439,20 @@ class ImportCommand extends Command
             $userContext->mapper->reset()->loadData();
 
             $this->logger->notice(
-                message: "SYSTEM: Preloading user '{user}: {mapper}' data completed in '{duration}s'. Memory usage '{memory.now}'.",
+                message: "Preloaded local state database for '{user}' in {duration_seconds}s.",
                 context: [
+                    'event_name' => 'state.import.preload.completed',
+                    'subsystem' => 'state.import',
+                    'operation' => 'preload',
+                    'outcome' => 'completed',
+                    'command' => self::ROUTE,
                     'user' => $userContext->name,
                     'mapper' => after_last($userContext->mapper::class, '\\'),
-                    'duration' => round(microtime(true) - $time, 4),
+                    'duration_seconds' => round(microtime(true) - $time, 4),
+                    'stats' => [
+                        'pointers' => count($userContext->mapper->getPointersList()),
+                        'objects' => $userContext->mapper->getObjectsCount(),
+                    ],
                     'memory' => [
                         'now' => get_memory_usage(),
                         'peak' => get_peak_memory_usage(),
@@ -405,11 +507,17 @@ class ImportCommand extends Command
                     $after = make_date($after);
                 }
 
-                $this->logger->notice("SYSTEM: Importing '{user}@{backend}' {import_type} changes.", [
+                $this->logger->notice("Importing {import_type} changes from '{user}@{backend}'.", [
+                    'event_name' => 'state.import.backend.started',
+                    'subsystem' => 'state.import',
+                    'operation' => 'import_backend',
+                    'outcome' => 'started',
+                    'command' => self::ROUTE,
                     'user' => $userContext->name,
                     'backend' => $name,
                     'import_type' => true === $metadata ? 'metadata' : 'metadata & play state',
                     'since' => null === $after ? 'Beginning' : (string) $after,
+                    'dry_run' => $dryRun,
                 ]);
 
                 array_push($queue, ...$backend['class']->pull($userContext->mapper, $after));
@@ -419,10 +527,16 @@ class ImportCommand extends Command
                 if (false === $inDryMode) {
                     if (true === (bool) Message::get("{$name}.has_errors")) {
                         $this->logger->warning(
-                            message: "SYSTEM: Not updating '{user}@{backend}' import last sync date. There was errors recorded during the operation.",
+                            message: "Skipping import cursor update for '{user}@{backend}': errors were recorded during import.",
                             context: [
+                                'event_name' => 'state.import.cursor.skipped',
+                                'subsystem' => 'state.import',
+                                'operation' => 'update_cursor',
+                                'outcome' => 'skipped',
+                                'command' => self::ROUTE,
                                 'user' => $userContext->name,
                                 'backend' => $name,
+                                'reason' => 'backend_errors_recorded',
                             ],
                         );
                     } else {
@@ -434,10 +548,15 @@ class ImportCommand extends Command
             unset($backend);
 
             $start = microtime(true);
-            $this->logger->notice("SYSTEM: Waiting on '{total}' {sync}requests for '{user}' backends.", [
+            $this->logger->notice("Waiting for {request_count} import requests for '{user}'.", [
+                'event_name' => 'state.import.requests.started',
+                'subsystem' => 'state.import',
+                'operation' => 'send_requests',
+                'outcome' => 'started',
+                'command' => self::ROUTE,
                 'user' => $userContext->name,
-                'total' => number_format(count($queue)),
-                'sync' => $syncRequests ? 'sync ' : '',
+                'request_count' => count($queue),
+                'sync_requests' => $syncRequests,
                 'memory' => [
                     'now' => get_memory_usage(),
                     'peak' => get_peak_memory_usage(),
@@ -449,9 +568,16 @@ class ImportCommand extends Command
             } catch (Throwable $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "SYSTEM: Import requests for '{user}' backends failed. '{error.kind}' with message '{error.message}' at '{error.file}:{error.line}'.",
+                        message: "Import requests failed for '{user}'.",
                         context: [
+                            'event_name' => 'state.import.requests.failed',
+                            'subsystem' => 'state.import',
+                            'operation' => 'send_requests',
+                            'outcome' => 'failed',
+                            'command' => self::ROUTE,
                             'user' => $userContext->name,
+                            'request_count' => count($queue),
+                            'sync_requests' => $syncRequests,
                             ...exception_log($e),
                         ],
                         e: $e,
@@ -462,11 +588,18 @@ class ImportCommand extends Command
             }
 
             $this->logger->notice(
-                "SYSTEM: Completed '{total}' requests in '{duration}'s for '{user}' backends. Parsed '{responses.size}' of data.",
+                "Completed {request_count} import requests for '{user}' in {duration_seconds}s.",
                 [
+                    'event_name' => 'state.import.requests.completed',
+                    'subsystem' => 'state.import',
+                    'operation' => 'send_requests',
+                    'outcome' => 'completed',
+                    'command' => self::ROUTE,
                     'user' => $userContext->name,
-                    'total' => number_format(count($queue)),
-                    'duration' => round(microtime(true) - $start, 4),
+                    'request_count' => count($queue),
+                    'duration_seconds' => round(microtime(true) - $start, 4),
+                    'failed_count' => 0,
+                    'sync_requests' => $syncRequests,
                     'memory' => [
                         'now' => get_memory_usage(),
                         'peak' => get_peak_memory_usage(),
@@ -482,9 +615,15 @@ class ImportCommand extends Command
             $total = count($userContext->mapper);
 
             if ($total >= 1) {
-                $this->logger->notice("SYSTEM: Found '{total}' updated items from '{user}' backends.", [
+                $this->logger->notice("Found {updated_count} updated items from '{user}' backends.", [
+                    'event_name' => 'state.import.changes.collected',
+                    'subsystem' => 'state.import',
+                    'operation' => 'collect_changes',
+                    'outcome' => 'completed',
+                    'command' => self::ROUTE,
                     'user' => $userContext->name,
-                    'total' => $total,
+                    'updated_count' => $total,
+                    'backend_count' => count($list),
                     'memory' => [
                         'now' => get_memory_usage(),
                         'peak' => get_peak_memory_usage(),
@@ -498,11 +637,16 @@ class ImportCommand extends Command
             $userContext->mapper->reset();
 
             $this->logger->info(
-                "SYSTEM: Importing '{user}' play states completed in '{duration}'s. Memory usage '{memory.now}'.",
+                "Importing play states for '{user}' completed in {duration_seconds}s.",
                 [
+                    'event_name' => 'state.import.user.completed',
+                    'subsystem' => 'state.import',
+                    'operation' => 'import',
+                    'outcome' => 'completed',
+                    'command' => self::ROUTE,
                     'user' => $userContext->name,
-                    'backends' => implode(', ', array_keys($list)),
-                    'duration' => round(microtime(true) - $userStart, 4),
+                    'backends' => array_keys($list),
+                    'duration_seconds' => round(microtime(true) - $userStart, 4),
                     'memory' => [
                         'now' => get_memory_usage(),
                         'peak' => get_peak_memory_usage(),
@@ -517,19 +661,24 @@ class ImportCommand extends Command
 
                 if (($added + $updated + $failed) > 0) {
                     $this->logger->notice(
-                        "SYSTEM: Status for '{user}' {type}s: '{added}' added, '{updated}' updated and '{failed}' failed.",
+                        "Import status for '{user}' {item_type}: added {added_count}, updated {updated_count}, failed {failed_count}.",
                         [
+                            'event_name' => 'state.import.status',
+                            'subsystem' => 'state.import',
+                            'operation' => 'commit',
+                            'outcome' => 'completed',
+                            'command' => self::ROUTE,
                             'user' => $userContext->name,
-                            'type' => ucfirst($type),
-                            'added' => str_pad((string) number_format($added), 4, '0', STR_PAD_LEFT),
-                            'updated' => str_pad((string) number_format($updated), 4, '0', STR_PAD_LEFT),
-                            'failed' => str_pad((string) number_format($failed), 4, '0', STR_PAD_LEFT),
+                            'item_type' => $type,
+                            'added_count' => $added,
+                            'updated_count' => $updated,
+                            'failed_count' => $failed,
                         ],
                     );
                 }
             }
 
-            if (false === $input->getOption('dry-run')) {
+            if (false === $dryRun) {
                 $userContext->config->persist();
             }
 
@@ -542,12 +691,27 @@ class ImportCommand extends Command
             }
         }
 
-        $this->logger->notice("SYSTEM: Import process completed in '{duration}'s for all users.", [
-            'duration' => round(microtime(true) - $totalStartTime, 4),
+        $this->logger->notice('Import completed for {user_count} users in {duration_seconds}s.', [
+            'event_name' => 'state.import.completed',
+            'subsystem' => 'state.import',
+            'operation' => 'import',
+            'outcome' => 'completed',
+            'command' => self::ROUTE,
+            'user_count' => count($users),
+            'duration_seconds' => round(microtime(true) - $totalStartTime, 4),
+            'dry_run' => $dryRun,
+            'force_full' => $forceFullRequested,
         ]);
 
-        $this->logger->notice('SYSTEM: Using WatchState {full_version}', [
-            'full_version' => get_full_version(),
+        $this->logger->notice('Using WatchState {version.full}.', [
+            'event_name' => 'app.version',
+            'subsystem' => 'app',
+            'operation' => 'version',
+            'outcome' => 'resolved',
+            'command' => self::ROUTE,
+            'version' => [
+                'full' => get_full_version(),
+            ],
         ]);
 
         return self::SUCCESS;
@@ -574,6 +738,23 @@ class ImportCommand extends Command
     private function in_array(array $list, string $search): bool
     {
         return array_any($list, static fn($item) => str_starts_with($search, $item));
+    }
+
+    /**
+     * @param array<int|string,mixed> $selected
+     */
+    private function resolveSelectionMode(array $selected, bool $exclude): string
+    {
+        $selected = array_values(array_filter(
+            array_map(trim(...), array_map('strval', $selected)),
+            static fn(string $item): bool => '' !== $item,
+        ));
+
+        if ([] === $selected) {
+            return 'all';
+        }
+
+        return true === $exclude ? 'exclude' : 'include';
     }
 
     /**

--- a/src/Commands/State/ImportCommand.php
+++ b/src/Commands/State/ImportCommand.php
@@ -494,22 +494,6 @@ class ImportCommand extends Command
 
             $operations = $userContext->mapper->commit();
 
-            $a = [
-                [
-                    'Type' => ucfirst(iState::TYPE_MOVIE),
-                    'Added' => $operations[iState::TYPE_MOVIE]['added'] ?? '-',
-                    'Updated' => $operations[iState::TYPE_MOVIE]['updated'] ?? '-',
-                    'Failed' => $operations[iState::TYPE_MOVIE]['failed'] ?? '-',
-                ],
-                new TableSeparator(),
-                [
-                    'Type' => ucfirst(iState::TYPE_EPISODE),
-                    'Added' => $operations[iState::TYPE_EPISODE]['added'] ?? '-',
-                    'Updated' => $operations[iState::TYPE_EPISODE]['updated'] ?? '-',
-                    'Failed' => $operations[iState::TYPE_EPISODE]['failed'] ?? '-',
-                ],
-            ];
-
             Message::reset();
             $userContext->mapper->reset();
 
@@ -526,13 +510,24 @@ class ImportCommand extends Command
                 ],
             );
 
-            $output->writeln('');
-            new Table($output)
-                ->setHeaders(array_keys($a[0]))
-                ->setStyle('box')
-                ->setRows(array_values($a))
-                ->render();
-            $output->writeln('');
+            foreach ($operations as $type => $ops) {
+                $added = $ops['added'] ?? 0;
+                $updated = $ops['updated'] ?? 0;
+                $failed = $ops['failed'] ?? 0;
+
+                if (($added + $updated + $failed) > 0) {
+                    $this->logger->notice(
+                        "SYSTEM: Status for '{user}' {type}s: '{added}' added, '{updated}' updated and '{failed}' failed.",
+                        [
+                            'user' => $userContext->name,
+                            'type' => ucfirst($type),
+                            'added' => str_pad((string) number_format($added), 4, '0', STR_PAD_LEFT),
+                            'updated' => str_pad((string) number_format($updated), 4, '0', STR_PAD_LEFT),
+                            'failed' => str_pad((string) number_format($failed), 4, '0', STR_PAD_LEFT),
+                        ],
+                    );
+                }
+            }
 
             if (false === $input->getOption('dry-run')) {
                 $userContext->config->persist();

--- a/src/Commands/State/PlaylistCommand.php
+++ b/src/Commands/State/PlaylistCommand.php
@@ -248,21 +248,14 @@ class PlaylistCommand extends Command
 
         if ([] === $rows) {
             $this->logger->warning('SYSTEM: Playlist sync completed without any syncable playlist results.');
-            $this->logger->notice("SYSTEM: Playlist sync process completed in '{duration}'s for all users.", [
-                'duration' => round(microtime(true) - $totalStart, 4),
-            ]);
-            $this->logger->notice('SYSTEM: Using WatchState {full_version}', [
-                'full_version' => get_full_version(),
-            ]);
-            $output->writeln('<comment>No matching backends produced syncable playlists.</comment>');
-            return self::SUCCESS;
+        } else {
+            foreach ($rows as $row) {
+                $this->logger->notice(
+                    message: 'SYSTEM: {User}@{Backend} - Playlists: {Playlists}, Items: {Items}, Added: {Added}, Updated: {Updated}, Removed: {Removed}',
+                    context: $row,
+                );
+            }
         }
-
-        new Table($output)
-            ->setStyle('box')
-            ->setHeaders(array_keys($rows[0]))
-            ->setRows($rows)
-            ->render();
 
         $this->logger->notice("SYSTEM: Playlist sync process completed in '{duration}'s for all users.", [
             'duration' => round(microtime(true) - $totalStart, 4),

--- a/src/Commands/State/PlaylistCommand.php
+++ b/src/Commands/State/PlaylistCommand.php
@@ -21,7 +21,6 @@ use App\Libs\UserContext;
 use Monolog\Level;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface as iLogger;
-use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -123,17 +122,36 @@ class PlaylistCommand extends Command
         }
 
         if (true === $dryRun) {
-            $this->logger->notice('Dry run mode. No playlist changes will be committed.');
+            $this->logger->notice('Dry run enabled; no playlist changes will be committed.', [
+                'event_name' => 'playlist.dry_run.enabled',
+                'subsystem' => 'playlist',
+                'operation' => 'sync',
+                'outcome' => 'started',
+                'command' => self::ROUTE,
+                'dry_run' => true,
+            ]);
         }
 
         $totalStart = microtime(true);
 
-        $this->logger->notice('SYSTEM: Using WatchState {full_version}', [
-            'full_version' => get_full_version(),
+        $this->logger->notice('Using WatchState {version.full}.', [
+            'event_name' => 'app.version',
+            'subsystem' => 'app',
+            'operation' => 'version',
+            'outcome' => 'resolved',
+            'command' => self::ROUTE,
+            'version' => [
+                'full' => get_full_version(),
+            ],
         ]);
 
-        $this->logger->notice("SYSTEM: Starting playlist sync process for '{total}' users.", [
-            'total' => count($users),
+        $this->logger->notice('Playlist sync started for {user_count} users.', [
+            'event_name' => 'playlist.sync.started',
+            'subsystem' => 'playlist',
+            'operation' => 'sync',
+            'outcome' => 'started',
+            'command' => self::ROUTE,
+            'user_count' => count($users),
             'dry_run' => $dryRun,
             'force_full' => $forceFull,
             'selection' => [
@@ -147,7 +165,12 @@ class PlaylistCommand extends Command
         foreach ($users as $userContext) {
             $userStart = microtime(true);
 
-            $this->logger->notice("SYSTEM: Syncing '{user}' playlists.", [
+            $this->logger->notice("Syncing playlists for '{user}'.", [
+                'event_name' => 'playlist.sync.user.started',
+                'subsystem' => 'playlist',
+                'operation' => 'sync',
+                'outcome' => 'started',
+                'command' => self::ROUTE,
                 'user' => $userContext->name,
                 'memory' => [
                     'now' => get_memory_usage(),
@@ -163,15 +186,24 @@ class PlaylistCommand extends Command
             );
 
             if ([] === $clients) {
-                $this->logger->warning(
-                    $selectedBackends === []
-                        ? r("SYSTEM: No playlist backends were prepared for '{user}'.", [
-                            'user' => $userContext->name,
-                        ])
-                        : r("SYSTEM: [-s, --select-backend] flag did not match any playlist backend for '{user}'.", [
-                            'user' => $userContext->name,
-                        ]),
-                );
+                $reason = [] === $selectedBackends ? 'no_backends' : 'selection_no_match';
+                $message = [] === $selectedBackends
+                    ? "No playlist backends were prepared for '{user}'."
+                    : "No playlist backends matched selection for '{user}'.";
+
+                $this->logger->warning($message, [
+                    'event_name' => 'playlist.backend.none_prepared',
+                    'subsystem' => 'playlist',
+                    'operation' => 'prepare_backend',
+                    'outcome' => 'skipped',
+                    'command' => self::ROUTE,
+                    'user' => $userContext->name,
+                    'reason' => $reason,
+                    'selection' => [
+                        'mode' => $this->resolveSelectionMode($selectedBackends, $exclude),
+                        'backends' => $selectedBackends,
+                    ],
+                ]);
 
                 continue;
             }
@@ -179,9 +211,14 @@ class PlaylistCommand extends Command
             $sourceBackends = $this->getSourceBackends($userContext, array_keys($clients));
             $targetBackends = $this->getTargetBackends($userContext, array_keys($clients));
 
-            $this->logger->notice("SYSTEM: Prepared '{total}' playlist backends for '{user}'.", [
+            $this->logger->notice("Prepared {backend_count} playlist backends for '{user}'.", [
+                'event_name' => 'playlist.clients.prepared',
+                'subsystem' => 'playlist',
+                'operation' => 'prepare_backend',
+                'outcome' => 'completed',
+                'command' => self::ROUTE,
                 'user' => $userContext->name,
-                'total' => count($clients),
+                'backend_count' => count($clients),
                 'backends' => array_keys($clients),
                 'source_backends' => $sourceBackends,
                 'target_backends' => $targetBackends,
@@ -201,8 +238,13 @@ class PlaylistCommand extends Command
             } catch (Throwable $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "SYSTEM: Playlist sync for '{user}' failed. '{error.kind}' with message '{error.message}' at '{error.file}:{error.line}'.",
+                        message: "Playlist sync failed for '{user}'.",
                         context: [
+                            'event_name' => 'playlist.sync.failed',
+                            'subsystem' => 'playlist',
+                            'operation' => 'sync',
+                            'outcome' => 'failed',
+                            'command' => self::ROUTE,
                             'user' => $userContext->name,
                             ...exception_log($e),
                         ],
@@ -215,13 +257,13 @@ class PlaylistCommand extends Command
 
             foreach ($results as $backend => $stats) {
                 $rows[] = [
-                    'User' => $userContext->name,
-                    'Backend' => $backend,
-                    'Playlists' => $stats['playlists'],
-                    'Items' => $stats['items'],
-                    'Added' => true === $dryRun ? '-' : $stats['added'],
-                    'Updated' => true === $dryRun ? '-' : $stats['updated'],
-                    'Removed' => true === $dryRun ? '-' : $stats['removed'],
+                    'user' => $userContext->name,
+                    'backend' => $backend,
+                    'playlists' => $stats['playlists'],
+                    'items' => $stats['items'],
+                    'added' => true === $dryRun ? '-' : $stats['added'],
+                    'updated' => true === $dryRun ? '-' : $stats['updated'],
+                    'removed' => true === $dryRun ? '-' : $stats['removed'],
                 ];
             }
 
@@ -229,16 +271,26 @@ class PlaylistCommand extends Command
                 $persistStart = microtime(true);
                 $userContext->config->persist();
 
-                $this->logger->notice("SYSTEM: Persisted playlist sync state for '{user}' in '{duration}'s.", [
+                $this->logger->notice("Persisted playlist sync state for '{user}' in {duration_seconds}s.", [
+                    'event_name' => 'playlist.sync.persisted',
+                    'subsystem' => 'playlist',
+                    'operation' => 'persist',
+                    'outcome' => 'completed',
+                    'command' => self::ROUTE,
                     'user' => $userContext->name,
-                    'duration' => round(microtime(true) - $persistStart, 4),
+                    'duration_seconds' => round(microtime(true) - $persistStart, 4),
                 ]);
             }
 
-            $this->logger->info("SYSTEM: Syncing '{user}' playlists completed in '{duration}'s. Memory usage '{memory.now}'.", [
+            $this->logger->info("Playlist sync for '{user}' completed in {duration_seconds}s.", [
+                'event_name' => 'playlist.sync.user.completed',
+                'subsystem' => 'playlist',
+                'operation' => 'sync',
+                'outcome' => 'completed',
+                'command' => self::ROUTE,
                 'user' => $userContext->name,
-                'backends' => implode(', ', array_keys($clients)),
-                'duration' => round(microtime(true) - $userStart, 4),
+                'backends' => array_keys($clients),
+                'duration_seconds' => round(microtime(true) - $userStart, 4),
                 'memory' => [
                     'now' => get_memory_usage(),
                     'peak' => get_peak_memory_usage(),
@@ -247,22 +299,46 @@ class PlaylistCommand extends Command
         }
 
         if ([] === $rows) {
-            $this->logger->warning('SYSTEM: Playlist sync completed without any syncable playlist results.');
+            $this->logger->warning('Playlist sync completed without syncable results across {user_count} users.', [
+                'event_name' => 'playlist.sync.no_results',
+                'subsystem' => 'playlist',
+                'operation' => 'sync',
+                'outcome' => 'completed',
+                'command' => self::ROUTE,
+                'user_count' => count($users),
+                'reason' => 'no_syncable_results',
+            ]);
         } else {
             foreach ($rows as $row) {
                 $this->logger->notice(
-                    message: 'SYSTEM: {User}@{Backend} - Playlists: {Playlists}, Items: {Items}, Added: {Added}, Updated: {Updated}, Removed: {Removed}',
-                    context: $row,
+                    message: "Playlist summary for '{user}@{backend}': {playlist_count} playlists, {item_count} items, added {added_count}, updated {updated_count}, removed {removed_count}.",
+                    context: [
+                        'event_name' => 'playlist.sync.summary',
+                        'subsystem' => 'playlist',
+                        'operation' => 'sync',
+                        'outcome' => 'completed',
+                        'command' => self::ROUTE,
+                        'user' => $row['user'],
+                        'backend' => $row['backend'],
+                        'playlist_count' => $row['playlists'],
+                        'item_count' => $row['items'],
+                        'added_count' => $row['added'],
+                        'updated_count' => $row['updated'],
+                        'removed_count' => $row['removed'],
+                        'dry_run' => $dryRun,
+                    ],
                 );
             }
         }
 
-        $this->logger->notice("SYSTEM: Playlist sync process completed in '{duration}'s for all users.", [
-            'duration' => round(microtime(true) - $totalStart, 4),
-        ]);
-
-        $this->logger->notice('SYSTEM: Using WatchState {full_version}', [
-            'full_version' => get_full_version(),
+        $this->logger->notice('Playlist sync completed for {user_count} users in {duration_seconds}s.', [
+            'event_name' => 'playlist.sync.completed',
+            'subsystem' => 'playlist',
+            'operation' => 'sync',
+            'outcome' => 'completed',
+            'command' => self::ROUTE,
+            'user_count' => count($users),
+            'duration_seconds' => round(microtime(true) - $totalStart, 4),
         ]);
 
         return self::SUCCESS;
@@ -292,9 +368,19 @@ class PlaylistCommand extends Command
 
             if ($selected !== [] && $exclude === $this->matchesSelection($selected, $backendName)) {
                 $stats['filtered']++;
-                $this->logger->info("PLAYLIST: Ignoring '{user}@{backend}'. As requested.", [
+                $this->logger->info("Skipping '{user}@{backend}': excluded by selection.", [
+                    'event_name' => 'playlist.backend.skipped',
+                    'subsystem' => 'playlist',
+                    'operation' => 'prepare_backend',
+                    'outcome' => 'skipped',
+                    'command' => self::ROUTE,
                     'user' => $userContext->name,
                     'backend' => $backendName,
+                    'reason' => 'selected_excluded',
+                    'selection' => [
+                        'mode' => $this->resolveSelectionMode($selected, $exclude),
+                        'backends' => $selected,
+                    ],
                 ]);
                 continue;
             }
@@ -307,18 +393,34 @@ class PlaylistCommand extends Command
 
                 if ($selected !== []) {
                     $this->logger->warning(
-                        "PLAYLIST: Syncing disabled '{user}@{backend}' as requested.",
+                        "Including disabled playlist backend '{user}@{backend}' because it was explicitly selected.",
                         [
+                            'event_name' => 'playlist.backend.forced',
+                            'subsystem' => 'playlist',
+                            'operation' => 'prepare_backend',
+                            'outcome' => 'forced',
+                            'command' => self::ROUTE,
                             'user' => $userContext->name,
                             'backend' => $backendName,
+                            'reason' => 'explicitly_selected',
+                            'import_enabled' => $importEnabled,
+                            'export_enabled' => $exportEnabled,
                         ],
                     );
                 } else {
                     $this->logger->info(
-                        "PLAYLIST: Ignoring '{user}@{backend}'. Playlist sync disabled.",
+                        "Skipping '{user}@{backend}': playlist sync is disabled.",
                         [
+                            'event_name' => 'playlist.backend.skipped',
+                            'subsystem' => 'playlist',
+                            'operation' => 'prepare_backend',
+                            'outcome' => 'skipped',
+                            'command' => self::ROUTE,
                             'user' => $userContext->name,
                             'backend' => $backendName,
+                            'reason' => 'sync_disabled',
+                            'import_enabled' => $importEnabled,
+                            'export_enabled' => $exportEnabled,
                         ],
                     );
                     continue;
@@ -329,11 +431,17 @@ class PlaylistCommand extends Command
             if (null === Config::get("supported.{$backendType}")) {
                 $stats['unsupported']++;
                 $this->logger->warning(
-                    "PLAYLIST: Ignoring '{user}@{backend}'. Unsupported backend type '{type}'.",
+                    "Skipping '{user}@{backend}': backend type '{backend_type}' is unsupported.",
                     [
+                        'event_name' => 'playlist.backend.skipped',
+                        'subsystem' => 'playlist',
+                        'operation' => 'prepare_backend',
+                        'outcome' => 'skipped',
+                        'command' => self::ROUTE,
                         'user' => $userContext->name,
                         'backend' => $backendName,
-                        'type' => $backendType,
+                        'backend_type' => $backendType,
+                        'reason' => 'unsupported_type',
                     ],
                 );
                 continue;
@@ -343,11 +451,17 @@ class PlaylistCommand extends Command
             if (false === filter_var($url, FILTER_VALIDATE_URL)) {
                 $stats['invalid_url']++;
                 $this->logger->warning(
-                    "PLAYLIST: Ignoring '{user}@{backend}'. Invalid URL '{url}'.",
+                    "Skipping '{user}@{backend}': URL '{url}' is invalid.",
                     [
+                        'event_name' => 'playlist.backend.skipped',
+                        'subsystem' => 'playlist',
+                        'operation' => 'prepare_backend',
+                        'outcome' => 'skipped',
+                        'command' => self::ROUTE,
                         'user' => $userContext->name,
                         'backend' => $backendName,
                         'url' => $url,
+                        'reason' => 'invalid_url',
                     ],
                 );
                 continue;
@@ -369,23 +483,33 @@ class PlaylistCommand extends Command
             } catch (Throwable $e) {
                 $stats['failed']++;
                 $this->logger->error(
-                    "PLAYLIST: Failed to initialize '{user}@{backend}' client. '{error.message}' at '{error.file}:{error.line}'.",
-                    [
-                        'user' => $userContext->name,
-                        'backend' => $backendName,
-                        'error' => [
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                            'line' => $e->getLine(),
-                            'kind' => $e::class,
+                    ...lw(
+                        message: "Failed to initialize playlist client for '{user}@{backend}'.",
+                        context: [
+                            'event_name' => 'playlist.client.initialize.failed',
+                            'subsystem' => 'playlist',
+                            'operation' => 'prepare_backend',
+                            'outcome' => 'failed',
+                            'command' => self::ROUTE,
+                            'user' => $userContext->name,
+                            'backend' => $backendName,
+                            'backend_type' => $backendType,
+                            ...exception_log($e),
                         ],
-                    ],
+                        e: $e,
+                    ),
                 );
             }
         }
 
-        $this->logger->info("SYSTEM: Prepared playlist clients for '{user}'.", [
+        $this->logger->info("Prepared {accepted_count} playlist clients for '{user}'.", [
+            'event_name' => 'playlist.clients.selection.completed',
+            'subsystem' => 'playlist',
+            'operation' => 'prepare_backend',
+            'outcome' => 'completed',
+            'command' => self::ROUTE,
             'user' => $userContext->name,
+            'accepted_count' => count($clients),
             'selection' => [
                 'mode' => $this->resolveSelectionMode($selected, $exclude),
                 'backends' => $selected,

--- a/src/Commands/State/ValidateCommand.php
+++ b/src/Commands/State/ValidateCommand.php
@@ -142,14 +142,37 @@ class ValidateCommand extends Command
 
         $start_time = microtime(true);
 
+        $this->output(
+            Level::Notice,
+            'Validation started for {user_count} users.',
+            [
+                'event_name' => 'state.validate.started',
+                'subsystem' => 'state.validate',
+                'operation' => 'validate',
+                'outcome' => 'started',
+                'command' => self::ROUTE,
+                'user_count' => count($users),
+            ],
+            $logIO,
+        );
+
         foreach ($users as $userContext) {
             $userStart = microtime(true);
 
             $this->output(
                 Level::Notice,
-                "SYSTEM: Validating '{user}' local database metadata reference ids.",
+                "Validating local metadata references for '{user}'.",
                 [
+                    'event_name' => 'state.validate.user.started',
+                    'subsystem' => 'state.validate',
+                    'operation' => 'validate',
+                    'outcome' => 'started',
+                    'command' => self::ROUTE,
                     'user' => $userContext->name,
+                    'memory' => [
+                        'now' => get_memory_usage(),
+                        'peak' => get_peak_memory_usage(),
+                    ],
                 ],
                 $logIO,
             );
@@ -158,10 +181,15 @@ class ValidateCommand extends Command
 
             $this->output(
                 Level::Notice,
-                "SYSTEM: Completed '{user}' local database validation in '{duration}'s.",
+                "Completed validation for '{user}' in {duration_seconds}s.",
                 [
+                    'event_name' => 'state.validate.user.completed',
+                    'subsystem' => 'state.validate',
+                    'operation' => 'validate',
+                    'outcome' => 'completed',
+                    'command' => self::ROUTE,
                     'user' => $userContext->name,
-                    'duration' => round(microtime(true) - $userStart, 4),
+                    'duration_seconds' => round(microtime(true) - $userStart, 4),
                 ],
                 $logIO,
             );
@@ -169,9 +197,15 @@ class ValidateCommand extends Command
 
         $this->output(
             Level::Notice,
-            "SYSTEM: Completed local databases validation in '{duration}'s.",
+            'Validation completed for {user_count} users in {duration_seconds}s.',
             [
-                'duration' => round(microtime(true) - $start_time, 4),
+                'event_name' => 'state.validate.completed',
+                'subsystem' => 'state.validate',
+                'operation' => 'validate',
+                'outcome' => 'completed',
+                'command' => self::ROUTE,
+                'user_count' => count($users),
+                'duration_seconds' => round(microtime(true) - $start_time, 4),
             ],
             $logIO,
         );
@@ -194,6 +228,23 @@ class ValidateCommand extends Command
 
         $records = $userContext->db->getTotal();
 
+        $this->output(
+            Level::Notice,
+            "Loaded {record_count} local records for '{user}'.",
+            [
+                'event_name' => 'state.validate.records.loaded',
+                'subsystem' => 'state.validate',
+                'operation' => 'load_records',
+                'outcome' => 'completed',
+                'command' => self::ROUTE,
+                'user' => $userContext->name,
+                'record_count' => $records,
+                'backend_count' => count($clients),
+                'backends' => array_keys($clients),
+            ],
+            $logIO,
+        );
+
         if (null !== $progBar) {
             $progBar->progressStart($records);
             $progBar->newLine();
@@ -215,10 +266,16 @@ class ValidateCommand extends Command
                 if (count($item->getMetadata()) < 1) {
                     $this->output(
                         Level::Warning,
-                        "SYSTEM: No metadata found for item '{user}: #{id}' Removing record.",
+                        "Removing '#{id}' for '{user}': no backend metadata was stored.",
                         [
+                            'event_name' => 'state.validate.item.removed',
+                            'subsystem' => 'state.validate',
+                            'operation' => 'validate_item',
+                            'outcome' => 'removed',
+                            'command' => self::ROUTE,
                             'id' => $item->id,
                             'user' => $userContext->name,
+                            'reason' => 'missing_metadata',
                         ],
                         $logIO,
                     );
@@ -231,12 +288,17 @@ class ValidateCommand extends Command
 
                 $this->output(
                     Level::Debug,
-                    "SYSTEM: Validating '{user}: #{id}' - '{title}' reference ID for '{backends}'.",
+                    "Checking stored references for '{user}' item '#{id}: {title}'.",
                     [
+                        'event_name' => 'state.validate.item.started',
+                        'subsystem' => 'state.validate',
+                        'operation' => 'validate_item',
+                        'outcome' => 'started',
+                        'command' => self::ROUTE,
                         'id' => $item->id,
                         'user' => $userContext->name,
                         'title' => $item->getName(),
-                        'backends' => implode(', ', array_keys($meta)),
+                        'backends' => array_keys($meta),
                     ],
                     $logIO,
                 );
@@ -245,8 +307,13 @@ class ValidateCommand extends Command
                     $id = ag($metadata, iState::COLUMN_ID);
                     $this->output(
                         Level::Debug,
-                        "SYSTEM: Validating '{user}@{backend}: #{id} - {item_id}' '{title}' reference ID.",
+                        "Checking reference '{item_id}' for '{user}@{backend}' item '#{id}: {title}'.",
                         [
+                            'event_name' => 'state.validate.reference.started',
+                            'subsystem' => 'state.validate',
+                            'operation' => 'validate_reference',
+                            'outcome' => 'started',
+                            'command' => self::ROUTE,
                             'id' => $item->id,
                             'item_id' => $id,
                             'user' => $userContext->name,
@@ -259,11 +326,17 @@ class ValidateCommand extends Command
                     if (null === $id) {
                         $this->output(
                             Level::Notice,
-                            "SYSTEM: No reference ID found for item '{user}@{backend}: #{id}' Removing reference ID.",
+                            "Removing stored reference for '{user}@{backend}' item '#{id}': no backend id was saved.",
                             [
+                                'event_name' => 'state.validate.reference.removed',
+                                'subsystem' => 'state.validate',
+                                'operation' => 'validate_reference',
+                                'outcome' => 'removed',
+                                'command' => self::ROUTE,
                                 'id' => $item->id,
                                 'backend' => $backend,
                                 'user' => $userContext->name,
+                                'reason' => 'missing_reference_id',
                             ],
                             $logIO,
                         );
@@ -275,11 +348,17 @@ class ValidateCommand extends Command
                     if (null === ($clients[$backend] ?? null)) {
                         $this->output(
                             Level::Warning,
-                            "SYSTEM: '{user}: #{id}' has reference to '{backend}' which doesn't exists. Removing reference ID.",
+                            "Removing '{user}' item '#{id}' reference for '{backend}': backend is no longer configured.",
                             [
+                                'event_name' => 'state.validate.reference.removed',
+                                'subsystem' => 'state.validate',
+                                'operation' => 'validate_reference',
+                                'outcome' => 'removed',
+                                'command' => self::ROUTE,
                                 'id' => $item->id,
                                 'user' => $userContext->name,
                                 'backend' => $backend,
+                                'reason' => 'backend_missing',
                             ],
                             $logIO,
                         );
@@ -303,12 +382,18 @@ class ValidateCommand extends Command
                         if (false === $data) {
                             $this->output(
                                 Level::Notice,
-                                "SYSTEM: Request for '{user}@{backend}: #{id} - {item_id}' didnt return any data. Removing reference ID.",
+                                "Removing '{user}@{backend}' reference '{item_id}' from item '#{id}': backend returned no metadata.",
                                 [
+                                    'event_name' => 'state.validate.reference.removed',
+                                    'subsystem' => 'state.validate',
+                                    'operation' => 'validate_reference',
+                                    'outcome' => 'removed',
+                                    'command' => self::ROUTE,
                                     'id' => $item->id,
                                     'item_id' => $id,
                                     'user' => $userContext->name,
                                     'backend' => $backend,
+                                    'reason' => 'metadata_missing',
                                 ],
                                 $logIO,
                             );
@@ -320,14 +405,20 @@ class ValidateCommand extends Command
                         $sub_ref['found']++;
                     } catch (Throwable $e) {
                         $this->output(
-                            Level::Notice,
-                            "SYSTEM: Request for '{user}@{backend}: #{id} - {item_id}'. returned with error. {error}. Removing reference ID.",
+                            Level::Warning,
+                            "Removing '{user}@{backend}' reference '{item_id}' from item '#{id}': metadata lookup failed.",
                             [
+                                'event_name' => 'state.validate.reference.removed',
+                                'subsystem' => 'state.validate',
+                                'operation' => 'validate_reference',
+                                'outcome' => 'removed',
+                                'command' => self::ROUTE,
                                 'id' => $item->id,
                                 'item_id' => $id,
                                 'user' => $userContext->name,
                                 'backend' => $backend,
-                                'error' => $e->getMessage(),
+                                'reason' => 'metadata_lookup_failed',
+                                ...exception_log($e),
                             ],
                             $logIO,
                         );
@@ -341,10 +432,16 @@ class ValidateCommand extends Command
                 if (count($item->metadata) < 1) {
                     $this->output(
                         Level::Notice,
-                        "SYSTEM: Item '{user}: #{id}' no longer have any reference ID. Removing record.",
+                        "Removing '#{id}' for '{user}': no backend references remain.",
                         [
+                            'event_name' => 'state.validate.item.removed',
+                            'subsystem' => 'state.validate',
+                            'operation' => 'validate_item',
+                            'outcome' => 'removed',
+                            'command' => self::ROUTE,
                             'id' => $item->id,
                             'user' => $userContext->name,
+                            'reason' => 'no_references_remaining',
                         ],
                         $logIO,
                     );
@@ -366,8 +463,14 @@ class ValidateCommand extends Command
                     if (0 === ($progressUpdate % 500)) {
                         $this->output(
                             Level::Info,
-                            "SYSTEM: Processed '{progress}/{total}' %{percent}.",
+                            "Validated {progress}/{total} records ({percent}%) for '{user}'.",
                             [
+                                'event_name' => 'state.validate.progress',
+                                'subsystem' => 'state.validate',
+                                'operation' => 'validate',
+                                'outcome' => 'running',
+                                'command' => self::ROUTE,
+                                'user' => $userContext->name,
                                 'progress' => number_format($progressUpdate),
                                 'total' => $recordsCount,
                                 'percent' => round(($progressUpdate / $records) * 100, 3),
@@ -400,11 +503,17 @@ class ValidateCommand extends Command
     private function renderStatus(iOutput $output): void
     {
         foreach ($this->perRun as $user => $data) {
-            $this->logger->notice("User '{user}' local database, had {u} updated, {r} removed, {n} no change.", [
+            $this->logger->notice("Validation summary for '{user}': updated {updated_count}, removed {removed_count}, unchanged {unchanged_count}.", [
+                'event_name' => 'state.validate.summary',
+                'subsystem' => 'state.validate',
+                'operation' => 'summarize',
+                'outcome' => 'completed',
+                'command' => self::ROUTE,
                 'user' => $user,
-                'u' => $data['updated'],
-                'r' => $data['removed'],
-                'n' => $data['no_change'],
+                'updated_count' => $data['updated'],
+                'removed_count' => $data['removed'],
+                'unchanged_count' => $data['no_change'],
+                'backends' => $data['backends'],
             ]);
 
             $tbl = [];
@@ -414,9 +523,9 @@ class ValidateCommand extends Command
             foreach ($data['backends'] as $backend => $backendData) {
                 $i++;
                 $tbl[] = [
-                    'Backend' => $backend,
-                    'Reference Found' => $backendData['found'],
-                    'Reference Removed' => $backendData['removed'],
+                    'backend' => $backend,
+                    'reference_found' => $backendData['found'],
+                    'reference_removed' => $backendData['removed'],
                 ];
                 if ($i < $total) {
                     $tbl[] = new TableSeparator();

--- a/src/Commands/System/BenchmarkDirectMapperCommand.php
+++ b/src/Commands/System/BenchmarkDirectMapperCommand.php
@@ -161,6 +161,7 @@ final class BenchmarkDirectMapperCommand extends Command
      */
     protected function runCommand(iInput $input, iOutput $output): int
     {
+        $startedAt = microtime(true);
         $memoryLimitOpt = $input->getOption('memory-limit');
 
         if (null !== $memoryLimitOpt && '' !== (string) $memoryLimitOpt) {
@@ -352,7 +353,7 @@ final class BenchmarkDirectMapperCommand extends Command
             }
         }
 
-        if (null !== ($reportPath = $this->storeReport($report, $lines, $benchDir))) {
+        if (null !== ($reportPath = $this->storeReport($report, $lines, $benchDir, $startedAt))) {
             $lines[] = '';
             $lines[] = 'Saved: ' . $reportPath;
         }
@@ -364,11 +365,15 @@ final class BenchmarkDirectMapperCommand extends Command
         return self::SUCCESS;
     }
 
-    private function storeReport(array $report, array $lines, string $benchDir): ?string
+    private function storeReport(array $report, array $lines, string $benchDir, float $startedAt): ?string
     {
         if (false === is_dir($benchDir)) {
             if (false === @mkdir($benchDir, 0o755, true) && false === is_dir($benchDir)) {
-                $this->logger->warning("BenchmarkDirectMapperCommand: Unable to create '{path}' directory.", [
+                $this->logger->warning("Unable to create benchmark report directory '{path}'.", [
+                    'event_name' => 'benchmark.report.create_failed',
+                    'subsystem' => 'benchmark',
+                    'operation' => 'store_report',
+                    'outcome' => 'failed',
                     'path' => $benchDir,
                 ]);
                 return null;
@@ -387,11 +392,25 @@ final class BenchmarkDirectMapperCommand extends Command
         $content = implode(PHP_EOL, $lines) . PHP_EOL;
 
         if (false === @file_put_contents($path, $content)) {
-            $this->logger->warning("BenchmarkDirectMapperCommand: Unable to write report '{path}'.", [
+            $this->logger->warning("Unable to write benchmark report '{path}'.", [
+                'event_name' => 'benchmark.report.create_failed',
+                'subsystem' => 'benchmark',
+                'operation' => 'store_report',
+                'outcome' => 'failed',
                 'path' => $path,
             ]);
             return null;
         }
+
+        $this->logger->notice("Benchmark report saved to '{path}' in {duration_seconds}s.", [
+            'event_name' => 'benchmark.report.created',
+            'subsystem' => 'benchmark',
+            'operation' => 'store_report',
+            'outcome' => 'completed',
+            'command' => self::ROUTE,
+            'path' => $path,
+            'duration_seconds' => round(microtime(true) - $startedAt, 4),
+        ]);
 
         return $path;
     }
@@ -409,15 +428,26 @@ final class BenchmarkDirectMapperCommand extends Command
                 return $path;
             }
 
-            $this->logger->warning("BenchmarkDirectMapperCommand: Compare path '{path}' does not exist.", [
+            $this->logger->warning("Benchmark baseline '{path}' does not exist.", [
+                'event_name' => 'benchmark.compare.failed',
+                'subsystem' => 'benchmark',
+                'operation' => 'compare',
+                'outcome' => 'failed',
+                'reason' => 'baseline_not_found',
                 'path' => $path,
+                'baseline' => $path,
             ]);
             return null;
         }
 
         $latest = $this->findLatestReport($benchDir);
         if (null === $latest) {
-            $this->logger->notice("BenchmarkDirectMapperCommand: No prior reports found in '{path}'.", [
+            $this->logger->notice("No prior benchmark reports found in '{path}'.", [
+                'event_name' => 'benchmark.compare.skipped',
+                'subsystem' => 'benchmark',
+                'operation' => 'compare',
+                'outcome' => 'skipped',
+                'reason' => 'baseline_not_found',
                 'path' => $benchDir,
             ]);
         }

--- a/src/Commands/System/DiffCommand.php
+++ b/src/Commands/System/DiffCommand.php
@@ -110,24 +110,34 @@ final class DiffCommand extends Command
 
         // -- source A.
         $mapper1 = new RestoreMapper($this->logger, $a);
-        $this->logger->info("Loading source A '{file}' into memory.", ['file' => $a]);
         $time = microtime(true);
         $mapper1->loadData();
         $end = microtime(true);
-        $this->logger->info("Finished parsing data from source A '{file}' in '{time}s'.", [
-            'file' => $a,
-            'time' => round($end - $time, 2),
+        $this->logger->info("Loaded diff source '{source}' from '{path}' with {entity_count} entities.", [
+            'event_name' => 'system.diff.source.loaded',
+            'subsystem' => 'system.diff',
+            'operation' => 'load_source',
+            'outcome' => 'completed',
+            'source' => 'a',
+            'path' => $a,
+            'entity_count' => $mapper1->getObjectsCount(),
+            'duration_seconds' => round($end - $time, 4),
         ]);
 
         // -- source B.
         $mapper2 = new RestoreMapper($this->logger, $b);
-        $this->logger->info("Loading source B '{file}' into memory.", ['file' => $b]);
         $time = microtime(true);
         $mapper2->loadData();
         $end = microtime(true);
-        $this->logger->info("Finished parsing data from source B '{file}' in '{time}s'.", [
-            'file' => $b,
-            'time' => round($end - $time, 2),
+        $this->logger->info("Loaded diff source '{source}' from '{path}' with {entity_count} entities.", [
+            'event_name' => 'system.diff.source.loaded',
+            'subsystem' => 'system.diff',
+            'operation' => 'load_source',
+            'outcome' => 'completed',
+            'source' => 'b',
+            'path' => $b,
+            'entity_count' => $mapper2->getObjectsCount(),
+            'duration_seconds' => round($end - $time, 4),
         ]);
 
         $this->logger->notice("Comparing '{memory}' of data. Please wait.", ['memory' => get_memory_usage()]);
@@ -204,12 +214,7 @@ final class DiffCommand extends Command
 
     private function saveContent(array $data, string $file, string $filter, string $source): void
     {
-        $this->logger->notice("Saving the difference 'Source: {source}, filter: {filter}' to '{file}'.", [
-            'file' => $file,
-            'source' => $source,
-            'filter' => $filter,
-        ]);
-
+        $start = microtime(true);
         $fp = Stream::make($file, 'wb');
         $fp->write('[');
 
@@ -231,6 +236,18 @@ final class DiffCommand extends Command
         $fp->seek(-1, SEEK_END);
         $fp->write(PHP_EOL . ']');
         $fp->close();
+
+        $this->logger->notice("Saved diff output to '{path}'.", [
+            'event_name' => 'system.diff.output.saved',
+            'subsystem' => 'system.diff',
+            'operation' => 'save_output',
+            'outcome' => 'completed',
+            'path' => $file,
+            'source' => $source,
+            'filter' => $filter,
+            'entity_count' => count($data),
+            'duration_seconds' => round(microtime(true) - $start, 4),
+        ]);
     }
 
     private function processEntity(iState $entity): string

--- a/src/Commands/System/LogsCommand.php
+++ b/src/Commands/System/LogsCommand.php
@@ -9,17 +9,16 @@ use App\Command;
 use App\Libs\Attributes\Route\Cli;
 use App\Libs\Config;
 use App\Libs\Exceptions\InvalidArgumentException;
+use App\Libs\Extends\ConsoleLogFormatter;
 use LimitIterator;
 use SplFileObject;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
-use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Yaml\Yaml;
-use Throwable;
 
 /**
  * Class LogsCommand.
@@ -30,6 +29,8 @@ use Throwable;
 final class LogsCommand extends Command
 {
     public const string ROUTE = 'system:logs';
+
+    private ?ConsoleLogFormatter $logFormatter = null;
 
     /**
      * @var array Constant array containing names of supported log files.
@@ -223,7 +224,7 @@ final class LogsCommand extends Command
                         $buffer .= $chunk;
                     }
 
-                    $lines = preg_split('/\R/', $buffer);
+                    $lines = preg_split('/\r\n|\r|\n/', $buffer);
                     if (false === $lines) {
                         $lines = [];
                     }
@@ -435,7 +436,9 @@ final class LogsCommand extends Command
             return;
         }
 
-        $output->writeln($this->formatEventLine($entry));
+        $this->logFormatter ??= new ConsoleLogFormatter();
+
+        $output->writeln($this->logFormatter->format($entry));
     }
 
     /**
@@ -468,113 +471,6 @@ final class LogsCommand extends Command
         }
 
         return $payload;
-    }
-
-    /**
-     * @param array<string,mixed> $entry
-     */
-    private function formatEventLine(array $entry): string
-    {
-        $severity = strtoupper((string) ag($entry, 'level', '-'));
-        $severityText = OutputFormatter::escape($severity);
-        $message = $this->messageText($entry);
-        $severityColor = $this->severityColor((string) ag($entry, 'level', ''), $message);
-
-        if (null !== $severityColor) {
-            $severityText = sprintf('<fg=%s;options=bold>%s</>', $severityColor, $severityText);
-        } else {
-            $severityText = sprintf('<options=bold>%s</>', $severityText);
-        }
-
-        return sprintf(
-            '<comment>%s</comment> <info>%s</info> %s <fg=cyan>%s</> %s',
-            OutputFormatter::escape($this->formatTimestamp((string) ag($entry, ['datetime', 'date'], '-'))),
-            OutputFormatter::escape($this->hostname($entry)),
-            $severityText,
-            OutputFormatter::escape((string) ag($entry, ['logger', 'channel'], '-')),
-            OutputFormatter::escape($message),
-        );
-    }
-
-    /**
-     * @param array<string,mixed> $entry
-     */
-    private function hostname(array $entry): string
-    {
-        $value = ag(
-            $entry,
-            [
-                'fields.structured.request.name',
-                'fields.hostname',
-                'fields.route.ip',
-                'fields.task_id',
-                'fields.command',
-                'fields.user',
-                'fields.backend',
-                'fields.cli.stream',
-                'source.module',
-                'process.name',
-                'logger',
-                'channel',
-            ],
-            '-',
-        );
-
-        return '' !== trim((string) $value) ? trim((string) $value) : '-';
-    }
-
-    /**
-     * @param array<string,mixed> $entry
-     */
-    private function messageText(array $entry): string
-    {
-        $message = trim((string) ag($entry, ['message', 'text'], '-'));
-
-        if ('' === $message) {
-            return '-';
-        }
-
-        if (null !== ($exception = ag($entry, 'exception_message')) && '' !== trim((string) $exception)) {
-            return $message . ' [' . trim((string) $exception) . ']';
-        }
-
-        return $message;
-    }
-
-    private function formatTimestamp(string $value): string
-    {
-        if ('' === trim($value)) {
-            return '-';
-        }
-
-        try {
-            return make_date($value)->format('m/d, H:i:s');
-        } catch (Throwable) {
-            return $value;
-        }
-    }
-
-    private function severityColor(string $severity, string $message): ?string
-    {
-        $value = strtolower($severity . ' ' . $message);
-
-        if (1 === preg_match('/(critical|crit|alert|error|err|fatal|panic|exception|failed)/', $value)) {
-            return 'red';
-        }
-
-        if (1 === preg_match('/(warning|warn|notice|noti|deprecated)/', $value)) {
-            return 'yellow';
-        }
-
-        if (1 === preg_match('/(success|started|listening|connected|ready|complete|done)/', $value)) {
-            return 'green';
-        }
-
-        if (1 === preg_match('/(info|inf|debug|deb|trace)/', $value)) {
-            return 'cyan';
-        }
-
-        return null;
     }
 
     private function getDisplayMode(InputInterface $input): string

--- a/src/Commands/System/LogsCommand.php
+++ b/src/Commands/System/LogsCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Commands\System;
 
+use App\API\Logs\Index as LogsIndex;
 use App\Command;
 use App\Libs\Attributes\Route\Cli;
 use App\Libs\Config;
@@ -12,10 +13,13 @@ use LimitIterator;
 use SplFileObject;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Yaml\Yaml;
+use Throwable;
 
 /**
  * Class LogsCommand.
@@ -169,16 +173,15 @@ final class LogsCommand extends Command
 
         $limit = (int) $input->getOption('limit');
 
-        $file = r(text: Config::get('tmpDir') . '/logs/{type}.{date}.log', context: [
-            'type' => $type,
-            'date' => $date,
-        ]);
-
-        if (false === file_exists($file)) {
+        if (null === ($file = $this->resolveLogFile($type, $date))) {
             $output->writeln(
                 sprintf(
                     '<info>Log file [%s] does not exist or is empty. This means it has been pruned, the date is incorrect or nothing has written to that file yet.</info>',
-                    after($file, dirname(Config::get('tmpDir'))),
+                    r('logs/{type}.{date}.{extension}', [
+                        'type' => $type,
+                        'date' => $date,
+                        'extension' => 'jsonl',
+                    ]),
                 ),
             );
             return self::SUCCESS;
@@ -210,11 +213,31 @@ final class LogsCommand extends Command
 
                     fseek($f, $lastPos);
 
+                    $buffer = '';
                     while (!feof($f)) {
-                        $buffer = fread($f, 4096);
-                        $output->write((string) $buffer);
-                        flush();
+                        $chunk = fread($f, 4096);
+                        if (false === $chunk || '' === $chunk) {
+                            continue;
+                        }
+
+                        $buffer .= $chunk;
                     }
+
+                    $lines = preg_split('/\R/', $buffer);
+                    if (false === $lines) {
+                        $lines = [];
+                    }
+
+                    foreach ($lines as $line) {
+                        $line = trim((string) $line);
+                        if ('' === $line) {
+                            continue;
+                        }
+
+                        $this->renderLogLine($line, $input, $output);
+                    }
+
+                    flush();
 
                     $lastPos = ftell($f);
 
@@ -247,7 +270,7 @@ final class LogsCommand extends Command
                 continue;
             }
 
-            $output->writeln($line);
+            $this->renderLogLine($line, $input, $output);
         }
 
         return self::SUCCESS;
@@ -269,24 +292,32 @@ final class LogsCommand extends Command
 
         $isTable = $input->getOption('output') === 'table';
 
-        foreach (glob($path . '/*.*.log') as $file) {
-            preg_match('/(\w+)\.(\w+)\.log/i', basename($file), $matches);
-
-            $size = filesize($file);
-
-            $builder = [
-                'type' => $matches[1] ?? '??',
-                'tag' => $matches[2] ?? '??',
-                'size' => $isTable ? fsize($size) : $size,
-                'modified' => make_date(filemtime($file))->format('Y-m-d H:i:s T'),
-            ];
-
-            if (!$isTable) {
-                $builder['file'] = $file;
-                $builder['modified'] = make_date(filemtime($file));
+        foreach (['*.*.jsonl'] as $pattern) {
+            $files = glob($path . '/' . $pattern);
+            if (false === $files) {
+                continue;
             }
 
-            $list[] = $builder;
+            foreach ($files as $file) {
+                preg_match('/(\w+)\.(\w+)\.(jsonl)/i', basename($file), $matches);
+
+                $size = filesize($file);
+
+                $builder = [
+                    'type' => $matches[1] ?? '??',
+                    'tag' => $matches[2] ?? '??',
+                    'format' => $matches[3] ?? '??',
+                    'size' => $isTable ? fsize($size) : $size,
+                    'modified' => make_date(filemtime($file))->format('Y-m-d H:i:s T'),
+                ];
+
+                if (!$isTable) {
+                    $builder['file'] = $file;
+                    $builder['modified'] = make_date(filemtime($file));
+                }
+
+                $list[] = $builder;
+            }
         }
 
         $this->displayContent($list, $output, $input->getOption('output'));
@@ -351,6 +382,206 @@ final class LogsCommand extends Command
         $file->openFile('w');
 
         return self::SUCCESS;
+    }
+
+    private function resolveLogFile(string $type, string $date): ?string
+    {
+        $file = r(text: Config::get('tmpDir') . '/logs/{type}.{date}.jsonl', context: [
+            'type' => $type,
+            'date' => $date,
+        ]);
+
+        return true === file_exists($file) ? $file : null;
+    }
+
+    private function renderLogLine(string $line, InputInterface $input, OutputInterface $output): void
+    {
+        if ($input->hasOption('jsonl') && true === (bool) $input->getOption('jsonl')) {
+            $output->writeln($line);
+            return;
+        }
+
+        if (null !== ($jsonl = $this->parseJsonlLine($line))) {
+            if ('' === trim((string) ag($jsonl, 'message', ''))) {
+                return;
+            }
+
+            $this->writeStructuredEntry($jsonl, $input, $output);
+            return;
+        }
+
+        $this->writeStructuredEntry(LogsIndex::formatLog($line), $input, $output);
+    }
+
+    /**
+     * @param array<string,mixed> $entry
+     */
+    private function writeStructuredEntry(array $entry, InputInterface $input, OutputInterface $output): void
+    {
+        $mode = $this->getDisplayMode($input);
+
+        if ('json' === $mode) {
+            $json = json_encode(
+                $entry,
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_IGNORE,
+            );
+
+            $output->writeln(false === $json ? 'null' : $json);
+            return;
+        }
+
+        if ('yaml' === $mode) {
+            $output->writeln(trim(Yaml::dump(input: $entry, inline: 8, indent: 2)));
+            return;
+        }
+
+        $output->writeln($this->formatEventLine($entry));
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function parseJsonlLine(string $line): ?array
+    {
+        $payload = json_decode($line, true, 512, JSON_INVALID_UTF8_IGNORE);
+
+        if (!is_array($payload)) {
+            return null;
+        }
+
+        foreach (['id', 'datetime', 'level', 'message'] as $required) {
+            if (false === array_key_exists($required, $payload)) {
+                return null;
+            }
+
+            if ('message' === $required) {
+                continue;
+            }
+
+            if ('' === trim((string) $payload[$required])) {
+                return null;
+            }
+        }
+
+        if (!array_key_exists('logger', $payload) && !array_key_exists('channel', $payload)) {
+            return null;
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param array<string,mixed> $entry
+     */
+    private function formatEventLine(array $entry): string
+    {
+        $severity = strtoupper((string) ag($entry, 'level', '-'));
+        $severityText = OutputFormatter::escape($severity);
+        $message = $this->messageText($entry);
+        $severityColor = $this->severityColor((string) ag($entry, 'level', ''), $message);
+
+        if (null !== $severityColor) {
+            $severityText = sprintf('<fg=%s;options=bold>%s</>', $severityColor, $severityText);
+        } else {
+            $severityText = sprintf('<options=bold>%s</>', $severityText);
+        }
+
+        return sprintf(
+            '<comment>%s</comment> <info>%s</info> %s <fg=cyan>%s</> %s',
+            OutputFormatter::escape($this->formatTimestamp((string) ag($entry, ['datetime', 'date'], '-'))),
+            OutputFormatter::escape($this->hostname($entry)),
+            $severityText,
+            OutputFormatter::escape((string) ag($entry, ['logger', 'channel'], '-')),
+            OutputFormatter::escape($message),
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $entry
+     */
+    private function hostname(array $entry): string
+    {
+        $value = ag(
+            $entry,
+            [
+                'fields.structured.request.name',
+                'fields.hostname',
+                'fields.route.ip',
+                'fields.task_id',
+                'fields.command',
+                'fields.user',
+                'fields.backend',
+                'fields.cli.stream',
+                'source.module',
+                'process.name',
+                'logger',
+                'channel',
+            ],
+            '-',
+        );
+
+        return '' !== trim((string) $value) ? trim((string) $value) : '-';
+    }
+
+    /**
+     * @param array<string,mixed> $entry
+     */
+    private function messageText(array $entry): string
+    {
+        $message = trim((string) ag($entry, ['message', 'text'], '-'));
+
+        if ('' === $message) {
+            return '-';
+        }
+
+        if (null !== ($exception = ag($entry, 'exception_message')) && '' !== trim((string) $exception)) {
+            return $message . ' [' . trim((string) $exception) . ']';
+        }
+
+        return $message;
+    }
+
+    private function formatTimestamp(string $value): string
+    {
+        if ('' === trim($value)) {
+            return '-';
+        }
+
+        try {
+            return make_date($value)->format('m/d, H:i:s');
+        } catch (Throwable) {
+            return $value;
+        }
+    }
+
+    private function severityColor(string $severity, string $message): ?string
+    {
+        $value = strtolower($severity . ' ' . $message);
+
+        if (1 === preg_match('/(critical|crit|alert|error|err|fatal|panic|exception|failed)/', $value)) {
+            return 'red';
+        }
+
+        if (1 === preg_match('/(warning|warn|notice|noti|deprecated)/', $value)) {
+            return 'yellow';
+        }
+
+        if (1 === preg_match('/(success|started|listening|connected|ready|complete|done)/', $value)) {
+            return 'green';
+        }
+
+        if (1 === preg_match('/(info|inf|debug|deb|trace)/', $value)) {
+            return 'cyan';
+        }
+
+        return null;
+    }
+
+    private function getDisplayMode(InputInterface $input): string
+    {
+        $mode = (string) $input->getOption('output');
+
+        return in_array($mode, self::DISPLAY_OUTPUT, true) ? $mode : self::DISPLAY_OUTPUT[0];
     }
 
     /**

--- a/src/Commands/System/PruneCommand.php
+++ b/src/Commands/System/PruneCommand.php
@@ -19,6 +19,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
+use function exception_log;
+
 #[Cli(command: self::ROUTE)]
 class PruneCommand extends Command
 {
@@ -236,11 +238,14 @@ class PruneCommand extends Command
 
     protected function reportPrunerError(array $pruner, Throwable $e, OutputInterface $output): void
     {
-        $this->logger->error("Skipping pruner '{name}'. {message}", [
-            'name' => ag($pruner, 'name', 'unknown'),
-            'message' => $e->getMessage(),
-            'exception' => $e::class,
-            'trace' => $e->getTrace(),
+        $this->logger->error("Pruner '{pruner}' failed for '{path}'.", [
+            'event_name' => 'system.prune.pruner.failed',
+            'subsystem' => 'system.prune',
+            'operation' => 'prune',
+            'outcome' => 'failed',
+            'pruner' => ag($pruner, 'name', 'unknown'),
+            'path' => $this->stringifyCallable(ag($pruner, 'callable')),
+            ...exception_log($e),
         ]);
 
         $output->writeln(r("<error>Skipping pruner '{name}'. {message}</error>", [

--- a/src/Commands/System/ReportCommand.php
+++ b/src/Commands/System/ReportCommand.php
@@ -433,7 +433,7 @@ final class ReportCommand extends Command
      */
     private function handleLog(string $type, string|int $date, int|string $limit): void
     {
-        $logFile = Config::get('tmpDir') . '/logs/' . r('{type}.{date}.log', ['type' => $type, 'date' => $date]);
+        $logFile = Config::get('tmpDir') . '/logs/' . r('{type}.{date}.jsonl', ['type' => $type, 'date' => $date]);
 
         $this->filter(r('[ <value>{logFile}</value> ]' . PHP_EOL, [
             'logFile' => after($logFile, Config::get('tmpDir')),

--- a/src/Commands/System/TasksCommand.php
+++ b/src/Commands/System/TasksCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Commands\System;
 
+use App\API\Logs\Index as LogsIndex;
 use App\Command;
 use App\Commands\Events\DispatchCommand;
 use App\Libs\Attributes\Route\Cli;
@@ -11,6 +12,7 @@ use App\Libs\Config;
 use App\Libs\Container;
 use App\Libs\Events\DataEvent;
 use App\Libs\Extends\ConsoleOutput;
+use App\Libs\Extends\JsonlFormatter;
 use App\Libs\LogSuppressor;
 use App\Libs\Stream;
 use App\Model\Events\EventListener;
@@ -20,6 +22,7 @@ use Closure;
 use Cron\CronExpression;
 use DateInterval;
 use Exception;
+use Monolog\Level;
 use Psr\Log\LoggerInterface as iLogger;
 use Psr\SimpleCache\CacheInterface as iCache;
 use Symfony\Component\Console\Completion\CompletionInput;
@@ -52,6 +55,7 @@ final class TasksCommand extends Command
 
     private array $logs = [];
     private array $taskOutput = [];
+    private array $logContext = [];
 
     private ?Closure $writer = null;
     private ?Closure $clear = null;
@@ -253,7 +257,7 @@ final class TasksCommand extends Command
                     $lastSave = $timeNow;
                 }
 
-                $event->addLog($msg);
+                $event->addLog(rtrim((string) $msg, "\r\n"));
 
                 if ($timeNow >= $lastSave) {
                     ($this->save)();
@@ -355,7 +359,7 @@ final class TasksCommand extends Command
         if ($input->getOption('save-log') && count($this->logs) >= 1) {
             try {
                 $stream = new Stream(Config::get('tasks.logfile'), 'a');
-                $stream->write(preg_replace('#\R+#', PHP_EOL, implode(PHP_EOL, $this->logs)) . PHP_EOL . PHP_EOL);
+                $stream->write(implode('', $this->logs));
                 $stream->close();
             } catch (Throwable $e) {
                 $this->write(
@@ -376,9 +380,20 @@ final class TasksCommand extends Command
 
     private function runTask(array $task, iInput $input, iOutput $output): int
     {
+        $this->logContext = [
+            'task_id' => (string) ag($task, 'name', ''),
+            'command' => (string) ag($task, 'command', ''),
+            'source' => 'task',
+        ];
+
         $cmd = [];
 
         $cmd[] = ROOT_PATH . '/bin/console';
+
+        if (true === $this->shouldUseJsonlChild($input)) {
+            $cmd[] = '--jsonl';
+        }
+
         $cmd[] = ag($task, 'command');
 
         if (null !== ($args = ag($task, 'args'))) {
@@ -395,33 +410,7 @@ final class TasksCommand extends Command
 
         $process->start(function ($std, $out) use ($input, $output) {
             assert($output instanceof ConsoleOutputInterface, 'Expected console output interface.');
-            $out = trim((string) $out);
-
-            if (empty($out)) {
-                return;
-            }
-
-            foreach (explode(PHP_EOL, $out) as $line) {
-                if (empty($line)) {
-                    continue;
-                }
-
-                $this->taskOutput[] = $line;
-            }
-
-            if (null !== $this->writer && false === $this->suppressor->isSuppressed($out)) {
-                try {
-                    ($this->writer)($out);
-                } catch (Throwable) {
-                    // Do nothing
-                }
-            }
-
-            if (!$input->hasOption('live') && $input->getOption('live')) {
-                return;
-            }
-
-            ('err' === $std ? $output->getErrorOutput() : $output)->writeln($out);
+            $this->captureProcessOutput($std, (string) $out, $input, $output);
         });
 
         if ($process->isRunning()) {
@@ -462,28 +451,72 @@ final class TasksCommand extends Command
             $event->event = self::NAME . '.' . $task['name'];
             $event->created_at = $started;
             $event->updated_at = $ended;
-            $event->logs[] = '--------------------------';
-            $event->logs[] = r('Task: {name} (Started: {start_date})', [
-                'name' => $task['name'],
-                'start_date' => $started->format('D, H:i:s T'),
-            ]);
-            $event->logs[] = r('Command: {cmd}', ['cmd' => $process->getCommandLine()]);
-            $event->logs[] = r('Exit Code: {code}:{status} (Ended: {end_date}) - Took {duration}s', [
-                'status' => 0 === $process->getExitCode() ? 'Success' : 'Failed',
-                'code' => $process->getExitCode() ?? self::INVALID,
-                'end_date' => $ended->format('D, H:i:s T'),
-                'duration' => $ended->getTimestamp() - $started->getTimestamp(),
-            ]);
-            $event->logs[] = '--------------------------';
+            $event->logs[] = new JsonlFormatter()->formatValues(
+                channel: 'task',
+                level: Level::Info,
+                message: r('run_task.{name}: {cmd} (Started: {start_date})', [
+                    'name' => $task['name'],
+                    'cmd' => $process->getCommandLine(),
+                    'start_date' => $started->format('D, H:i:s T'),
+                ]),
+                context: [
+                    'event_id' => (string) $event->id,
+                    'event' => $event->event,
+                    'task_id' => (string) $task['name'],
+                    'command' => (string) ag($task, 'command', ''),
+                    'source' => 'task',
+                ],
+            );
+
             if (count($this->taskOutput) < 1) {
                 if (0 === $process->getExitCode()) {
-                    $event->logs[] = 'Task completed successfully. And did not produce any output.';
+                    $event->logs[] = new JsonlFormatter()->formatValues(
+                        channel: 'task',
+                        level: Level::Info,
+                        message: 'Task completed successfully. And did not produce any output.',
+                        context: [
+                            'event_id' => (string) $event->id,
+                            'event' => $event->event,
+                            'task_id' => (string) $task['name'],
+                            'command' => (string) ag($task, 'command', ''),
+                            'source' => 'task',
+                        ],
+                    );
                 } else {
-                    $event->logs[] = 'Task failed to complete. And did not produce any output.';
+                    $event->logs[] = new JsonlFormatter()->formatValues(
+                        channel: 'task',
+                        level: Level::Error,
+                        message: 'Task failed to complete. And did not produce any output.',
+                        context: [
+                            'event_id' => (string) $event->id,
+                            'event' => $event->event,
+                            'task_id' => (string) $task['name'],
+                            'command' => (string) ag($task, 'command', ''),
+                            'source' => 'task',
+                        ],
+                    );
                 }
             } else {
                 $event->logs = array_merge($event->logs, array_slice($this->taskOutput, -200));
             }
+            $event->logs[] = new JsonlFormatter()->formatValues(
+                channel: 'task',
+                level: 0 === $process->getExitCode() ? Level::Info : Level::Error,
+                message: r('run_task.{name} ExitCode: {code}:{status} (Ended: {end_date}) - Took {duration}s', [
+                    'name' => $task['name'],
+                    'status' => 0 === $process->getExitCode() ? 'Success' : 'Failed',
+                    'code' => $process->getExitCode() ?? self::INVALID,
+                    'end_date' => $ended->format('D, H:i:s T'),
+                    'duration' => $ended->getTimestamp() - $started->getTimestamp(),
+                ]),
+                context: [
+                    'event_id' => (string) $event->id,
+                    'event' => $event->event,
+                    'task_id' => (string) $task['name'],
+                    'command' => (string) ag($task, 'command', ''),
+                    'source' => 'task',
+                ],
+            );
             $this->eventsRepo->save($event);
         }
 
@@ -499,18 +532,21 @@ final class TasksCommand extends Command
             }
         }
 
-        $this->write('--------------------------', $input, $output);
         $this->write(
-            r('Task: {name} (Started: {startDate})', [
+            r('run_task.{name}: {cmd} (Started: {startDate})', [
                 'name' => $task['name'],
+                'cmd' => $process->getCommandLine(),
                 'startDate' => $started->format('D, H:i:s T'),
             ]),
             $input,
             $output,
         );
-        $this->write(r('Command: {cmd}', ['cmd' => $process->getCommandLine()]), $input, $output);
+        foreach ($this->taskOutput as $line) {
+            $this->write($line, $input, $output);
+        }
         $this->write(
-            r('Exit Code: {code}:{status} (Ended: {end_date}) - Took {duration}s', [
+            r('run_task.{name}: ExitCode: {code}:{status} (Ended: {end_date}) - Took {duration}s', [
+                'name' => $task['name'],
                 'status' => 0 === $process->getExitCode() ? 'Success' : 'Failed',
                 'code' => $process->getExitCode() ?? self::INVALID,
                 'end_date' => $ended->format('D, H:i:s T'),
@@ -519,12 +555,6 @@ final class TasksCommand extends Command
             $input,
             $output,
         );
-        $this->write('--------------------------', $input, $output);
-        $this->write(' ' . PHP_EOL, $input, $output);
-
-        foreach ($this->taskOutput as $line) {
-            $this->write($line, $input, $output);
-        }
 
         $this->taskOutput = [];
 
@@ -533,9 +563,20 @@ final class TasksCommand extends Command
 
     private function run_command(string $command, array $args, iInput $input, iOutput $output): int
     {
+        $this->logContext = [
+            'task_id' => self::CNAME,
+            'command' => $command,
+            'source' => 'task',
+        ];
+
         $cmd = [];
 
         $cmd[] = ROOT_PATH . '/bin/console';
+
+        if (true === $this->shouldUseJsonlChild($input)) {
+            $cmd[] = '--jsonl';
+        }
+
         $cmd[] = $command;
 
         if (count($args) > 0) {
@@ -553,33 +594,7 @@ final class TasksCommand extends Command
 
         $process->start(function ($std, $out) use ($input, $output) {
             assert($output instanceof ConsoleOutputInterface, 'Expected console output interface.');
-            $out = trim((string) $out);
-
-            if (empty($out)) {
-                return;
-            }
-
-            foreach (explode(PHP_EOL, $out) as $line) {
-                if (empty($line)) {
-                    continue;
-                }
-
-                $this->taskOutput[] = $line;
-            }
-
-            if (null !== $this->writer && false === $this->suppressor->isSuppressed($out)) {
-                try {
-                    ($this->writer)($out);
-                } catch (Throwable) {
-                    // Do nothing
-                }
-            }
-
-            if (!$input->hasOption('live') && $input->getOption('live')) {
-                return;
-            }
-
-            ('err' === $std ? $output->getErrorOutput() : $output)->writeln($out);
+            $this->captureProcessOutput($std, (string) $out, $input, $output);
         });
 
         if ($process->isRunning()) {
@@ -673,17 +688,119 @@ final class TasksCommand extends Command
     private function write(string $text, iInput $input, iOutput $output, int $level = iOutput::OUTPUT_NORMAL): void
     {
         assert($output instanceof ConsoleOutput, 'Expected console output for task runner.');
-        $output->writeln($text, $level);
+        $output->writeln($this->formatTaskOutputLine($text), $level);
 
-        $message = $output->getLastMessage();
+        $stored = $this->formatTaskLogLine($text);
 
         if (null !== $this->writer) {
-            ($this->writer)($message);
+            ($this->writer)($stored);
         }
 
         if ($input->hasOption('save-log') && $input->getOption('save-log')) {
-            $this->logs[] = $message;
+            $this->logs[] = $stored;
         }
+    }
+
+    private function shouldUseJsonlChild(iInput $input): bool
+    {
+        if (true === $this->viaEvent) {
+            return true;
+        }
+
+        if ($input->hasOption('save-log') && true === (bool) $input->getOption('save-log')) {
+            return true;
+        }
+
+        return $input->hasOption('jsonl') && true === (bool) $input->getOption('jsonl');
+    }
+
+    private function captureProcessOutput(string $std, string $out, iInput $input, ConsoleOutputInterface $output): void
+    {
+        $out = trim($out);
+
+        if ('' === $out) {
+            return;
+        }
+
+        $lines = preg_split('/\R/', $out);
+        if (false === $lines) {
+            $lines = [];
+        }
+
+        foreach ($lines as $line) {
+            $line = trim((string) $line);
+
+            if ('' === $line) {
+                continue;
+            }
+
+            $this->taskOutput[] = $line;
+
+            if (null !== $this->writer && false === $this->suppressor->isSuppressed($line)) {
+                try {
+                    ($this->writer)($this->formatTaskLogLine($line));
+                } catch (Throwable) {
+                    // Do nothing
+                }
+            }
+
+            if (!$input->hasOption('live') || false === $input->getOption('live')) {
+                continue;
+            }
+
+            ('err' === $std ? $output->getErrorOutput() : $output)->writeln($this->formatTaskOutputLine($line));
+        }
+    }
+
+    private function formatTaskLogLine(string $line): string
+    {
+        if (true === JsonlFormatter::isJsonlRecord($line)) {
+            return rtrim($line, "\r\n") . PHP_EOL;
+        }
+
+        return new JsonlFormatter()->formatValues(
+            channel: 'task',
+            level: Level::Info,
+            message: $this->normalizeTaskMessage($line),
+            context: $this->logContext,
+        );
+    }
+
+    private function formatTaskOutputLine(string $line): string
+    {
+        if ('jsonl' === Config::get('console.output')) {
+            return $this->formatTaskLogLine($line);
+        }
+
+        if (false === JsonlFormatter::isJsonlRecord($line)) {
+            return $line;
+        }
+
+        $entry = LogsIndex::formatLog($line);
+        $parts = [];
+
+        if (null !== ($date = ag($entry, ['datetime', 'date']))) {
+            $parts[] = '[' . $date . ']';
+        }
+
+        if (null !== ($logger = ag($entry, 'logger')) && null !== ($entryLevel = ag($entry, 'level'))) {
+            $parts[] = $logger . '.' . strtoupper((string) $entryLevel) . ':';
+        } elseif (null !== ($logger = ag($entry, 'logger'))) {
+            $parts[] = $logger . ':';
+        } elseif (null !== ($entryLevel = ag($entry, 'level'))) {
+            $parts[] = strtoupper((string) $entryLevel) . ':';
+        }
+
+        $parts[] = (string) ag($entry, 'text', $line);
+
+        return implode(' ', array_values(array_filter($parts, static fn(mixed $value): bool => is_string($value) && '' !== trim($value))));
+    }
+
+    private function normalizeTaskMessage(string $line): string
+    {
+        $line = preg_replace('/\x1b\[[0-9;]*m/', '', $line) ?? $line;
+
+        return trim(strip_tags($line));
     }
 
     /**

--- a/src/Commands/System/TasksCommand.php
+++ b/src/Commands/System/TasksCommand.php
@@ -56,6 +56,7 @@ final class TasksCommand extends Command
     private array $logs = [];
     private array $taskOutput = [];
     private array $logContext = [];
+    private array $eventLogContext = [];
 
     private ?Closure $writer = null;
     private ?Closure $clear = null;
@@ -215,27 +216,33 @@ final class TasksCommand extends Command
         switch ($eventName) {
             case self::NAME:
                 if (null === ($name = ag($event->getData(), 'name'))) {
-                    $event->addLog(r('No task name was specified.'));
+                    $event->addLogEntry(Level::Error, 'No task name was specified.');
                     return $event;
                 }
 
                 $task = self::getTasks($name);
                 if (empty($task)) {
-                    $event->addLog(
-                        r("Invalid task '{name}'. There are no task with that name registered.", ['name' => $name]),
+                    $event->addLogEntry(
+                        Level::Error,
+                        "Invalid task '{task_id}'. There are no task with that name registered.",
+                        ['task_id' => $name],
                     );
                     return $event;
                 }
                 break;
             case self::CNAME:
                 if (null === ag($event->getData(), 'command')) {
-                    $event->addLog(r('No command name was specified.'));
+                    $event->addLogEntry(Level::Error, 'No command name was specified.');
                     return $event;
                 }
                 break;
         }
 
         try {
+            $this->eventLogContext = [
+                'event_id' => (string) $event->getEvent()->id,
+                'event' => $eventName,
+            ];
             $this->viaEvent = true;
 
             $input = new ArrayInput([], $this->getDefinition());
@@ -269,30 +276,39 @@ final class TasksCommand extends Command
             };
 
             if (self::CNAME === $eventName) {
-                $event->addLog(r("Task: Run '{name}'.", ['name' => $eventName]));
+                $event->addLogEntry(Level::Info, "Task: Run '{task_id}'.", [
+                    'task_id' => $eventName,
+                    'command' => ag($event->getData(), 'command'),
+                ]);
                 $exitCode = $this->run_command(
                     ag($event->getData(), 'command'),
                     ag($event->getData(), 'args', []),
                     $input,
                     Container::get(iOutput::class),
                 );
-                $event->addLog(r("Task: End '{name}' (Exit Code: {code})", [
-                    'name' => $eventName,
-                    'code' => $exitCode,
-                ]));
+                $event->addLogEntry(Level::Info, "Task: End '{task_id}' (Exit Code: {exit_code})", [
+                    'task_id' => $eventName,
+                    'command' => ag($event->getData(), 'command'),
+                    'exit_code' => $exitCode,
+                ]);
             }
 
             if (self::NAME === $eventName && !empty($task)) {
-                $event->addLog(r("Task: Run '{command}'.", ['command' => ag($task, 'command')]));
-                $exitCode = $this->runTask($task, $input, Container::get(iOutput::class));
-                $event->addLog(r("Task: End '{command}' (Exit Code: {code})", [
+                $event->addLogEntry(Level::Info, "Task: Run '{command}'.", [
+                    'task_id' => ag($task, 'name'),
                     'command' => ag($task, 'command'),
-                    'code' => $exitCode,
-                ]));
+                ]);
+                $exitCode = $this->runTask($task, $input, Container::get(iOutput::class));
+                $event->addLogEntry(Level::Info, "Task: End '{command}' (Exit Code: {exit_code})", [
+                    'task_id' => ag($task, 'name'),
+                    'command' => ag($task, 'command'),
+                    'exit_code' => $exitCode,
+                ]);
             }
         } finally {
             $this->needToSave = false;
             $this->writer = $this->clear = null;
+            $this->eventLogContext = [];
             $this->sleep = 1000;
             $this->viaEvent = false;
         }
@@ -396,7 +412,7 @@ final class TasksCommand extends Command
 
         $cmd[] = ag($task, 'command');
 
-        if (null !== ($args = ag($task, 'args'))) {
+        if (null !== ($args = ag($task, 'args')) && '' !== trim((string) $args)) {
             $cmd[] = $args;
         }
 
@@ -464,6 +480,8 @@ final class TasksCommand extends Command
                     'event' => $event->event,
                     'task_id' => (string) $task['name'],
                     'command' => (string) ag($task, 'command', ''),
+                    'cmd' => $process->getCommandLine(),
+                    'start_date' => $started->format('D, H:i:s T'),
                     'source' => 'task',
                 ],
             );
@@ -514,6 +532,10 @@ final class TasksCommand extends Command
                     'event' => $event->event,
                     'task_id' => (string) $task['name'],
                     'command' => (string) ag($task, 'command', ''),
+                    'exit_code' => $process->getExitCode() ?? self::INVALID,
+                    'status' => 0 === $process->getExitCode() ? 'Success' : 'Failed',
+                    'end_date' => $ended->format('D, H:i:s T'),
+                    'duration' => $ended->getTimestamp() - $started->getTimestamp(),
                     'source' => 'task',
                 ],
             );
@@ -762,7 +784,7 @@ final class TasksCommand extends Command
             channel: 'task',
             level: Level::Info,
             message: $this->normalizeTaskMessage($line),
-            context: $this->logContext,
+            context: array_replace($this->logContext, $this->eventLogContext),
         );
     }
 

--- a/src/Commands/System/TasksCommand.php
+++ b/src/Commands/System/TasksCommand.php
@@ -55,6 +55,7 @@ final class TasksCommand extends Command
 
     private array $logs = [];
     private array $taskOutput = [];
+    private array $processOutputBuffers = [];
     private array $logContext = [];
     private array $eventLogContext = [];
 
@@ -401,6 +402,7 @@ final class TasksCommand extends Command
             'command' => (string) ag($task, 'command', ''),
             'source' => 'task',
         ];
+        $this->processOutputBuffers = [];
 
         $cmd = [];
 
@@ -457,6 +459,10 @@ final class TasksCommand extends Command
                     }
                 }
             }
+        }
+
+        if (true === $output instanceof ConsoleOutputInterface) {
+            $this->flushProcessOutputBuffers($input, $output);
         }
 
         $ended = make_date();
@@ -590,6 +596,7 @@ final class TasksCommand extends Command
             'command' => $command,
             'source' => 'task',
         ];
+        $this->processOutputBuffers = [];
 
         $cmd = [];
 
@@ -647,6 +654,10 @@ final class TasksCommand extends Command
                     }
                 }
             }
+        }
+
+        if (true === $output instanceof ConsoleOutputInterface) {
+            $this->flushProcessOutputBuffers($input, $output);
         }
 
         $ended = make_date();
@@ -738,40 +749,78 @@ final class TasksCommand extends Command
 
     private function captureProcessOutput(string $std, string $out, iInput $input, ConsoleOutputInterface $output): void
     {
-        $out = trim($out);
-
         if ('' === $out) {
             return;
         }
 
-        $lines = preg_split('/\R/', $out);
-        if (false === $lines) {
-            $lines = [];
+        $this->processOutputBuffers[$std] = (string) ($this->processOutputBuffers[$std] ?? '') . $out;
+        $this->drainProcessOutputBuffer($std, $input, $output);
+    }
+
+    private function flushProcessOutputBuffers(iInput $input, ConsoleOutputInterface $output): void
+    {
+        foreach (array_keys($this->processOutputBuffers) as $std) {
+            $this->drainProcessOutputBuffer((string) $std, $input, $output, true);
         }
 
-        foreach ($lines as $line) {
-            $line = trim((string) $line);
+        $this->processOutputBuffers = [];
+    }
 
-            if ('' === $line) {
-                continue;
-            }
+    private function drainProcessOutputBuffer(string $std, iInput $input, ConsoleOutputInterface $output, bool $flush = false): void
+    {
+        $buffer = (string) ($this->processOutputBuffers[$std] ?? '');
 
-            $this->taskOutput[] = $line;
-
-            if (null !== $this->writer && false === $this->suppressor->isSuppressed($line)) {
-                try {
-                    ($this->writer)($this->formatTaskLogLine($line));
-                } catch (Throwable) {
-                    // Do nothing
-                }
-            }
-
-            if (!$input->hasOption('live') || false === $input->getOption('live')) {
-                continue;
-            }
-
-            ('err' === $std ? $output->getErrorOutput() : $output)->writeln($this->formatTaskOutputLine($line));
+        if ('' === $buffer) {
+            return;
         }
+
+        $offset = 0;
+
+        while (1 === preg_match('/\r\n|\r|\n/', $buffer, $matches, PREG_OFFSET_CAPTURE, $offset)) {
+            $match = $matches[0];
+            $line = substr($buffer, $offset, $match[1] - $offset);
+            $this->captureProcessOutputLine($std, $line, $input, $output);
+            $offset = $match[1] + strlen((string) $match[0]);
+        }
+
+        $remaining = substr($buffer, $offset);
+
+        if (true === $flush && '' !== $remaining) {
+            $this->captureProcessOutputLine($std, $remaining, $input, $output);
+            $remaining = '';
+        }
+
+        if ('' === $remaining) {
+            unset($this->processOutputBuffers[$std]);
+            return;
+        }
+
+        $this->processOutputBuffers[$std] = $remaining;
+    }
+
+    private function captureProcessOutputLine(string $std, string $line, iInput $input, ConsoleOutputInterface $output): void
+    {
+        $line = trim($line);
+
+        if ('' === $line) {
+            return;
+        }
+
+        $this->taskOutput[] = $line;
+
+        if (null !== $this->writer && false === $this->suppressor->isSuppressed($line)) {
+            try {
+                ($this->writer)($this->formatTaskLogLine($line));
+            } catch (Throwable) {
+                // Do nothing
+            }
+        }
+
+        if (!$input->hasOption('live') || false === $input->getOption('live')) {
+            return;
+        }
+
+        ('err' === $std ? $output->getErrorOutput() : $output)->writeln($this->formatTaskOutputLine($line));
     }
 
     private function formatTaskLogLine(string $line): string

--- a/src/Commands/System/TasksCommand.php
+++ b/src/Commands/System/TasksCommand.php
@@ -36,6 +36,8 @@ use Symfony\Component\Process\Exception\ExceptionInterface as ProcessException;
 use Symfony\Component\Process\Process;
 use Throwable;
 
+use function exception_log;
+
 /**
  * Class TasksCommand
  *
@@ -242,7 +244,7 @@ final class TasksCommand extends Command
         try {
             $this->eventLogContext = [
                 'event_id' => (string) $event->getEvent()->id,
-                'event' => $eventName,
+                'queued_event' => $eventName,
             ];
             $this->viaEvent = true;
 
@@ -277,9 +279,14 @@ final class TasksCommand extends Command
             };
 
             if (self::CNAME === $eventName) {
-                $event->addLogEntry(Level::Info, "Task: Run '{task_id}'.", [
+                $runStartedAt = make_date();
+                $event->addLogEntry(Level::Info, "Task '{task_id}' started: {command}.", [
                     'task_id' => $eventName,
                     'command' => ag($event->getData(), 'command'),
+                    'event_name' => 'task.run.started',
+                    'subsystem' => 'task',
+                    'operation' => 'run',
+                    'outcome' => 'started',
                 ]);
                 $exitCode = $this->run_command(
                     ag($event->getData(), 'command'),
@@ -287,24 +294,49 @@ final class TasksCommand extends Command
                     $input,
                     Container::get(iOutput::class),
                 );
-                $event->addLogEntry(Level::Info, "Task: End '{task_id}' (Exit Code: {exit_code})", [
-                    'task_id' => $eventName,
-                    'command' => ag($event->getData(), 'command'),
-                    'exit_code' => $exitCode,
-                ]);
+                $event->addLogEntry(
+                    0 === $exitCode ? Level::Info : Level::Error,
+                    "Task '{task_id}' {status} with exit code {exit_code} in {duration_seconds}s.",
+                    [
+                        'task_id' => $eventName,
+                        'command' => ag($event->getData(), 'command'),
+                        'exit_code' => $exitCode,
+                        'status' => 0 === $exitCode ? 'completed' : 'failed',
+                        'duration_seconds' => max(0, make_date()->getTimestamp() - $runStartedAt->getTimestamp()),
+                        'event_name' => 0 === $exitCode ? 'task.run.completed' : 'task.run.failed',
+                        'subsystem' => 'task',
+                        'operation' => 'run',
+                        'outcome' => 0 === $exitCode ? 'completed' : 'failed',
+                    ],
+                );
             }
 
             if (self::NAME === $eventName && !empty($task)) {
-                $event->addLogEntry(Level::Info, "Task: Run '{command}'.", [
+                $runStartedAt = make_date();
+                $event->addLogEntry(Level::Info, "Task '{task_id}' started: {command}.", [
                     'task_id' => ag($task, 'name'),
                     'command' => ag($task, 'command'),
+                    'event_name' => 'task.run.started',
+                    'subsystem' => 'task',
+                    'operation' => 'run',
+                    'outcome' => 'started',
                 ]);
                 $exitCode = $this->runTask($task, $input, Container::get(iOutput::class));
-                $event->addLogEntry(Level::Info, "Task: End '{command}' (Exit Code: {exit_code})", [
-                    'task_id' => ag($task, 'name'),
-                    'command' => ag($task, 'command'),
-                    'exit_code' => $exitCode,
-                ]);
+                $event->addLogEntry(
+                    0 === $exitCode ? Level::Info : Level::Error,
+                    "Task '{task_id}' {status} with exit code {exit_code} in {duration_seconds}s.",
+                    [
+                        'task_id' => ag($task, 'name'),
+                        'command' => ag($task, 'command'),
+                        'exit_code' => $exitCode,
+                        'status' => 0 === $exitCode ? 'completed' : 'failed',
+                        'duration_seconds' => max(0, make_date()->getTimestamp() - $runStartedAt->getTimestamp()),
+                        'event_name' => 0 === $exitCode ? 'task.run.completed' : 'task.run.failed',
+                        'subsystem' => 'task',
+                        'operation' => 'run',
+                        'outcome' => 0 === $exitCode ? 'completed' : 'failed',
+                    ],
+                );
             }
         } finally {
             $this->needToSave = false;
@@ -445,15 +477,22 @@ final class TasksCommand extends Command
                         usleep($this->sleep);
                     } catch (ProcessException $e) {
                         $process->stop();
-                        $this->write(
-                            r('Task: {name} (Failed). ({type}: {message}', [
-                                'name' => $task['name'],
-                                'startDate' => $started->format('D, H:i:s T'),
-                                'type' => $e::class,
-                                'message' => $e->getMessage(),
+                        $this->taskOutput[] = new JsonlFormatter()->formatValues(
+                            channel: 'task',
+                            level: Level::Error,
+                            message: r("Task process '{task_id}' failed while running {command}.", [
+                                'task_id' => (string) $task['name'],
+                                'command' => (string) ag($task, 'command', ''),
                             ]),
-                            $input,
-                            $output,
+                            context: array_replace($this->logContext, $this->eventLogContext, [
+                                'task_id' => (string) $task['name'],
+                                'command' => (string) ag($task, 'command', ''),
+                                'event_name' => 'task.process.failed',
+                                'subsystem' => 'task',
+                                'operation' => 'process',
+                                'outcome' => 'failed',
+                                ...exception_log($e),
+                            ]),
                         );
                         break;
                     }
@@ -476,18 +515,21 @@ final class TasksCommand extends Command
             $event->logs[] = new JsonlFormatter()->formatValues(
                 channel: 'task',
                 level: Level::Info,
-                message: r('run_task.{name}: {cmd} (Started: {start_date})', [
-                    'name' => $task['name'],
+                message: r("Task process '{task_id}' started: {cmd}.", [
+                    'task_id' => $task['name'],
                     'cmd' => $process->getCommandLine(),
-                    'start_date' => $started->format('D, H:i:s T'),
                 ]),
                 context: [
                     'event_id' => (string) $event->id,
-                    'event' => $event->event,
+                    'queued_event' => $event->event,
                     'task_id' => (string) $task['name'],
                     'command' => (string) ag($task, 'command', ''),
                     'cmd' => $process->getCommandLine(),
-                    'start_date' => $started->format('D, H:i:s T'),
+                    'started_at' => $started->format(DATE_ATOM),
+                    'event_name' => 'task.process.started',
+                    'subsystem' => 'task',
+                    'operation' => 'process',
+                    'outcome' => 'started',
                     'source' => 'task',
                 ],
             );
@@ -497,12 +539,20 @@ final class TasksCommand extends Command
                     $event->logs[] = new JsonlFormatter()->formatValues(
                         channel: 'task',
                         level: Level::Info,
-                        message: 'Task completed successfully. And did not produce any output.',
+                        message: r("Task '{task_id}' completed successfully without output.", [
+                            'task_id' => $task['name'],
+                        ]),
                         context: [
                             'event_id' => (string) $event->id,
-                            'event' => $event->event,
+                            'queued_event' => $event->event,
                             'task_id' => (string) $task['name'],
                             'command' => (string) ag($task, 'command', ''),
+                            'status' => 'success',
+                            'output_line_count' => 0,
+                            'event_name' => 'task.run.no_output',
+                            'subsystem' => 'task',
+                            'operation' => 'run',
+                            'outcome' => 'completed',
                             'source' => 'task',
                         ],
                     );
@@ -510,12 +560,22 @@ final class TasksCommand extends Command
                     $event->logs[] = new JsonlFormatter()->formatValues(
                         channel: 'task',
                         level: Level::Error,
-                        message: 'Task failed to complete. And did not produce any output.',
+                        message: r("Task '{task_id}' failed with exit code {exit_code} and no output.", [
+                            'task_id' => $task['name'],
+                            'exit_code' => $process->getExitCode() ?? self::INVALID,
+                        ]),
                         context: [
                             'event_id' => (string) $event->id,
-                            'event' => $event->event,
+                            'queued_event' => $event->event,
                             'task_id' => (string) $task['name'],
                             'command' => (string) ag($task, 'command', ''),
+                            'status' => 'failed',
+                            'output_line_count' => 0,
+                            'exit_code' => $process->getExitCode() ?? self::INVALID,
+                            'event_name' => 'task.run.no_output',
+                            'subsystem' => 'task',
+                            'operation' => 'run',
+                            'outcome' => 'failed',
                             'source' => 'task',
                         ],
                     );
@@ -526,22 +586,25 @@ final class TasksCommand extends Command
             $event->logs[] = new JsonlFormatter()->formatValues(
                 channel: 'task',
                 level: 0 === $process->getExitCode() ? Level::Info : Level::Error,
-                message: r('run_task.{name} ExitCode: {code}:{status} (Ended: {end_date}) - Took {duration}s', [
-                    'name' => $task['name'],
-                    'status' => 0 === $process->getExitCode() ? 'Success' : 'Failed',
-                    'code' => $process->getExitCode() ?? self::INVALID,
-                    'end_date' => $ended->format('D, H:i:s T'),
-                    'duration' => $ended->getTimestamp() - $started->getTimestamp(),
+                message: r("Task process '{task_id}' {status} with exit code {exit_code} in {duration_seconds}s.", [
+                    'task_id' => $task['name'],
+                    'status' => 0 === $process->getExitCode() ? 'completed' : 'failed',
+                    'exit_code' => $process->getExitCode() ?? self::INVALID,
+                    'duration_seconds' => $ended->getTimestamp() - $started->getTimestamp(),
                 ]),
                 context: [
                     'event_id' => (string) $event->id,
-                    'event' => $event->event,
+                    'queued_event' => $event->event,
                     'task_id' => (string) $task['name'],
                     'command' => (string) ag($task, 'command', ''),
                     'exit_code' => $process->getExitCode() ?? self::INVALID,
-                    'status' => 0 === $process->getExitCode() ? 'Success' : 'Failed',
-                    'end_date' => $ended->format('D, H:i:s T'),
-                    'duration' => $ended->getTimestamp() - $started->getTimestamp(),
+                    'status' => 0 === $process->getExitCode() ? 'completed' : 'failed',
+                    'ended_at' => $ended->format(DATE_ATOM),
+                    'duration_seconds' => $ended->getTimestamp() - $started->getTimestamp(),
+                    'event_name' => 'task.process.completed',
+                    'subsystem' => 'task',
+                    'operation' => 'process',
+                    'outcome' => 0 === $process->getExitCode() ? 'completed' : 'failed',
                     'source' => 'task',
                 ],
             );
@@ -561,10 +624,9 @@ final class TasksCommand extends Command
         }
 
         $this->write(
-            r('run_task.{name}: {cmd} (Started: {startDate})', [
-                'name' => $task['name'],
+            r("Task process '{task_id}' started: {cmd}.", [
+                'task_id' => $task['name'],
                 'cmd' => $process->getCommandLine(),
-                'startDate' => $started->format('D, H:i:s T'),
             ]),
             $input,
             $output,
@@ -573,12 +635,11 @@ final class TasksCommand extends Command
             $this->write($line, $input, $output);
         }
         $this->write(
-            r('run_task.{name}: ExitCode: {code}:{status} (Ended: {end_date}) - Took {duration}s', [
-                'name' => $task['name'],
-                'status' => 0 === $process->getExitCode() ? 'Success' : 'Failed',
-                'code' => $process->getExitCode() ?? self::INVALID,
-                'end_date' => $ended->format('D, H:i:s T'),
-                'duration' => $ended->getTimestamp() - $started->getTimestamp(),
+            r("Task process '{task_id}' {status} with exit code {exit_code} in {duration_seconds}s.", [
+                'task_id' => $task['name'],
+                'status' => 0 === $process->getExitCode() ? 'completed' : 'failed',
+                'exit_code' => $process->getExitCode() ?? self::INVALID,
+                'duration_seconds' => $ended->getTimestamp() - $started->getTimestamp(),
             ]),
             $input,
             $output,
@@ -640,15 +701,22 @@ final class TasksCommand extends Command
                         usleep($this->sleep);
                     } catch (ProcessException $e) {
                         $process->stop();
-                        $this->write(
-                            r('Command: {command} (Failed). ({type}: {message}', [
+                        $this->taskOutput[] = new JsonlFormatter()->formatValues(
+                            channel: 'task',
+                            level: Level::Error,
+                            message: r("Task process '{task_id}' failed while running {command}.", [
+                                'task_id' => self::CNAME,
                                 'command' => $command,
-                                'startDate' => $started->format('D, H:i:s T'),
-                                'type' => $e::class,
-                                'message' => $e->getMessage(),
                             ]),
-                            $input,
-                            $output,
+                            context: array_replace($this->logContext, $this->eventLogContext, [
+                                'task_id' => self::CNAME,
+                                'command' => $command,
+                                'event_name' => 'task.process.failed',
+                                'subsystem' => 'task',
+                                'operation' => 'process',
+                                'outcome' => 'failed',
+                                ...exception_log($e),
+                            ]),
                         );
                         break;
                     }
@@ -674,28 +742,24 @@ final class TasksCommand extends Command
             }
         }
 
-        $this->write('--------------------------', $input, $output);
         $this->write(
-            r('Command: {name} (Started: {startDate})', [
+            r("Task process '{task_id}' started: {command}.", [
+                'task_id' => self::CNAME,
                 'command' => $command,
-                'startDate' => $started->format('D, H:i:s T'),
             ]),
             $input,
             $output,
         );
-        $this->write(r('Command: {cmd}', ['cmd' => $process->getCommandLine()]), $input, $output);
         $this->write(
-            r('Exit Code: {code}:{status} (Ended: {end_date}) - Took {duration}s', [
-                'status' => 0 === $process->getExitCode() ? 'Success' : 'Failed',
-                'code' => $process->getExitCode() ?? self::INVALID,
-                'end_date' => $ended->format('D, H:i:s T'),
-                'duration' => $ended->getTimestamp() - $started->getTimestamp(),
+            r("Task process '{task_id}' {status} with exit code {exit_code} in {duration_seconds}s.", [
+                'task_id' => self::CNAME,
+                'status' => 0 === $process->getExitCode() ? 'completed' : 'failed',
+                'exit_code' => $process->getExitCode() ?? self::INVALID,
+                'duration_seconds' => $ended->getTimestamp() - $started->getTimestamp(),
             ]),
             $input,
             $output,
         );
-        $this->write('--------------------------', $input, $output);
-        $this->write(' ' . PHP_EOL, $input, $output);
 
         foreach ($this->taskOutput as $line) {
             $this->write($line, $input, $output);
@@ -806,11 +870,35 @@ final class TasksCommand extends Command
             return;
         }
 
-        $this->taskOutput[] = $line;
+        $lineNumber = count($this->taskOutput) + 1;
+        $wrappedLine = $line;
+
+        if (false === JsonlFormatter::isJsonlRecord($line)) {
+            $wrappedLine = rtrim(new JsonlFormatter()->formatValues(
+                channel: 'task',
+                level: 'err' === $std ? Level::Warning : Level::Info,
+                message: r('{stream} from task \'{task_id}\': {line}', [
+                    'stream' => 'err' === $std ? 'stderr' : 'stdout',
+                    'task_id' => (string) ag($this->logContext, 'task_id', ''),
+                    'line' => $this->normalizeTaskMessage($line),
+                ]),
+                context: array_replace($this->logContext, $this->eventLogContext, [
+                    'stream' => 'err' === $std ? 'stderr' : 'stdout',
+                    'line' => $this->normalizeTaskMessage($line),
+                    'line_number' => $lineNumber,
+                    'event_name' => 'task.output',
+                    'subsystem' => 'task',
+                    'operation' => 'output',
+                    'outcome' => 'received',
+                ]),
+            ), "\r\n");
+        }
+
+        $this->taskOutput[] = $wrappedLine;
 
         if (null !== $this->writer && false === $this->suppressor->isSuppressed($line)) {
             try {
-                ($this->writer)($this->formatTaskLogLine($line));
+                ($this->writer)($this->formatTaskLogLine($wrappedLine));
             } catch (Throwable) {
                 // Do nothing
             }
@@ -820,7 +908,7 @@ final class TasksCommand extends Command
             return;
         }
 
-        ('err' === $std ? $output->getErrorOutput() : $output)->writeln($this->formatTaskOutputLine($line));
+        ('err' === $std ? $output->getErrorOutput() : $output)->writeln($this->formatTaskOutputLine($wrappedLine));
     }
 
     private function formatTaskLogLine(string $line): string

--- a/src/Libs/Database/DBLayer.php
+++ b/src/Libs/Database/DBLayer.php
@@ -968,9 +968,15 @@ final class DBLayer implements LoggerAwareInterface
 
                 $this->logger?->log(
                     ($attempts + 1) >= $this->retry ? Level::Warning : Level::Info,
-                    "PDOAdapter: Database is locked. sleeping for '{sleep}s'.",
+                    'Database is locked; retrying in {sleep}s.',
                     [
+                        'event_name' => 'database.lock.retry',
+                        'subsystem' => 'database',
+                        'operation' => 'query',
+                        'outcome' => 'retrying',
+                        'reason' => 'database_locked',
                         'sleep' => $sleep,
+                        'attempt' => $attempts + 1,
                     ],
                 );
 

--- a/src/Libs/Database/PDO/PDOAdapter.php
+++ b/src/Libs/Database/PDO/PDOAdapter.php
@@ -134,7 +134,7 @@ final class PDOAdapter implements iDB
         try {
             if (null !== ($entity->id ?? null)) {
                 throw new DBException(
-                    r("PDOAdapter: Unable to insert item that has primary key already defined. '#{id}'.", [
+                    r("Unable to insert item: primary key already defined for '#{id}'.", [
                         'id' => $entity->id,
                     ]),
                     21,
@@ -144,7 +144,7 @@ final class PDOAdapter implements iDB
             if (true === $entity->isEpisode() && $entity->episode < 1) {
                 throw new DBException(
                     r(
-                        "PDOAdapter: Unexpected episode number '{number}' was given for '{via}: {title}'.",
+                        "Unexpected episode number '{number}' was given for '{via}: {title}'.",
                         [
                             'via' => $entity->via,
                             'title' => $entity->getName(),
@@ -157,7 +157,7 @@ final class PDOAdapter implements iDB
             if (false === in_array($entity->type, [iState::TYPE_MOVIE, iState::TYPE_EPISODE], true)) {
                 throw new DBException(
                     r(
-                        "PDOAdapter: Unexpected content type '{type}' was given for '{via}: {title}'. Expecting '{types}'.",
+                        "Unexpected content type '{type}' was given for '{via}: {title}'. Expected '{types}'.",
                         [
                             'type' => $entity->type,
                             'types' => implode(', ', [iState::TYPE_MOVIE, iState::TYPE_EPISODE]),
@@ -226,26 +226,7 @@ final class PDOAdapter implements iDB
                 if (true === $failFast) {
                     throw $e;
                 }
-                $this->logger->error(
-                    message: "PDOAdapter: Exception '{error.kind}' was thrown unhandled. '{error.message}' at '{error.file}:{error.line}'.",
-                    context: [
-                        'entity' => $entity->getAll(),
-                        'error' => [
-                            'kind' => $e::class,
-                            'line' => $e->getLine(),
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
-                        'exception' => [
-                            'kind' => $e::class,
-                            'line' => $e->getLine(),
-                            'trace' => $e->getTrace(),
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
-                        'last' => $this->db->getLastStatement(),
-                    ],
-                );
+                $this->logDatabaseFailure('insert', $entity, $e);
                 return $entity;
             }
             throw $e;
@@ -262,7 +243,14 @@ final class PDOAdapter implements iDB
         $inTraceMode = true === (bool) ($this->options[Options::DEBUG_TRACE] ?? false);
 
         if ($inTraceMode) {
-            $this->logger->debug("PDOAdapter: Looking for '{name}'.", ['name' => $entity->getName()]);
+            $this->logger->debug("Looking up '{name}' in the local database.", [
+                'event_name' => 'database.state.lookup.started',
+                'subsystem' => 'database',
+                'operation' => 'lookup',
+                'outcome' => 'started',
+                'item_id' => null === $entity->id ? null : (string) $entity->id,
+                'item_title' => $entity->getName(),
+            ]);
         }
 
         if (null !== $entity->id) {
@@ -272,7 +260,13 @@ final class PDOAdapter implements iDB
                 $item = $entity::fromArray($item);
 
                 if ($inTraceMode) {
-                    $this->logger->debug("PDOAdapter: Found '{name}' using direct id match.", [
+                    $this->logger->debug("Found '{name}' using direct id match.", [
+                        'event_name' => 'database.state.lookup.completed',
+                        'subsystem' => 'database',
+                        'operation' => 'lookup',
+                        'outcome' => 'completed',
+                        'matched' => true,
+                        'match_strategy' => 'direct_id',
                         'name' => $item->getName(),
                         iState::COLUMN_ID => $entity->id,
                     ]);
@@ -284,7 +278,13 @@ final class PDOAdapter implements iDB
 
         if (null !== ($item = $this->findByExternalId($entity))) {
             if ($inTraceMode) {
-                $this->logger->debug("PDOAdapter: Found '{name}' using external id match.", [
+                $this->logger->debug("Found '{name}' using external id match.", [
+                    'event_name' => 'database.state.lookup.completed',
+                    'subsystem' => 'database',
+                    'operation' => 'lookup',
+                    'outcome' => 'completed',
+                    'matched' => true,
+                    'match_strategy' => 'external_id',
                     'name' => $item->getName(),
                     iState::COLUMN_GUIDS => $entity->getGuids(),
                 ]);
@@ -309,7 +309,11 @@ final class PDOAdapter implements iDB
         }
 
         if (true === (bool) ($this->options[Options::DEBUG_TRACE] ?? false)) {
-            $this->logger->debug("PDOAdapter: Selecting fields '{fields}'.", [
+            $this->logger->debug("Selecting database fields '{fields}'.", [
+                'event_name' => 'database.state.query.started',
+                'subsystem' => 'database',
+                'operation' => 'select',
+                'outcome' => 'started',
                 'fields' => array_to_string($opts['fields'] ?? ['all']),
             ]);
         }
@@ -391,7 +395,7 @@ final class PDOAdapter implements iDB
     {
         try {
             if (null === ($entity->id ?? null)) {
-                throw new DBException(r("PDOAdapter: Unable to update '{title}' without primary key defined.", [
+                throw new DBException(r("Unable to update '{title}' without primary key defined.", [
                     'title' => $entity->getName() ?? 'Unknown',
                 ]), 51);
             }
@@ -399,7 +403,7 @@ final class PDOAdapter implements iDB
             if (true === $entity->isEpisode() && $entity->episode < 1) {
                 throw new DBException(
                     r(
-                        "PDOAdapter: Unexpected episode number '{number}' was given for '#{id}' '{via}: {title}'.",
+                        "Unexpected episode number '{number}' was given for '#{id}' '{via}: {title}'.",
                         [
                             'id' => $entity->id,
                             'via' => $entity->via,
@@ -455,26 +459,7 @@ final class PDOAdapter implements iDB
                 if (true === $failFast) {
                     throw $e;
                 }
-                $this->logger->error(
-                    message: "PDOAdapter: Exception '{error.kind}' was thrown unhandled. '{error.message}' at '{error.file}:{error.line}'.",
-                    context: [
-                        'entity' => $entity->getAll(),
-                        'error' => [
-                            'kind' => $e::class,
-                            'line' => $e->getLine(),
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
-                        'exception' => [
-                            'kind' => $e::class,
-                            'line' => $e->getLine(),
-                            'trace' => $e->getTrace(),
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
-                        'last' => $this->db->getLastStatement(),
-                    ],
-                );
+                $this->logDatabaseFailure('update', $entity, $e);
                 return $entity;
             }
             throw $e;
@@ -504,25 +489,7 @@ final class PDOAdapter implements iDB
 
             $this->db->query('DELETE FROM state WHERE id = :id', ['id' => (int) $id]);
         } catch (PDOException $e) {
-            $this->logger->error(
-                message: "PDOAdapter: Exception '{error.kind}' was thrown unhandled. '{error.message}' at '{error.file}:{error.line}'.",
-                context: [
-                    'entity' => $entity->getAll(),
-                    'error' => [
-                        'kind' => $e::class,
-                        'line' => $e->getLine(),
-                        'message' => $e->getMessage(),
-                        'file' => after($e->getFile(), ROOT_PATH),
-                    ],
-                    'exception' => [
-                        'kind' => $e::class,
-                        'line' => $e->getLine(),
-                        'trace' => $e->getTrace(),
-                        'message' => $e->getMessage(),
-                        'file' => after($e->getFile(), ROOT_PATH),
-                    ],
-                ],
-            );
+            $this->logDatabaseFailure('remove', $entity, $e);
             return false;
         }
 
@@ -552,25 +519,7 @@ final class PDOAdapter implements iDB
                     }
                 } catch (PDOException $e) {
                     $actions['failed']++;
-                    $this->logger->error(
-                        message: "PDOAdapter: Exception '{error.kind}' was thrown unhandled. '{error.message}' at '{error.file}:{error.line}'.",
-                        context: [
-                            'entity' => $entity->getAll(),
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
-                            'exception' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'trace' => $e->getTrace(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
-                        ],
-                    );
+                    $this->logDatabaseFailure(null === $entity->id ? 'insert' : 'update', $entity, $e);
                 }
             }
 
@@ -854,5 +803,28 @@ final class PDOAdapter implements iDB
         }
 
         return $entity::fromArray($row);
+    }
+
+    private function logDatabaseFailure(string $operation, iState $entity, PDOException $e): void
+    {
+        $this->logger->error('Database {operation} failed for {item_type} {item_label}.', [
+            'event_name' => 'database.state.operation_failed',
+            'subsystem' => 'database',
+            'operation' => $operation,
+            'outcome' => 'failed',
+            'table' => 'state',
+            'item_id' => null === $entity->id ? null : (string) $entity->id,
+            'item_type' => $entity->type,
+            'item_title' => $entity->getName(),
+            'item_label' => null !== $entity->id
+                ? r("'#{id}: {title}'", [
+                    'id' => $entity->id,
+                    'title' => $entity->getName(),
+                ]) : r("'{title}'", ['title' => $entity->getName()]),
+            'entity' => $entity->getAll(),
+            'query' => ag($this->db->getLastStatement(), 'sql'),
+            'bind' => ag($this->db->getLastStatement(), 'bind', []),
+            ...exception_log($e),
+        ]);
     }
 }

--- a/src/Libs/Events/DataEvent.php
+++ b/src/Libs/Events/DataEvent.php
@@ -123,7 +123,7 @@ class DataEvent extends Event
     {
         return [
             'event_id' => (string) ($this->eventInfo->id ?? ''),
-            'event' => $this->eventInfo->event,
+            'queued_event' => $this->eventInfo->event,
         ];
     }
 

--- a/src/Libs/Events/DataEvent.php
+++ b/src/Libs/Events/DataEvent.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\Libs\Events;
 
+use App\Libs\Extends\JsonlFormatter;
 use App\Model\Events\Event as EventInfo;
 use App\Model\Events\EventStatus;
+use Monolog\Level;
+use Monolog\LogRecord;
 use Symfony\Contracts\EventDispatcher\Event;
 
 class DataEvent extends Event
@@ -39,12 +42,13 @@ class DataEvent extends Event
         return $this->eventInfo->reference;
     }
 
-    public function addLog(string $log): void
+    public function addLog(string $log, mixed $record = null): void
     {
         if (count($this->eventInfo->logs) >= 200) {
             array_shift($this->eventInfo->logs);
         }
-        $this->eventInfo->logs[] = $log;
+
+        $this->eventInfo->logs[] = $this->normalizeLog($log, $record);
     }
 
     public function clearLogs(): void
@@ -65,5 +69,44 @@ class DataEvent extends Event
     public function getOptions(): array
     {
         return $this->eventInfo->options;
+    }
+
+    private function normalizeLog(string $log, mixed $record = null): string
+    {
+        if (true === JsonlFormatter::isJsonlRecord($log)) {
+            return rtrim($log, "\r\n") . PHP_EOL;
+        }
+
+        $formatter = new JsonlFormatter();
+        $context = [
+            'event_id' => (string) ($this->eventInfo->id ?? ''),
+            'event' => $this->eventInfo->event,
+        ];
+
+        if ($record instanceof LogRecord) {
+            return $formatter->format($record->with(context: array_replace($record->context, $context)));
+        }
+
+        return $formatter->formatValues(
+            channel: 'event',
+            level: $this->detectLevel($log),
+            message: $log,
+            context: $context,
+        );
+    }
+
+    private function detectLevel(string $log): Level
+    {
+        $levelRegex = '/^(?:\[[^\]]+]\s*)?(?:[a-z0-9_.-]+\.)?(?<level>EMERGENCY|ALERT|CRITICAL|ERROR|WARNING|NOTICE|INFO|DEBUG):\s*/i';
+
+        if (1 !== preg_match($levelRegex, trim($log), $matches)) {
+            return Level::Info;
+        }
+
+        try {
+            return Level::fromName(strtoupper((string) $matches['level']));
+        } catch (\ValueError) {
+            return Level::Info;
+        }
     }
 }

--- a/src/Libs/Events/DataEvent.php
+++ b/src/Libs/Events/DataEvent.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Libs\Events;
 
 use App\Libs\Extends\JsonlFormatter;
+use App\Libs\Options;
 use App\Model\Events\Event as EventInfo;
 use App\Model\Events\EventStatus;
 use Monolog\Level;
@@ -44,11 +45,34 @@ class DataEvent extends Event
 
     public function addLog(string $log, mixed $record = null): void
     {
+        if (false === $this->shouldPersistRecord($log, $record)) {
+            return;
+        }
+
         if (count($this->eventInfo->logs) >= 200) {
             array_shift($this->eventInfo->logs);
         }
 
         $this->eventInfo->logs[] = $this->normalizeLog($log, $record);
+    }
+
+    /**
+     * Add a structured log entry to the event log.
+     *
+     * @param array<string,mixed> $context
+     */
+    public function addLogEntry(Level $level, string $message, array $context = [], string $channel = 'event'): void
+    {
+        if (false === $this->shouldPersistLevel($level)) {
+            return;
+        }
+
+        $this->addLog(new JsonlFormatter()->formatValues(
+            channel: $channel,
+            level: $level,
+            message: r($message, $context, ['log_behavior' => true]),
+            context: array_replace($context, $this->eventContext()),
+        ));
     }
 
     public function clearLogs(): void
@@ -78,10 +102,7 @@ class DataEvent extends Event
         }
 
         $formatter = new JsonlFormatter();
-        $context = [
-            'event_id' => (string) ($this->eventInfo->id ?? ''),
-            'event' => $this->eventInfo->event,
-        ];
+        $context = $this->eventContext();
 
         if ($record instanceof LogRecord) {
             return $formatter->format($record->with(context: array_replace($record->context, $context)));
@@ -93,6 +114,17 @@ class DataEvent extends Event
             message: $log,
             context: $context,
         );
+    }
+
+    /**
+     * @return array{event_id:string,event:string}
+     */
+    private function eventContext(): array
+    {
+        return [
+            'event_id' => (string) ($this->eventInfo->id ?? ''),
+            'event' => $this->eventInfo->event,
+        ];
     }
 
     private function detectLevel(string $log): Level
@@ -108,5 +140,23 @@ class DataEvent extends Event
         } catch (\ValueError) {
             return Level::Info;
         }
+    }
+
+    private function shouldPersistRecord(string $log, mixed $record): bool
+    {
+        if ($record instanceof LogRecord) {
+            return $this->shouldPersistLevel($record->level);
+        }
+
+        return $this->shouldPersistLevel($this->detectLevel($log));
+    }
+
+    private function shouldPersistLevel(Level $level): bool
+    {
+        if (true === (bool) ($this->eventInfo->options[Options::DEBUG_TRACE] ?? false)) {
+            return true;
+        }
+
+        return $level->value >= Level::Info->value;
     }
 }

--- a/src/Libs/Extends/ConsoleHandler.php
+++ b/src/Libs/Extends/ConsoleHandler.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ConsoleHandler extends AbstractProcessingHandler
 {
     private JsonlFormatter $jsonlFormatter;
+    private ConsoleLogFormatter $consoleFormatter;
 
     /**
      * @var OutputInterface|null $output The console output interface to be used for printing log records
@@ -63,6 +64,7 @@ class ConsoleHandler extends AbstractProcessingHandler
 
         $this->output = $output;
         $this->jsonlFormatter = new JsonlFormatter();
+        $this->consoleFormatter = new ConsoleLogFormatter();
 
         if ($levelsMapper) {
             $this->levelsMapper = $levelsMapper;
@@ -121,6 +123,13 @@ class ConsoleHandler extends AbstractProcessingHandler
             return;
         }
 
+        $errOutput = $this->output instanceof ConsoleOutputInterface ? $this->output->getErrorOutput() : $this->output;
+
+        if (true === $this->output->isDecorated() && null !== $errOutput) {
+            $errOutput->writeln($this->consoleFormatter->format($record), $this->output->getVerbosity());
+            return;
+        }
+
         $date = $record['datetime'] ?? 'No date set';
 
         if (true === $date instanceof DateTimeInterface) {
@@ -136,8 +145,6 @@ class ConsoleHandler extends AbstractProcessingHandler
         if (false === empty($record['context']) && true === (bool) Config::get('logs.context')) {
             $message .= ' ' . array_to_json($record['context']);
         }
-
-        $errOutput = $this->output instanceof ConsoleOutputInterface ? $this->output->getErrorOutput() : $this->output;
 
         $errOutput?->writeln($message, $this->output->getVerbosity());
     }

--- a/src/Libs/Extends/ConsoleHandler.php
+++ b/src/Libs/Extends/ConsoleHandler.php
@@ -21,6 +21,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ConsoleHandler extends AbstractProcessingHandler
 {
+    private JsonlFormatter $jsonlFormatter;
+
     /**
      * @var OutputInterface|null $output The console output interface to be used for printing log records
      */
@@ -60,6 +62,7 @@ class ConsoleHandler extends AbstractProcessingHandler
         parent::__construct(Level::Debug, $bubble);
 
         $this->output = $output;
+        $this->jsonlFormatter = new JsonlFormatter();
 
         if ($levelsMapper) {
             $this->levelsMapper = $levelsMapper;
@@ -113,6 +116,11 @@ class ConsoleHandler extends AbstractProcessingHandler
      */
     protected function write(LogRecord $record): void
     {
+        if (true === $this->isJsonlOutput()) {
+            $this->output->writeJsonlRecord($this->jsonlFormatter->format($record), true);
+            return;
+        }
+
         $date = $record['datetime'] ?? 'No date set';
 
         if (true === $date instanceof DateTimeInterface) {
@@ -132,6 +140,14 @@ class ConsoleHandler extends AbstractProcessingHandler
         $errOutput = $this->output instanceof ConsoleOutputInterface ? $this->output->getErrorOutput() : $this->output;
 
         $errOutput?->writeln($message, $this->output->getVerbosity());
+    }
+
+    /**
+     * Whether the current output is configured for JSONL mode.
+     */
+    protected function isJsonlOutput(): bool
+    {
+        return $this->output instanceof ConsoleOutput && true === $this->output->isJsonl();
     }
 
     /**

--- a/src/Libs/Extends/ConsoleLogFormatter.php
+++ b/src/Libs/Extends/ConsoleLogFormatter.php
@@ -80,9 +80,13 @@ final class ConsoleLogFormatter
                 'fields.route.ip',
                 'fields.task_id',
                 'fields.command',
+                'fields.user.name',
                 'fields.user',
+                'fields.backend.name',
                 'fields.backend',
                 'fields.cli.stream',
+                'fields.item_id',
+                'fields.event_name',
                 'source.module',
                 'process.name',
                 'logger',
@@ -90,6 +94,10 @@ final class ConsoleLogFormatter
             ],
             '-',
         );
+
+        if (false === is_scalar($value)) {
+            return '-';
+        }
 
         return '' !== trim((string) $value) ? trim((string) $value) : '-';
     }

--- a/src/Libs/Extends/ConsoleLogFormatter.php
+++ b/src/Libs/Extends/ConsoleLogFormatter.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Libs\Extends;
+
+use DateTimeInterface;
+use Monolog\LogRecord;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Throwable;
+
+final class ConsoleLogFormatter
+{
+    /**
+     * Format a log record or structured log entry for interactive console display.
+     *
+     * @param LogRecord|array<string,mixed> $record
+     */
+    public function format(LogRecord|array $record): string
+    {
+        $entry = true === $record instanceof LogRecord ? $this->fromRecord($record) : $record;
+        $severity = strtoupper((string) ag($entry, 'level', '-'));
+        $severityText = OutputFormatter::escape($severity);
+        $message = $this->messageText($entry);
+        $severityColor = $this->severityColor((string) ag($entry, 'level', ''));
+
+        if (null !== $severityColor) {
+            $severityText = sprintf('<fg=%s;options=bold>%s</>', $severityColor, $severityText);
+        } else {
+            $severityText = sprintf('<options=bold>%s</>', $severityText);
+        }
+
+        return sprintf(
+            '<comment>%s</comment> <info>%s</info> %s <fg=cyan>%s</> %s',
+            OutputFormatter::escape($this->formatTimestamp(ag($entry, ['datetime', 'date'], '-'))),
+            OutputFormatter::escape($this->hostname($entry)),
+            $severityText,
+            OutputFormatter::escape((string) ag($entry, ['logger', 'channel'], '-')),
+            OutputFormatter::escape($message),
+        );
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function fromRecord(LogRecord $record): array
+    {
+        $entry = [
+            'datetime' => $record->datetime,
+            'level' => $record->level->getName(),
+            'logger' => $record->channel,
+            'message' => $record->message,
+            'fields' => $record->context,
+            'source' => [
+                'module' => $record->channel,
+            ],
+            'process' => [
+                'name' => PHP_SAPI,
+            ],
+        ];
+
+        $exception = ag($record->context, 'exception');
+        if (true === $exception instanceof Throwable) {
+            $entry['exception_message'] = $exception->getMessage();
+        }
+
+        return $entry;
+    }
+
+    /**
+     * @param array<string,mixed> $entry
+     */
+    private function hostname(array $entry): string
+    {
+        $value = ag(
+            $entry,
+            [
+                'fields.structured.request.name',
+                'fields.hostname',
+                'fields.route.ip',
+                'fields.task_id',
+                'fields.command',
+                'fields.user',
+                'fields.backend',
+                'fields.cli.stream',
+                'source.module',
+                'process.name',
+                'logger',
+                'channel',
+            ],
+            '-',
+        );
+
+        return '' !== trim((string) $value) ? trim((string) $value) : '-';
+    }
+
+    /**
+     * @param array<string,mixed> $entry
+     */
+    private function messageText(array $entry): string
+    {
+        $message = trim((string) ag($entry, ['message', 'text'], '-'));
+
+        if ('' === $message) {
+            return '-';
+        }
+
+        if (null !== ($exception = ag($entry, 'exception_message')) && '' !== trim((string) $exception)) {
+            return $message . ' [' . trim((string) $exception) . ']';
+        }
+
+        return $message;
+    }
+
+    private function formatTimestamp(mixed $value): string
+    {
+        if (true === $value instanceof DateTimeInterface) {
+            return make_date($value)->format('m/d, H:i:s');
+        }
+
+        $value = (string) $value;
+
+        if ('' === trim($value)) {
+            return '-';
+        }
+
+        try {
+            return make_date($value)->format('m/d, H:i:s');
+        } catch (Throwable) {
+            return $value;
+        }
+    }
+
+    private function severityColor(string $severity): ?string
+    {
+        $level = strtolower(trim($severity));
+
+        if (true === in_array($level, ['emergency', 'alert', 'critical'], true)) {
+            return 'bright-red';
+        }
+
+        if ('error' === $level) {
+            return 'red';
+        }
+
+        if ('warning' === $level) {
+            return 'yellow';
+        }
+
+        if ('notice' === $level) {
+            return 'magenta';
+        }
+
+        if ('info' === $level) {
+            return 'cyan';
+        }
+
+        if ('debug' === $level) {
+            return 'gray';
+        }
+
+        return null;
+    }
+}

--- a/src/Libs/Extends/ConsoleOutput.php
+++ b/src/Libs/Extends/ConsoleOutput.php
@@ -6,10 +6,14 @@ namespace App\Libs\Extends;
 
 use App\Libs\Container;
 use App\Libs\LogSuppressor;
+use Monolog\Level;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Formatter\OutputFormatterInterface as iOutput;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput as baseConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Class ConsoleOutput
@@ -22,6 +26,10 @@ final class ConsoleOutput extends baseConsoleOutput
 {
     private bool $noSuppressor = false;
     private ?LogSuppressor $suppressor = null;
+    private bool $jsonl = false;
+    private string $streamName = 'stdout';
+    private JsonlFormatter $jsonlFormatter;
+    private mixed $message = '';
 
     /**
      * Constructor for the class.
@@ -38,6 +46,7 @@ final class ConsoleOutput extends baseConsoleOutput
         ?iOutput $formatter = null,
     ) {
         $formatter ??= new OutputFormatter();
+        $this->jsonlFormatter = new JsonlFormatter();
 
         if (null !== $formatter) {
             //(black, red, green, yellow, blue, magenta, cyan, white, default, gray, bright-red, bright-green,
@@ -50,9 +59,8 @@ final class ConsoleOutput extends baseConsoleOutput
         }
 
         parent::__construct($verbosity, $decorated, $formatter);
+        $this->setErrorOutput($this->makeStreamOutput($this->openErrorStreamHandle(), 'stderr', $verbosity, $decorated, $formatter));
     }
-
-    private mixed $message = '';
 
     /**
      * Writes the given message to a certain location, optionally appending a newline character.
@@ -73,6 +81,26 @@ final class ConsoleOutput extends baseConsoleOutput
 
         $this->message = $message;
 
+        if (true === $this->jsonl) {
+            if (true === JsonlFormatter::isJsonlRecord($message)) {
+                $payload = rtrim($message, "\r\n");
+                $this->message = $payload . PHP_EOL;
+                parent::doWrite($payload, true);
+                return;
+            }
+
+            $payload = $this->jsonlFormatter->formatValues(
+                channel: 'cli',
+                level: 'stderr' === $this->streamName ? Level::Warning : Level::Info,
+                message: $this->normalizeMessage($message, $newline),
+                context: ['cli' => ['stream' => $this->streamName]],
+            );
+
+            $this->message = $payload;
+            parent::doWrite(rtrim($payload, "\r\n"), true);
+            return;
+        }
+
         parent::doWrite($message, $newline);
     }
 
@@ -87,6 +115,80 @@ final class ConsoleOutput extends baseConsoleOutput
     }
 
     /**
+     * Enable or disable JSONL output mode.
+     */
+    public function setJsonl(bool $jsonl): void
+    {
+        $this->jsonl = $jsonl;
+
+        $error = $this->getErrorOutput();
+        if (method_exists($error, 'setJsonl')) {
+            $error->setJsonl($jsonl);
+        }
+    }
+
+    /**
+     * Whether this output is in JSONL mode.
+     */
+    public function isJsonl(): bool
+    {
+        return $this->jsonl;
+    }
+
+    /**
+     * Enable JSONL output if the current input contains --jsonl.
+     */
+    public function syncJsonlMode(?InputInterface $input = null): void
+    {
+        $input ??= new ArgvInput();
+
+        if (false === $input->hasParameterOption('--jsonl', true)) {
+            return;
+        }
+
+        $this->setJsonl(true);
+    }
+
+    /**
+     * Write an existing JSONL record without wrapping it.
+     */
+    public function writeJsonlRecord(string $payload, bool $error = false): void
+    {
+        $payload = rtrim($payload, "\r\n");
+
+        if (false === $error) {
+            $this->message = $payload . PHP_EOL;
+            parent::doWrite($payload, true);
+            return;
+        }
+
+        $errorOutput = $this->getErrorOutput();
+        if (method_exists($errorOutput, 'writeJsonlRecord')) {
+            $errorOutput->writeJsonlRecord($payload);
+            return;
+        }
+
+        $errorOutput->writeln($payload, OutputInterface::OUTPUT_RAW);
+    }
+
+    public function setErrorOutput(OutputInterface $error): void
+    {
+        parent::setErrorOutput($error);
+
+        if (method_exists($error, 'setJsonl')) {
+            $error->setJsonl($this->jsonl);
+        }
+    }
+
+    /**
+     * @param resource $stream
+     */
+    public function setErrorStream($stream, int $verbosity = self::VERBOSITY_NORMAL, ?bool $decorated = null): void
+    {
+        $this->setErrorOutput($this->makeStreamOutput($stream, 'stderr', $verbosity, $decorated, $this->getFormatter()));
+    }
+
+    /**
      * Disable the suppressor
      * @return $this
      */
@@ -97,5 +199,36 @@ final class ConsoleOutput extends baseConsoleOutput
         $instance->suppressor = null;
 
         return $instance;
+    }
+
+    private function normalizeMessage(string $message, bool $newline): string
+    {
+        $normalized = preg_replace('/\x1b\[[0-9;]*m/', '', $message) ?? $message;
+
+        if (true === $newline) {
+            return rtrim($normalized, "\r\n");
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return resource
+     */
+    private function openErrorStreamHandle()
+    {
+        if (defined('STDERR')) {
+            return STDERR;
+        }
+
+        return fopen('php://stderr', 'w');
+    }
+
+    /**
+     * @param resource $stream
+     */
+    private function makeStreamOutput($stream, string $streamName, int $verbosity, ?bool $decorated, ?iOutput $formatter): JsonlStreamOutput
+    {
+        return new JsonlStreamOutput($stream, $verbosity, $decorated, $formatter, $streamName);
     }
 }

--- a/src/Libs/Extends/HttpClient.php
+++ b/src/Libs/Extends/HttpClient.php
@@ -84,10 +84,18 @@ class HttpClient implements iHttp, iLoggerAware, iReset
                 }
             }
 
-            $this->logger->debug('HttpClient - Request [ {method}: {url} ]', [
-                'method' => $method,
-                'url' => (string) $rUrl,
+            $this->logger->debug('HTTP {http.method} request started: {http.url}.', [
+                'event_name' => 'http.client.request.started',
+                'subsystem' => 'http.client',
+                'operation' => 'request',
+                'outcome' => 'started',
+                'http' => [
+                    'method' => $method,
+                    'url' => (string) $rUrl,
+                    'timeout' => $options['timeout'] ?? null,
+                ],
                 'options' => array_replace_recursive($options, [
+                    'keys' => array_keys($options),
                     'headers' => $headers,
                     'user_data' => [
                         'ok' => 'callable',

--- a/src/Libs/Extends/JsonlFileHandler.php
+++ b/src/Libs/Extends/JsonlFileHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Libs\Extends;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Handler\StreamHandler;
+
+final class JsonlFileHandler extends StreamHandler
+{
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new JsonlFormatter();
+    }
+}

--- a/src/Libs/Extends/JsonlFormatter.php
+++ b/src/Libs/Extends/JsonlFormatter.php
@@ -130,7 +130,15 @@ final class JsonlFormatter extends NormalizerFormatter
         $stack = $this->stack($record->context);
         $processId = getmypid();
 
-        $this->flattenInto($fields, $record->context, skip: ['id', 'trace', 'e_file', 'e_line']);
+        $this->flattenInto($fields, $record->context, skip: [
+            'id',
+            'trace',
+            'e_file',
+            'e_line',
+            'exception.trace',
+            'error.trace',
+            'structured.exception.trace',
+        ]);
         $this->flattenInto($fields, $record->extra);
 
         $payload = [
@@ -188,7 +196,7 @@ final class JsonlFormatter extends NormalizerFormatter
             $line = $exceptionData['line'] ?? null;
         }
 
-        $function = $this->traceFunction($context['trace'] ?? ag($context, 'exception.trace'));
+        $function = $this->traceFunction($this->traceData($context));
         $path ??= $context['e_file'] ?? $context['file'] ?? null;
         $line ??= $context['e_line'] ?? $context['line'] ?? null;
 
@@ -388,7 +396,7 @@ final class JsonlFormatter extends NormalizerFormatter
      */
     private function stack(array $context): ?string
     {
-        $trace = $context['trace'] ?? ag($context, 'exception.trace');
+        $trace = $this->traceData($context);
 
         if (is_string($trace) && '' !== trim($trace)) {
             return $trace;
@@ -406,7 +414,7 @@ final class JsonlFormatter extends NormalizerFormatter
      */
     private function exceptionTrace(array $context): ?string
     {
-        $trace = $context['trace'] ?? ag($context, 'exception.trace');
+        $trace = $this->traceData($context);
 
         if (is_string($trace) && '' !== trim($trace)) {
             return trim($trace);
@@ -443,6 +451,11 @@ final class JsonlFormatter extends NormalizerFormatter
         }
 
         return [] === $lines ? null : implode(PHP_EOL, $lines);
+    }
+
+    private function traceData(array $context): mixed
+    {
+        return ag($context, ['trace', 'exception.trace', 'error.trace', 'structured.exception.trace']);
     }
 
     private function traceFunction(mixed $trace): ?string
@@ -510,11 +523,11 @@ final class JsonlFormatter extends NormalizerFormatter
 
             $key = (string) $key;
 
-            if ('' === $prefix && in_array($key, $skip, true)) {
+            $path = '' === $prefix ? $key : $prefix . '.' . $key;
+
+            if (true === $this->shouldSkipPath($path, $skip)) {
                 continue;
             }
-
-            $path = '' === $prefix ? $key : $prefix . '.' . $key;
 
             if ($this->isSensitivePath($path)) {
                 $output[$path] = '[redacted]';
@@ -527,7 +540,7 @@ final class JsonlFormatter extends NormalizerFormatter
                     continue;
                 }
 
-                $this->flattenInto($output, $value, $path);
+                $this->flattenInto($output, $value, $path, $skip);
                 continue;
             }
 
@@ -545,7 +558,7 @@ final class JsonlFormatter extends NormalizerFormatter
                 $normalizedObject = $this->normalizeValue($value);
 
                 if (is_array($normalizedObject)) {
-                    $this->flattenInto($output, $normalizedObject, $path);
+                    $this->flattenInto($output, $normalizedObject, $path, $skip);
                     continue;
                 }
 
@@ -566,6 +579,20 @@ final class JsonlFormatter extends NormalizerFormatter
                 $output[$path] = $normalized;
             }
         }
+    }
+
+    /**
+     * @param list<string> $skip
+     */
+    private function shouldSkipPath(string $path, array $skip): bool
+    {
+        foreach ($skip as $skipPath) {
+            if ($path === $skipPath || true === str_starts_with($path, $skipPath . '.')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function isSensitivePath(string $path): bool

--- a/src/Libs/Extends/JsonlFormatter.php
+++ b/src/Libs/Extends/JsonlFormatter.php
@@ -1,0 +1,617 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Libs\Extends;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use DateTimeZone;
+use Monolog\Formatter\NormalizerFormatter;
+use Monolog\Level;
+use Monolog\LogRecord;
+use stdClass;
+use Throwable;
+
+final class JsonlFormatter extends NormalizerFormatter
+{
+    private const array SENSITIVE_KEYS = [
+        'authorization',
+        'cookie',
+        'jwt',
+        'token',
+        'password',
+        'passwd',
+        'secret',
+        'apikey',
+        'api_key',
+        'accesskey',
+        'privatekey',
+        'session',
+        'bearer',
+    ];
+
+    public function __construct()
+    {
+        parent::__construct(DateTimeInterface::RFC3339_EXTENDED);
+        $this->removeJsonEncodeOption(JSON_UNESCAPED_SLASHES);
+        $this->addJsonEncodeOption(JSON_UNESCAPED_UNICODE);
+        $this->addJsonEncodeOption(JSON_INVALID_UTF8_SUBSTITUTE);
+    }
+
+    /**
+     * Format a Monolog record as one JSONL line.
+     */
+    public function format(LogRecord $record): string
+    {
+        return $this->toJson($this->formatRecord($record), true) . PHP_EOL;
+    }
+
+    /**
+     * Format a batch of records as JSONL.
+     *
+     * @param array<LogRecord> $records
+     */
+    public function formatBatch(array $records): string
+    {
+        $lines = [];
+
+        foreach ($records as $record) {
+            $lines[] = $this->format($record);
+        }
+
+        return implode('', $lines);
+    }
+
+    /**
+     * Format non-Monolog values with the same JSONL schema.
+     *
+     * @param array<string,mixed> $context
+     * @param array<string,mixed> $extra
+     */
+    public function formatValues(
+        string $channel,
+        Level $level,
+        string $message,
+        array $context = [],
+        array $extra = [],
+        ?DateTimeInterface $datetime = null,
+    ): string {
+        $date = $datetime instanceof DateTimeInterface ? DateTimeImmutable::createFromInterface($datetime) : new DateTimeImmutable();
+
+        return $this->format(new LogRecord(
+            datetime: $date,
+            channel: $channel,
+            level: $level,
+            message: $message,
+            context: $context,
+            extra: $extra,
+        ));
+    }
+
+    /**
+     * Check whether a line already looks like a structured JSONL log record.
+     */
+    public static function isJsonlRecord(string $message): bool
+    {
+        $payload = json_decode(trim($message), true, 512, JSON_INVALID_UTF8_IGNORE);
+
+        if (false === is_array($payload)) {
+            return false;
+        }
+
+        if (1 === (int) ag($payload, 'schema', 0) && array_key_exists('message', $payload)) {
+            return true;
+        }
+
+        foreach (['id', 'datetime', 'level'] as $required) {
+            if (!isset($payload[$required]) || '' === trim((string) $payload[$required])) {
+                return false;
+            }
+        }
+
+        if (!isset($payload['logger']) && !isset($payload['channel'])) {
+            return false;
+        }
+
+        return array_key_exists('message', $payload);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function formatRecord(LogRecord $record): array
+    {
+        $fields = [];
+        $exceptionData = $this->exceptionData($record->context);
+        $source = $this->source($record->context, $record->channel, $exceptionData);
+        $exceptionMessage = $this->exceptionMessage($exceptionData);
+        $exception = $this->exception($exceptionData, $record->context);
+        $stack = $this->stack($record->context);
+        $processId = getmypid();
+
+        $this->flattenInto($fields, $record->context, skip: ['id', 'trace', 'e_file', 'e_line']);
+        $this->flattenInto($fields, $record->extra);
+
+        $payload = [
+            'id' => (string) ($record->context['id'] ?? generate_uuid()),
+            'datetime' => $record->datetime->setTimezone($this->timezone())->format(DateTimeInterface::RFC3339_EXTENDED),
+            'level' => strtolower((string) $record->level->getName()),
+            'levelno' => $this->syslogLevel($record->level),
+            'logger' => $record->channel,
+            'message' => $record->message,
+            'source' => $source,
+            'process' => [
+                'id' => false === $processId ? 0 : $processId,
+                'name' => PHP_SAPI,
+            ],
+            'thread' => [
+                'id' => 0,
+                'name' => 'main',
+            ],
+            'fields' => [] === $fields ? new stdClass() : $fields,
+        ];
+
+        if (null !== $exception) {
+            $payload['exception'] = $exception;
+        }
+
+        if (null !== $exceptionMessage) {
+            $payload['exception_message'] = $exceptionMessage;
+        }
+
+        if (null !== $stack) {
+            $payload['stack'] = $stack;
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param array<string,mixed> $context
+     * @param array<string,mixed> $exceptionData
+     * @return array<string,mixed>
+     */
+    private function source(array $context, string $channel, array $exceptionData = []): array
+    {
+        $path = null;
+        $line = null;
+        $function = null;
+        $module = $channel;
+
+        if (isset($context['cli']) && is_array($context['cli'])) {
+            $module = (string) ($context['cli']['command_name'] ?? $context['cli']['command_class'] ?? $module);
+        }
+
+        if ([] !== $exceptionData) {
+            $path = $exceptionData['file'] ?? null;
+            $line = $exceptionData['line'] ?? null;
+        }
+
+        $function = $this->traceFunction($context['trace'] ?? ag($context, 'exception.trace'));
+        $path ??= $context['e_file'] ?? $context['file'] ?? null;
+        $line ??= $context['e_line'] ?? $context['line'] ?? null;
+
+        $source = ['module' => $module];
+
+        if (is_string($path) && '' !== trim($path)) {
+            $source['path'] = $path;
+            $source['file'] = basename($path);
+        }
+
+        if (is_int($line) || is_numeric($line)) {
+            $source['line'] = (int) $line;
+        }
+
+        if (is_string($function) && '' !== trim($function)) {
+            $source['function'] = trim($function);
+        }
+
+        return $source;
+    }
+
+    /**
+     * @param array<string,mixed> $exceptionData
+     */
+    private function exceptionMessage(array $exceptionData): ?string
+    {
+        if ([] === $exceptionData) {
+            return null;
+        }
+
+        $type = $exceptionData['type'] ?? null;
+        $message = $exceptionData['message'] ?? null;
+
+        if (!is_string($type) || '' === trim($type)) {
+            return null;
+        }
+
+        $parts = explode('\\', $type);
+        $type = (string) end($parts);
+        $message = is_string($message) ? trim($message) : '';
+
+        return '' === $message ? $type : sprintf('%s: %s', $type, $message);
+    }
+
+    /**
+     * @param array<string,mixed> $exceptionData
+     * @param array<string,mixed> $context
+     */
+    private function exception(array $exceptionData, array $context): ?string
+    {
+        if ([] === $exceptionData) {
+            return null;
+        }
+
+        $type = $exceptionData['type'] ?? null;
+
+        if (!is_string($type) || '' === trim($type)) {
+            return null;
+        }
+
+        $headline = $this->exceptionHeadline($exceptionData) ?? trim($type);
+        $trace = $this->exceptionTrace($context);
+
+        if (is_string($trace) && '' !== trim($trace)) {
+            return $headline . PHP_EOL . trim($trace);
+        }
+
+        $file = $exceptionData['file'] ?? null;
+        $line = $exceptionData['line'] ?? null;
+
+        if (is_string($file) && '' !== trim($file)) {
+            $location = $file;
+
+            if (is_int($line) || is_numeric($line)) {
+                $location .= ':' . (int) $line;
+            }
+
+            return sprintf('%s (%s)', $headline, $location);
+        }
+
+        return $headline;
+    }
+
+    /**
+     * @param array<string,mixed> $exceptionData
+     */
+    private function exceptionHeadline(array $exceptionData): ?string
+    {
+        if ([] === $exceptionData) {
+            return null;
+        }
+
+        $type = $exceptionData['type'] ?? null;
+        $message = $exceptionData['message'] ?? null;
+
+        if (!is_string($type) || '' === trim($type)) {
+            return null;
+        }
+
+        $message = is_string($message) ? trim($message) : '';
+
+        return '' === $message ? trim($type) : sprintf('%s: %s', trim($type), $message);
+    }
+
+    /**
+     * @param array<string,mixed> $context
+     * @return array{type?:string,message?:string,file?:string,line?:int|string|float|null}
+     */
+    private function exceptionData(array $context): array
+    {
+        $exception = ag($context, 'structured.exception');
+
+        if (is_array($exception) && [] !== $exception) {
+            return $this->normalizeExceptionData($exception);
+        }
+
+        $exception = ag($context, 'exception');
+
+        if ($exception instanceof Throwable) {
+            return $this->normalizeExceptionData([
+                'type' => $exception::class,
+                'message' => $exception->getMessage(),
+                'file' => $exception->getFile(),
+                'line' => $exception->getLine(),
+            ]);
+        }
+
+        if (is_array($exception) && [] !== $exception) {
+            return $this->normalizeExceptionData([
+                'type' => ag($exception, ['type', 'kind']),
+                'message' => ag($exception, 'message'),
+                'file' => ag($exception, 'file'),
+                'line' => ag($exception, 'line'),
+            ]);
+        }
+
+        $error = ag($context, 'error');
+        if (is_array($error) && [] !== $error) {
+            return $this->normalizeExceptionData([
+                'type' => ag($error, ['type', 'kind']),
+                'message' => ag($error, ['message', 'error']),
+                'file' => ag($error, 'file'),
+                'line' => ag($error, 'line'),
+            ]);
+        }
+
+        if (isset($context['kind']) || isset($context['class']) || isset($context['file']) || isset($context['line'])) {
+            return $this->normalizeExceptionData([
+                'type' => $context['kind'] ?? $context['class'] ?? null,
+                'message' => $context['message'] ?? $context['error'] ?? null,
+                'file' => $context['file'] ?? null,
+                'line' => $context['line'] ?? null,
+            ]);
+        }
+
+        if (is_string($exception) && '' !== trim($exception)) {
+            return $this->normalizeExceptionData([
+                'type' => trim($exception),
+                'message' => $context['message'] ?? null,
+                'file' => $context['e_file'] ?? null,
+                'line' => $context['e_line'] ?? null,
+            ]);
+        }
+
+        return [];
+    }
+
+    /**
+     * @param array<string,mixed> $exception
+     * @return array{type?:string,message?:string,file?:string,line?:int|string|float|null}
+     */
+    private function normalizeExceptionData(array $exception): array
+    {
+        $normalized = [];
+
+        if ('' !== trim((string) ($exception['type'] ?? ''))) {
+            $normalized['type'] = trim((string) $exception['type']);
+        }
+
+        if ('' !== trim((string) ($exception['message'] ?? ''))) {
+            $normalized['message'] = trim((string) $exception['message']);
+        }
+
+        if ('' !== trim((string) ($exception['file'] ?? ''))) {
+            $normalized['file'] = trim((string) $exception['file']);
+        }
+
+        if (isset($exception['line']) && '' !== trim((string) $exception['line'])) {
+            $normalized['line'] = $exception['line'];
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param array<string,mixed> $context
+     */
+    private function stack(array $context): ?string
+    {
+        $trace = $context['trace'] ?? ag($context, 'exception.trace');
+
+        if (is_string($trace) && '' !== trim($trace)) {
+            return $trace;
+        }
+
+        if (!is_array($trace) || [] === $trace) {
+            return null;
+        }
+
+        return $this->toJson($trace, true);
+    }
+
+    /**
+     * @param array<string,mixed> $context
+     */
+    private function exceptionTrace(array $context): ?string
+    {
+        $trace = $context['trace'] ?? ag($context, 'exception.trace');
+
+        if (is_string($trace) && '' !== trim($trace)) {
+            return trim($trace);
+        }
+
+        if (!is_array($trace) || [] === $trace) {
+            return null;
+        }
+
+        $lines = [];
+
+        foreach ($trace as $index => $frame) {
+            if (!is_array($frame)) {
+                continue;
+            }
+
+            $prefix = '#' . $index;
+            $call = $this->traceCall($frame);
+            $location = $this->traceLocation($frame);
+
+            if ('' !== $location && '' !== $call) {
+                $lines[] = sprintf('%s %s at %s', $prefix, $call, $location);
+                continue;
+            }
+
+            if ('' !== $call) {
+                $lines[] = sprintf('%s %s', $prefix, $call);
+                continue;
+            }
+
+            if ('' !== $location) {
+                $lines[] = sprintf('%s %s', $prefix, $location);
+            }
+        }
+
+        return [] === $lines ? null : implode(PHP_EOL, $lines);
+    }
+
+    private function traceFunction(mixed $trace): ?string
+    {
+        if (!is_array($trace) || [] === $trace) {
+            return null;
+        }
+
+        $frame = $trace[0] ?? null;
+
+        if (!is_array($frame)) {
+            return null;
+        }
+
+        $call = $this->traceCall($frame);
+
+        return '' === $call ? null : $call;
+    }
+
+    /**
+     * @param array<string,mixed> $frame
+     */
+    private function traceCall(array $frame): string
+    {
+        $function = trim((string) ($frame['function'] ?? ''));
+        $class = trim((string) ($frame['class'] ?? ''));
+        $type = trim((string) ($frame['type'] ?? ''));
+
+        if ('' === $function) {
+            return '';
+        }
+
+        return '' === $class ? $function : $class . $type . $function;
+    }
+
+    /**
+     * @param array<string,mixed> $frame
+     */
+    private function traceLocation(array $frame): string
+    {
+        $file = trim((string) ($frame['file'] ?? ''));
+
+        if ('' === $file) {
+            return '';
+        }
+
+        if (isset($frame['line']) && '' !== trim((string) $frame['line'])) {
+            return $file . ':' . (int) $frame['line'];
+        }
+
+        return $file;
+    }
+
+    /**
+     * @param array<string,mixed> $output
+     * @param array<string,mixed> $data
+     * @param list<string> $skip
+     */
+    private function flattenInto(array &$output, array $data, string $prefix = '', array $skip = []): void
+    {
+        foreach ($data as $key => $value) {
+            if (!is_string($key) && !is_int($key)) {
+                continue;
+            }
+
+            $key = (string) $key;
+
+            if ('' === $prefix && in_array($key, $skip, true)) {
+                continue;
+            }
+
+            $path = '' === $prefix ? $key : $prefix . '.' . $key;
+
+            if ($this->isSensitivePath($path)) {
+                $output[$path] = '[redacted]';
+                continue;
+            }
+
+            if (is_array($value)) {
+                if ([] === $value) {
+                    $output[$path] = [];
+                    continue;
+                }
+
+                $this->flattenInto($output, $value, $path);
+                continue;
+            }
+
+            if ($value instanceof DateTimeInterface) {
+                $output[$path] = $value->format(DateTimeInterface::RFC3339_EXTENDED);
+                continue;
+            }
+
+            if ($value instanceof Throwable) {
+                $output[$path] = sprintf('%s: %s', $value::class, $value->getMessage());
+                continue;
+            }
+
+            if (is_object($value)) {
+                $normalizedObject = $this->normalizeValue($value);
+
+                if (is_array($normalizedObject)) {
+                    $this->flattenInto($output, $normalizedObject, $path);
+                    continue;
+                }
+
+                if (is_scalar($normalizedObject) || null === $normalizedObject) {
+                    $output[$path] = is_string($normalizedObject) ? $this->redactString($normalizedObject) : $normalizedObject;
+                }
+
+                continue;
+            }
+
+            $normalized = $this->normalizeValue($value);
+
+            if (is_string($normalized)) {
+                $normalized = $this->redactString($normalized);
+            }
+
+            if (is_scalar($normalized) || null === $normalized || [] === $normalized) {
+                $output[$path] = $normalized;
+            }
+        }
+    }
+
+    private function isSensitivePath(string $path): bool
+    {
+        $normalizedPath = strtolower(str_replace(['-', '_', '.'], '', $path));
+
+        foreach (self::SENSITIVE_KEYS as $key) {
+            if (str_contains($normalizedPath, strtolower(str_replace(['-', '_'], '', $key)))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function redactString(string $value): string
+    {
+        if (!str_contains($value, '?')) {
+            return $value;
+        }
+
+        return (string) preg_replace_callback(
+            '/([?&])([^=&]+)=([^&]*)/',
+            fn(array $matches): string => (
+                $matches[1] . $matches[2] . '=' . ($this->isSensitivePath((string) $matches[2]) ? '[redacted]' : $matches[3])
+            ),
+            $value,
+        );
+    }
+
+    private function timezone(): DateTimeZone
+    {
+        return new DateTimeZone(date_default_timezone_get());
+    }
+
+    private function syslogLevel(Level $level): int
+    {
+        return match ($level) {
+            Level::Debug => LOG_DEBUG,
+            Level::Info => LOG_INFO,
+            Level::Notice => LOG_NOTICE,
+            Level::Warning => LOG_WARNING,
+            Level::Error => LOG_ERR,
+            Level::Critical => LOG_CRIT,
+            Level::Alert => LOG_ALERT,
+            Level::Emergency => LOG_EMERG,
+        };
+    }
+}

--- a/src/Libs/Extends/JsonlStreamOutput.php
+++ b/src/Libs/Extends/JsonlStreamOutput.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Libs\Extends;
+
+use Monolog\Level;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface as iOutput;
+use Symfony\Component\Console\Output\StreamOutput;
+
+final class JsonlStreamOutput extends StreamOutput
+{
+    private bool $jsonl = false;
+    private mixed $message = '';
+    private JsonlFormatter $jsonlFormatter;
+
+    /**
+     * @param resource $stream
+     */
+    public function __construct(
+        $stream,
+        int $verbosity,
+        ?bool $decorated,
+        ?iOutput $formatter,
+        private readonly string $streamName,
+    ) {
+        $this->jsonlFormatter = new JsonlFormatter();
+
+        parent::__construct($stream, $verbosity, $decorated, $formatter);
+    }
+
+    /**
+     * Enable or disable JSONL output mode.
+     */
+    public function setJsonl(bool $jsonl): void
+    {
+        $this->jsonl = $jsonl;
+    }
+
+    /**
+     * Whether this stream output is in JSONL mode.
+     */
+    public function isJsonl(): bool
+    {
+        return $this->jsonl;
+    }
+
+    /**
+     * Return the last written message.
+     */
+    public function getLastMessage(): mixed
+    {
+        return $this->message;
+    }
+
+    /**
+     * Write an existing JSONL payload without wrapping it again.
+     */
+    public function writeJsonlRecord(string $payload): void
+    {
+        $payload = rtrim($payload, "\r\n");
+        $this->message = $payload . PHP_EOL;
+        parent::doWrite($payload, true);
+    }
+
+    protected function doWrite(string $message, bool $newline): void
+    {
+        $this->message = $message;
+
+        if (true === $this->jsonl) {
+            if (true === JsonlFormatter::isJsonlRecord($message)) {
+                $this->writeJsonlRecord($message);
+                return;
+            }
+
+            $payload = $this->jsonlFormatter->formatValues(
+                channel: 'cli',
+                level: 'stderr' === $this->streamName ? Level::Warning : Level::Info,
+                message: $this->normalizeMessage($message, $newline),
+                context: ['cli' => ['stream' => $this->streamName]],
+            );
+
+            $this->message = $payload;
+            parent::doWrite(rtrim($payload, "\r\n"), true);
+            return;
+        }
+
+        parent::doWrite($message, $newline);
+    }
+
+    private function normalizeMessage(string $message, bool $newline): string
+    {
+        $normalized = preg_replace('/\x1b\[[0-9;]*m/', '', $message) ?? $message;
+
+        if (true === $newline) {
+            return rtrim($normalized, "\r\n");
+        }
+
+        return $normalized;
+    }
+}

--- a/src/Libs/Extends/LogMessageProcessor.php
+++ b/src/Libs/Extends/LogMessageProcessor.php
@@ -34,6 +34,6 @@ class LogMessageProcessor implements ProcessorInterface
             'log_behavior' => true,
         ]);
 
-        return $record->with(...$repl);
+        return $record->with(message: $repl['message'], context: $record->context);
     }
 }

--- a/src/Libs/Extends/RemoteHandler.php
+++ b/src/Libs/Extends/RemoteHandler.php
@@ -47,14 +47,13 @@ final class RemoteHandler extends AbstractProcessingHandler
 
     protected function write(LogRecord $record): void
     {
-        $server = $_SERVER ?? [];
+        $structured = ag($record->context, 'structured', []);
+        if (false === is_array($structured)) {
+            $structured = [];
+        }
 
-        foreach ($server as $key => $value) {
-            if (!(is_string($key) && str_starts_with(strtoupper($key), 'WS_'))) {
-                continue;
-            }
-
-            $server[$key] = '***';
+        if (is_array($structured['server'] ?? null)) {
+            $structured['server'] = get_log_server_params($structured['server']);
         }
 
         try {
@@ -64,10 +63,14 @@ final class RemoteHandler extends AbstractProcessingHandler
                     'id' => generate_uuid(),
                     'message' => $record->message,
                     'trace' => ag($record->context, 'trace', []),
-                    'structured' => ag($record->context, 'structured', []),
+                    'structured' => $structured,
                     'server' => ag($_SERVER ?? [], ['HTTP_HOST', 'SERVER_NAME'], 'watchstate.cli'),
-                    'context' => $server,
-                    'raw' => $record->toArray(),
+                    'context' => get_log_server_params($_SERVER ?? []),
+                    'raw' => [
+                        'datetime' => $record->datetime->format(DATE_ATOM),
+                        'level' => strtolower((string) $record->level->getName()),
+                        'channel' => $record->channel,
+                    ],
                 ],
             ]);
         } catch (Throwable $e) {

--- a/src/Libs/Extends/StreamLogHandler.php
+++ b/src/Libs/Extends/StreamLogHandler.php
@@ -42,6 +42,11 @@ class StreamLogHandler extends ConsoleHandler
      */
     protected function write(LogRecord|array $record): void
     {
+        if ((true === $this->isJsonlOutput() || 'jsonl' === Config::get('console.output')) && true === $record instanceof LogRecord) {
+            $this->stream->write(new JsonlFormatter()->format($record));
+            return;
+        }
+
         if (true === $record instanceof LogRecord) {
             $record = $record->toArray();
         }

--- a/src/Libs/Guid.php
+++ b/src/Libs/Guid.php
@@ -37,7 +37,7 @@ final class Guid implements JsonSerializable, Stringable
     /**
      * @var array GUID types and their respective data types.
      */
-    private static array $supported = [
+    private const array DEFAULT_SUPPORTED = [
         Guid::GUID_IMDB => 'string',
         Guid::GUID_TVDB => 'string',
         Guid::GUID_TMDB => 'string',
@@ -49,6 +49,11 @@ final class Guid implements JsonSerializable, Stringable
     ];
 
     /**
+     * @var array GUID types and their respective data types.
+     */
+    private static array $supported = self::DEFAULT_SUPPORTED;
+
+    /**
      * Constant array for validating GUIDs.
      *
      * This array contains the patterns and example formats for validating GUIDs of different types.
@@ -58,7 +63,7 @@ final class Guid implements JsonSerializable, Stringable
      *
      * @var array<string, array{ pattern: string, example: string, tests: array{ valid: array<string|int>, invalid: array<string|int> } }>
      */
-    private static array $validateGuid = [
+    private const array DEFAULT_VALIDATE_GUID = [
         Guid::GUID_IMDB => [
             'description' => 'IMDB ID Parser.',
             'pattern' => '/^(?<guid>tt[0-9\/]+)$/i',
@@ -116,6 +121,18 @@ final class Guid implements JsonSerializable, Stringable
     ];
 
     /**
+     * Constant array for validating GUIDs.
+     *
+     * This array contains the patterns and example formats for validating GUIDs of different types.
+     * Each GUID type is mapped to an array with two keys:
+     * - 'pattern' (string): The regular expression pattern to match against the GUID.
+     * - 'example' (string): An example format of the GUID value.
+     *
+     * @var array<string, array{ pattern: string, example: string, tests: array{ valid: array<string|int>, invalid: array<string|int> } }>
+     */
+    private static array $validateGuid = self::DEFAULT_VALIDATE_GUID;
+
+    /**
      * @var string LOOKUP_KEY is how we format external ids to look up a record.
      */
     private const string LOOKUP_KEY = '{db}://{id}';
@@ -158,6 +175,18 @@ final class Guid implements JsonSerializable, Stringable
                 $this->getLogger()->info(
                     "Ignoring '{backend}' {item.type} '{item.title}' '{key}' external id. Unexpected value type.",
                     [
+                        'event_name' => 'guid.external_id.ignored',
+                        'subsystem' => 'guid',
+                        'operation' => 'parse',
+                        'outcome' => 'ignored',
+                        'reason' => 'unexpected_value_type',
+                        'reason_label' => 'external id value type is invalid',
+                        'client' => self::clientName($context),
+                        'user' => ag($context, 'user'),
+                        'backend' => ag($context, 'backend'),
+                        'item_id' => ag($context, 'item.id'),
+                        'guid_source' => $key,
+                        'guid_value' => is_scalar($value) || null === $value ? $value : get_debug_type($value),
                         'key' => $key,
                         'condition' => [
                             'expecting' => self::$supported[$key],
@@ -174,6 +203,18 @@ final class Guid implements JsonSerializable, Stringable
                     $this->getLogger()->info(
                         "Ignoring '{backend}' {item.type} '{item.title}' '{key}' external id. Unexpected value '{given}'. Expecting '{expected}'.",
                         [
+                            'event_name' => 'guid.external_id.ignored',
+                            'subsystem' => 'guid',
+                            'operation' => 'parse',
+                            'outcome' => 'ignored',
+                            'reason' => 'invalid_guid',
+                            'reason_label' => 'external id is invalid',
+                            'client' => self::clientName($context),
+                            'user' => ag($context, 'user'),
+                            'backend' => ag($context, 'backend'),
+                            'item_id' => ag($context, 'item.id'),
+                            'guid_source' => $key,
+                            'guid_value' => $value,
                             'key' => $key,
                             'expected' => self::$validateGuid[$key]['example'],
                             'given' => $value,
@@ -220,7 +261,19 @@ final class Guid implements JsonSerializable, Stringable
         }
 
         if (filesize($file) < 1) {
-            self::$logger?->info(r("The external GUID mapping file '{file}' is empty.", ['file' => $file]));
+            self::$logger?->info("GUID mapping file '{file}' is empty.", [
+                'event_name' => 'guid.mapping.ignored',
+                'subsystem' => 'guid',
+                'operation' => 'load_config',
+                'outcome' => 'ignored',
+                'reason' => 'empty_file',
+                'reason_label' => 'mapping file is empty',
+                'client' => 'guid',
+                'mapping_key' => null,
+                'mapping_from' => null,
+                'mapping_to' => null,
+                'file' => $file,
+            ]);
             return;
         }
 
@@ -261,59 +314,94 @@ final class Guid implements JsonSerializable, Stringable
 
         foreach ($guids as $key => $def) {
             if (false === is_array($def)) {
-                self::$logger?->warning(
-                    "Ignoring 'guids.{key}'. Value must be an object. '{given}' is given.",
-                    [
-                        'key' => $key,
-                        'given' => get_debug_type($def),
-                    ],
-                );
+                self::$logger?->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                    'event_name' => 'guid.mapping.ignored',
+                    'subsystem' => 'guid',
+                    'operation' => 'parse_config',
+                    'outcome' => 'ignored',
+                    'reason' => 'invalid_link_value',
+                    'reason_label' => 'value must be an object',
+                    'client' => 'guid',
+                    'mapping_key' => 'guids.' . $key,
+                    'mapping_from' => null,
+                    'mapping_to' => null,
+                    'given' => get_debug_type($def),
+                    'file' => $file,
+                ]);
                 continue;
             }
 
             $name = ag($def, 'name');
             if (null === $name || false === self::validateGUIDName($name)) {
-                self::$logger?->warning(
-                    "Ignoring 'guids.{key}'. name must start with 'guid_'. '{given}' is given.",
-                    [
-                        'key' => $key,
-                        'given' => $name ?? 'null',
-                    ],
-                );
+                self::$logger?->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                    'event_name' => 'guid.mapping.ignored',
+                    'subsystem' => 'guid',
+                    'operation' => 'parse_config',
+                    'outcome' => 'ignored',
+                    'reason' => 'invalid_guid_type_name',
+                    'reason_label' => "name must start with 'guid_'",
+                    'client' => 'guid',
+                    'mapping_key' => 'guids.' . $key,
+                    'mapping_from' => null,
+                    'mapping_to' => true === is_string($name) ? $name : null,
+                    'given' => $name ?? 'null',
+                    'file' => $file,
+                ]);
                 continue;
             }
 
             $type = ag($def, 'type');
             if (null === $type || false === is_string($type)) {
-                self::$logger?->warning(
-                    "Ignoring 'guids.{key}.{name}'. type must be a string. '{given}' is given.",
-                    [
-                        'key' => $key,
-                        'name' => $name,
-                        'given' => get_debug_type($type),
-                    ],
-                );
+                self::$logger?->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                    'event_name' => 'guid.mapping.ignored',
+                    'subsystem' => 'guid',
+                    'operation' => 'parse_config',
+                    'outcome' => 'ignored',
+                    'reason' => 'invalid_map_value',
+                    'reason_label' => 'type must be a string',
+                    'client' => 'guid',
+                    'mapping_key' => 'guids.' . $key,
+                    'mapping_from' => null,
+                    'mapping_to' => $name,
+                    'given' => get_debug_type($type),
+                    'file' => $file,
+                ]);
                 continue;
             }
 
             $validator = ag($def, 'validator', null);
             if (null === $validator || false === is_array($validator) || count($validator) < 1) {
-                self::$logger?->warning(
-                    "Ignoring 'guids.{key}.{name}'. validator key must be an object. '{given}' is given.",
-                    [
-                        'key' => $key,
-                        'name' => $name,
-                        'given' => get_debug_type($validator),
-                    ],
-                );
+                self::$logger?->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                    'event_name' => 'guid.mapping.ignored',
+                    'subsystem' => 'guid',
+                    'operation' => 'parse_config',
+                    'outcome' => 'ignored',
+                    'reason' => 'invalid_map_value',
+                    'reason_label' => 'validator key must be an object',
+                    'client' => 'guid',
+                    'mapping_key' => 'guids.' . $key,
+                    'mapping_from' => null,
+                    'mapping_to' => $name,
+                    'given' => get_debug_type($validator),
+                    'file' => $file,
+                ]);
                 continue;
             }
 
             $pattern = ag($validator, 'pattern');
             if (null === $pattern || false === @preg_match($pattern, '')) {
-                self::$logger?->warning("Ignoring 'guids.{key}.{name}'. validator.pattern is empty or invalid.", [
-                    'key' => $key,
-                    'name' => $name,
+                self::$logger?->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                    'event_name' => 'guid.mapping.ignored',
+                    'subsystem' => 'guid',
+                    'operation' => 'parse_config',
+                    'outcome' => 'ignored',
+                    'reason' => 'invalid_map_from',
+                    'reason_label' => 'validator.pattern is empty or invalid',
+                    'client' => 'guid',
+                    'mapping_key' => 'guids.' . $key,
+                    'mapping_from' => true === is_string($pattern) ? $pattern : null,
+                    'mapping_to' => $name,
+                    'file' => $file,
                 ]);
                 continue;
             }
@@ -321,27 +409,54 @@ final class Guid implements JsonSerializable, Stringable
             $example = ag($validator, 'example');
 
             if (empty($example) || false === is_string($example)) {
-                self::$logger?->warning("Ignoring 'guids.{key}.{name}'. validator.example is empty or not a string.", [
-                    'key' => $key,
-                    'name' => $name,
+                self::$logger?->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                    'event_name' => 'guid.mapping.ignored',
+                    'subsystem' => 'guid',
+                    'operation' => 'parse_config',
+                    'outcome' => 'ignored',
+                    'reason' => 'invalid_map_to',
+                    'reason_label' => 'validator.example is empty or not a string',
+                    'client' => 'guid',
+                    'mapping_key' => 'guids.' . $key,
+                    'mapping_from' => $pattern,
+                    'mapping_to' => true === is_string($example) ? $example : $name,
+                    'file' => $file,
                 ]);
                 continue;
             }
 
             $tests = ag($validator, 'tests', []);
             if (empty($tests) || false === is_array($tests)) {
-                self::$logger?->warning("Ignoring 'guids.{key}.{name}'. validator.tests key must be an object.", [
-                    'key' => $key,
-                    'name' => $name,
+                self::$logger?->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                    'event_name' => 'guid.mapping.ignored',
+                    'subsystem' => 'guid',
+                    'operation' => 'parse_config',
+                    'outcome' => 'ignored',
+                    'reason' => 'invalid_map_value',
+                    'reason_label' => 'validator.tests key must be an object',
+                    'client' => 'guid',
+                    'mapping_key' => 'guids.' . $key,
+                    'mapping_from' => $pattern,
+                    'mapping_to' => $name,
+                    'file' => $file,
                 ]);
                 continue;
             }
 
             $valid = ag($tests, 'valid', []);
             if (empty($valid) || false === is_array($valid) || count($valid) < 1) {
-                self::$logger?->warning("Ignoring 'guids.{key}.{name}'. validator.tests.valid key must be an array.", [
-                    'key' => $key,
-                    'name' => $name,
+                self::$logger?->warning("Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.", [
+                    'event_name' => 'guid.mapping.ignored',
+                    'subsystem' => 'guid',
+                    'operation' => 'parse_config',
+                    'outcome' => 'ignored',
+                    'reason' => 'invalid_map_from',
+                    'reason_label' => 'validator.tests.valid key must be an array',
+                    'client' => 'guid',
+                    'mapping_key' => 'guids.' . $key,
+                    'mapping_from' => $pattern,
+                    'mapping_to' => $name,
+                    'file' => Config::get('guid.file'),
                 ]);
                 continue;
             }
@@ -352,11 +467,19 @@ final class Guid implements JsonSerializable, Stringable
                 }
 
                 self::$logger?->warning(
-                    "Ignoring 'guids.{key}.{name}'. validator.tests.valid value '{val}' does not match pattern.",
+                    "Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.",
                     [
-                        'key' => $key,
-                        'name' => $name,
-                        'val' => $val,
+                        'event_name' => 'guid.mapping.ignored',
+                        'subsystem' => 'guid',
+                        'operation' => 'parse_config',
+                        'outcome' => 'ignored',
+                        'reason' => 'invalid_map_from',
+                        'reason_label' => 'validator.tests.valid value does not match pattern',
+                        'client' => 'guid',
+                        'mapping_key' => 'guids.' . $key,
+                        'mapping_from' => (string) $val,
+                        'mapping_to' => $name,
+                        'file' => $file,
                     ],
                 );
                 continue 2;
@@ -365,10 +488,19 @@ final class Guid implements JsonSerializable, Stringable
             $invalid = ag($tests, 'invalid', []);
             if (empty($invalid) || false === is_array($invalid) || count($invalid) < 1) {
                 self::$logger?->warning(
-                    "Ignoring 'guids.{key}.{name}'. validator.tests.invalid key must be an array.",
+                    "Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.",
                     [
-                        'key' => $key,
-                        'name' => $name,
+                        'event_name' => 'guid.mapping.ignored',
+                        'subsystem' => 'guid',
+                        'operation' => 'parse_config',
+                        'outcome' => 'ignored',
+                        'reason' => 'invalid_map_to',
+                        'reason_label' => 'validator.tests.invalid key must be an array',
+                        'client' => 'guid',
+                        'mapping_key' => 'guids.' . $key,
+                        'mapping_from' => $pattern,
+                        'mapping_to' => $name,
+                        'file' => $file,
                     ],
                 );
                 continue;
@@ -380,11 +512,19 @@ final class Guid implements JsonSerializable, Stringable
                 }
 
                 self::$logger?->warning(
-                    "Ignoring 'guids.{key}.{name}'. validator.tests.invalid value '{val}' matches pattern.",
+                    "Ignoring GUID mapping '{mapping_key}' for {client}: {reason_label}.",
                     [
-                        'key' => $key,
-                        'name' => $name,
-                        'val' => $val,
+                        'event_name' => 'guid.mapping.ignored',
+                        'subsystem' => 'guid',
+                        'operation' => 'parse_config',
+                        'outcome' => 'ignored',
+                        'reason' => 'invalid_map_to',
+                        'reason_label' => 'validator.tests.invalid value matches pattern',
+                        'client' => 'guid',
+                        'mapping_key' => 'guids.' . $key,
+                        'mapping_from' => (string) $val,
+                        'mapping_to' => $name,
+                        'file' => $file,
                     ],
                 );
                 continue 2;
@@ -561,16 +701,14 @@ final class Guid implements JsonSerializable, Stringable
                 self::parseGUIDFile($file);
             }
         } catch (Throwable $e) {
-            self::$logger?->error("Failed to read or parse '{guid}' file. Error '{error}'.", [
-                'guid' => $file,
-                'error' => $e->getMessage(),
-                'exception' => [
-                    'message' => $e->getMessage(),
-                    'code' => $e->getCode(),
-                    'file' => $e->getFile(),
-                    'line' => $e->getLine(),
-                    'trace' => $e->getTrace(),
-                ],
+            self::$logger?->error("Failed to parse GUID mapping file '{file}' for {client}.", [
+                'event_name' => 'guid.file.parse_failed',
+                'subsystem' => 'guid',
+                'operation' => 'load_config',
+                'outcome' => 'failed',
+                'client' => 'guid',
+                'file' => $file,
+                ...exception_log($e),
             ]);
         } finally {
             self::$checkedExternalFile = true;
@@ -584,6 +722,8 @@ final class Guid implements JsonSerializable, Stringable
     public static function reparse(): void
     {
         self::$checkedExternalFile = false;
+        self::$supported = self::DEFAULT_SUPPORTED;
+        self::$validateGuid = self::DEFAULT_VALIDATE_GUID;
     }
 
     /**
@@ -596,5 +736,16 @@ final class Guid implements JsonSerializable, Stringable
     public static function validateGUIDName(string $name): bool
     {
         return str_starts_with($name, 'guid_') && is_valid_name($name);
+    }
+
+    private static function clientName(array $context): string
+    {
+        $client = ag($context, 'client');
+
+        if (true === is_string($client) && '' !== $client) {
+            return $client;
+        }
+
+        return 'guid';
     }
 }

--- a/src/Libs/Identities/IdentityProvisionService.php
+++ b/src/Libs/Identities/IdentityProvisionService.php
@@ -20,6 +20,16 @@ use Throwable;
 
 final class IdentityProvisionService
 {
+    /**
+     * @var array<int, array{backend: string, client: string, user: string, message: string}>
+     */
+    private array $backendUserFailures = [];
+
+    /**
+     * @var array<int, array{identity: string, backend: string, message: string}>
+     */
+    private array $tokenFailures = [];
+
     public function __construct(
         private readonly iImport $mapper,
         private readonly iLogger $logger,
@@ -159,6 +169,8 @@ final class IdentityProvisionService
      */
     public function preview(array $mapping = []): array
     {
+        $this->resetProvisionFailures();
+
         if ([] === $mapping) {
             $mapping = $this->loadMappings();
         }
@@ -203,6 +215,7 @@ final class IdentityProvisionService
     public function provision(IdentityProvisionRequest $request): array
     {
         set_time_limit(60 * 10);
+        $this->resetProvisionFailures();
 
         $hasIdentities = $this->hasIdentities();
 
@@ -253,7 +266,7 @@ final class IdentityProvisionService
             $backendUsers = $this->getBackendUsers($backends, $mapping, false);
 
             if (count($backendUsers) < 1) {
-                throw new RuntimeException('No backend users were found.');
+                throw new RuntimeException($this->noBackendUsersMessage());
             }
 
             $results = $this->generateSingleBackendIdentities($backendUsers);
@@ -282,6 +295,7 @@ final class IdentityProvisionService
             return [
                 'identities' => $identities,
                 'has_identities' => $hasIdentities,
+                'warnings' => $this->tokenFailures,
             ];
         }
 
@@ -297,7 +311,7 @@ final class IdentityProvisionService
         $backendUsers = $this->getBackendUsers($backends, $mapping);
 
         if (count($backendUsers) < 1) {
-            throw new RuntimeException('No backend users were found.');
+            throw new RuntimeException($this->noBackendUsersMessage());
         }
 
         $results = $this->generateIdentitiesList($backendUsers, $mapping);
@@ -325,7 +339,39 @@ final class IdentityProvisionService
         return [
             'identities' => $identities,
             'has_identities' => $hasIdentities,
+            'warnings' => $this->tokenFailures,
         ];
+    }
+
+    /**
+     * Reset per-run provisioning failures.
+     */
+    private function resetProvisionFailures(): void
+    {
+        $this->backendUserFailures = [];
+        $this->tokenFailures = [];
+    }
+
+    /**
+     * Build the user-facing no-users error message.
+     */
+    private function noBackendUsersMessage(): string
+    {
+        if ([] === $this->backendUserFailures) {
+            return 'No backend users were found.';
+        }
+
+        $failures = array_map(
+            static fn(array $failure): string => r('{backend}: {message}', [
+                'backend' => $failure['backend'],
+                'message' => $failure['message'],
+            ]),
+            $this->backendUserFailures,
+        );
+
+        return r('No backend users were found. Failed backends: {failures}', [
+            'failures' => implode('; ', $failures),
+        ]);
     }
 
     /**
@@ -585,6 +631,13 @@ final class IdentityProvisionService
                     $users[] = $user;
                 }
             } catch (Throwable $e) {
+                $this->backendUserFailures[] = [
+                    'backend' => $client->getContext()->backendName,
+                    'client' => $client->getContext()->clientName,
+                    'user' => $client->getContext()->userContext->name,
+                    'message' => $e->getMessage(),
+                ];
+
                 $this->logger->error(
                     "Failed to load users from backend '{backend}' via {client}.",
                     [
@@ -793,6 +846,12 @@ final class IdentityProvisionService
                             );
 
                             if (false === $token) {
+                                $this->tokenFailures[] = [
+                                    'identity' => $identityName,
+                                    'backend' => $name,
+                                    'message' => 'Failed to generate access token.',
+                                ];
+
                                 $this->logger->error(
                                     message: "Failed to generate an access token for '{identity}@{backend}'.",
                                     context: [
@@ -811,6 +870,12 @@ final class IdentityProvisionService
                         }
                     }
                 } catch (Throwable $e) {
+                    $this->tokenFailures[] = [
+                        'identity' => $identityName,
+                        'backend' => $name,
+                        'message' => $e->getMessage(),
+                    ];
+
                     $this->logger->error(
                         message: "Failed to generate an access token for '{identity}@{backend}'.",
                         context: [

--- a/src/Libs/Identities/IdentityProvisionService.php
+++ b/src/Libs/Identities/IdentityProvisionService.php
@@ -41,16 +41,26 @@ final class IdentityProvisionService
             $type = strtolower(ag($backend, 'type', 'unknown'));
 
             if (!isset($supported[$type])) {
-                $this->logger->error("SYSTEM: Ignoring '{backend}'. Unexpected backend type '{type}'.", [
-                    'type' => $type,
+                $this->logger->warning("Skipping backend '{backend}': type '{backend_type}' is unsupported.", [
+                    'event_name' => 'identity.provision.backend.ignored',
+                    'subsystem' => 'identity.provision',
+                    'operation' => 'backend.load',
+                    'outcome' => 'ignored',
+                    'reason' => 'unsupported_type',
+                    'backend_type' => $type,
                     'backend' => $backendName,
-                    'types' => implode(', ', array_keys($supported)),
+                    'supported_backend_types' => array_keys($supported),
                 ]);
                 continue;
             }
 
             if (null === ($url = ag($backend, 'url')) || false === is_valid_url($url)) {
-                $this->logger->error("SYSTEM: Ignoring '{backend}'. Invalid url '{url}'.", [
+                $this->logger->warning("Skipping backend '{backend}': URL '{url}' is invalid.", [
+                    'event_name' => 'identity.provision.backend.ignored',
+                    'subsystem' => 'identity.provision',
+                    'operation' => 'backend.load',
+                    'outcome' => 'ignored',
+                    'reason' => 'invalid_url',
                     'url' => $url ?? 'None',
                     'backend' => $backendName,
                 ]);
@@ -88,15 +98,31 @@ final class IdentityProvisionService
         }
 
         if (false === $map->has('version')) {
-            $this->logger->warning('SYSTEM: Starting with mapper.yaml v1.5, the version key is required.');
+            $this->logger->warning('Mapper file is missing the required version key.', [
+                'event_name' => 'identity.provision.map.warning',
+                'subsystem' => 'identity.provision',
+                'operation' => 'map.load',
+                'outcome' => 'warning',
+                'reason' => 'missing_version',
+            ]);
         }
 
         if (false === $map->has('map')) {
-            $this->logger->warning('SYSTEM: Please upgrade your mapper.yaml file to v1.5 format spec.');
+            $this->logger->warning('Mapper file uses the legacy format and should be upgraded.', [
+                'event_name' => 'identity.provision.map.warning',
+                'subsystem' => 'identity.provision',
+                'operation' => 'map.load',
+                'outcome' => 'warning',
+                'reason' => 'legacy_format',
+            ]);
         }
 
-        $this->logger->info('SYSTEM: Mapper file found, using it to map identities.', [
-            'map' => array_to_string($mapping),
+        $this->logger->info('Loaded persisted identity mappings from the mapper file.', [
+            'event_name' => 'identity.provision.map.loaded',
+            'subsystem' => 'identity.provision',
+            'operation' => 'map.load',
+            'outcome' => 'completed',
+            'stats' => ['mapping_count' => count($mapping)],
         ]);
 
         return $mapping;
@@ -214,7 +240,15 @@ final class IdentityProvisionService
                 );
             }
 
-            $this->logger->notice('SYSTEM: Running in single backend identity mode.');
+            $this->logger->notice('Starting identity provisioning in single-backend mode.', [
+                'event_name' => 'identity.provision.started',
+                'subsystem' => 'identity.provision',
+                'operation' => 'provision',
+                'outcome' => 'started',
+                'reason' => 'single_backend_mode',
+                'backend_count' => $countBackends,
+                'dry_run' => $request->dryRun,
+            ]);
 
             $backendUsers = $this->getBackendUsers($backends, $mapping, false);
 
@@ -229,11 +263,21 @@ final class IdentityProvisionService
                 throw new RuntimeException('No identities were found in the single backend.');
             }
 
-            $this->logger->notice("SYSTEM: Matched '{results}' from single backend.", [
-                'results' => array_to_string($this->identitiesList($identities)),
-            ]);
-
             $this->createIdentities($request, $identities);
+
+            $this->logger->notice('Identity provisioning completed with {identity_count} identities from the single backend.', [
+                'event_name' => 'identity.provision.completed',
+                'subsystem' => 'identity.provision',
+                'operation' => 'provision',
+                'outcome' => 'completed',
+                'reason' => 'single_backend_mode',
+                'backend_count' => $countBackends,
+                'identity_count' => count($identities),
+                'dry_run' => $request->dryRun,
+                'stats' => [
+                    'identity_count' => count($identities),
+                ],
+            ]);
 
             return [
                 'identities' => $identities,
@@ -241,8 +285,13 @@ final class IdentityProvisionService
             ];
         }
 
-        $this->logger->notice("SYSTEM: Getting users list from '{backends}'.", [
-            'backends' => implode(', ', array_keys($backends)),
+        $this->logger->notice('Starting identity provisioning across {backend_count} backends.', [
+            'event_name' => 'identity.provision.started',
+            'subsystem' => 'identity.provision',
+            'operation' => 'provision',
+            'outcome' => 'started',
+            'backend_count' => count($backends),
+            'dry_run' => $request->dryRun,
         ]);
 
         $backendUsers = $this->getBackendUsers($backends, $mapping);
@@ -258,11 +307,20 @@ final class IdentityProvisionService
             throw new RuntimeException("We weren't able to match any identities across backends.");
         }
 
-        $this->logger->notice("SYSTEM: Matched '{results}'.", [
-            'results' => array_to_string($this->identitiesList($identities)),
-        ]);
-
         $this->createIdentities($request, $identities);
+
+        $this->logger->notice('Identity provisioning completed with {identity_count} identities across {backend_count} backends.', [
+            'event_name' => 'identity.provision.completed',
+            'subsystem' => 'identity.provision',
+            'operation' => 'provision',
+            'outcome' => 'completed',
+            'backend_count' => count($backends),
+            'identity_count' => count($identities),
+            'dry_run' => $request->dryRun,
+            'stats' => [
+                'identity_count' => count($identities),
+            ],
+        ]);
 
         return [
             'identities' => $identities,
@@ -347,11 +405,16 @@ final class IdentityProvisionService
                     'source_backend' => $sourceBackendName,
                 ];
 
-                $this->logger->info("SYSTEM: Syncing identity backend '{identity}@{backend}' from '{source}'.", [
+                $this->logger->info("Synced backend '{identity}@{backend}' from '{source_backend}'.", [
+                    'event_name' => 'identity.provision.backend.completed',
+                    'subsystem' => 'identity.provision',
+                    'operation' => 'backend.sync',
+                    'outcome' => 'completed',
                     'identity' => $identityName,
                     'backend' => $backendName,
-                    'source' => $sourceBackendName,
+                    'source_backend' => $sourceBackendName,
                     'dry_run' => $dryRun,
+                    'updated' => true,
                 ]);
 
                 if (false === $dryRun) {
@@ -383,7 +446,15 @@ final class IdentityProvisionService
             $backend = $user['backend'];
 
             if (ag($user, 'id') === ag($user, 'client_data.options.' . Options::ALT_ID)) {
-                $this->logger->debug('Skipping main user "{name}".', ['name' => $user['name']]);
+                $this->logger->debug('Skipping main user during single-backend identity generation.', [
+                    'event_name' => 'identity.provision.user.skipped',
+                    'subsystem' => 'identity.provision',
+                    'operation' => 'user.match',
+                    'outcome' => 'skipped',
+                    'reason' => 'main_user',
+                    'user' => $user['name'],
+                    'backend' => $backend,
+                ]);
                 continue;
             }
 
@@ -412,8 +483,14 @@ final class IdentityProvisionService
             $client = ag($backend, 'class');
             assert($client instanceof iClient, 'Expected backend client instance.');
 
-            $this->logger->info("SYSTEM: Getting users from '{backend}'.", [
+            $this->logger->info("Loading users from backend '{backend}'.", [
+                'event_name' => 'identity.provision.backend.started',
+                'subsystem' => 'identity.provision',
+                'operation' => 'backend.users.load',
+                'outcome' => 'started',
                 'backend' => $client->getContext()->backendName,
+                'backend_type' => strtolower($client->getType()),
+                'client' => $client->getContext()->clientName,
             ]);
 
             try {
@@ -436,8 +513,16 @@ final class IdentityProvisionService
 
                     if (false === is_valid_name($user['name'])) {
                         $this->logger->error(
-                            message: "SYSTEM: Invalid user name '{backend}: {name}'. User names must be in [a-z_0-9] format. Skipping user.",
-                            context: ['name' => $user['name'], 'backend' => $backendName],
+                            message: "Skipping '{backend}: {user}': user names must use [a-z_0-9].",
+                            context: [
+                                'event_name' => 'identity.provision.user.ignored',
+                                'subsystem' => 'identity.provision',
+                                'operation' => 'user.validate',
+                                'outcome' => 'ignored',
+                                'reason' => 'invalid_user_name',
+                                'user' => $user['name'],
+                                'backend' => $backendName,
+                            ],
                         );
                         continue;
                     }
@@ -451,8 +536,16 @@ final class IdentityProvisionService
 
                     if (false === is_valid_name($info['backendName'])) {
                         $this->logger->error(
-                            message: "SYSTEM: Invalid backend name '{name}'. Backend name must be in [a-z_0-9] format. skipping the associated users.",
-                            context: ['name' => $info['backendName']],
+                            message: "Skipping users from backend '{backend}': generated backend name '{backend_name}' is invalid.",
+                            context: [
+                                'event_name' => 'identity.provision.backend.ignored',
+                                'subsystem' => 'identity.provision',
+                                'operation' => 'backend.users.load',
+                                'outcome' => 'ignored',
+                                'reason' => 'invalid_backend_name',
+                                'backend' => $backendName,
+                                'backend_name' => $info['backendName'],
+                            ],
                         );
                         continue;
                     }
@@ -493,23 +586,16 @@ final class IdentityProvisionService
                 }
             } catch (Throwable $e) {
                 $this->logger->error(
-                    "Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' get users list. '{error.message}' at '{error.file}:{error.line}'.",
+                    "Failed to load users from backend '{backend}' via {client}.",
                     [
+                        'event_name' => 'identity.provision.backend.failed',
+                        'subsystem' => 'identity.provision',
+                        'operation' => 'backend.users.load',
+                        'outcome' => 'failed',
                         'client' => $client->getContext()->clientName,
                         'backend' => $client->getContext()->backendName,
                         'user' => $client->getContext()->userContext->name,
-                        'error' => [
-                            'kind' => $e::class,
-                            'line' => $e->getLine(),
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
-                        'exception' => [
-                            'file' => $e->getFile(),
-                            'line' => $e->getLine(),
-                            'kind' => get_class($e),
-                            'message' => $e->getMessage(),
-                        ],
+                        ...exception_log($e),
                     ],
                 );
             }
@@ -534,8 +620,15 @@ final class IdentityProvisionService
 
             if (false === is_valid_name($identityName)) {
                 $this->logger->error(
-                    message: "SYSTEM: Invalid identity name '{identity}'. Identity names must be in [a-z_0-9] format. skipping identity.",
-                    context: ['identity' => $identityName],
+                    message: "Skipping identity '{identity}': names must use [a-z_0-9].",
+                    context: [
+                        'event_name' => 'identity.provision.user.ignored',
+                        'subsystem' => 'identity.provision',
+                        'operation' => 'user.validate',
+                        'outcome' => 'ignored',
+                        'reason' => 'invalid_identity_name',
+                        'identity' => $identityName,
+                    ],
                 );
                 continue;
             }
@@ -544,16 +637,28 @@ final class IdentityProvisionService
 
             $this->logger->info(
                 false === is_dir($identityPath)
-                    ? "SYSTEM: Creating '{identity}' directory '{path}'."
-                    : "SYSTEM: '{identity}' directory '{path}' already exists.",
+                    ? "Creating directory '{path}' for identity '{identity}'."
+                    : "Identity directory '{path}' already exists for '{identity}'.",
                 [
+                    'event_name' => false === is_dir($identityPath)
+                        ? 'identity.provision.user.started'
+                        : 'identity.provision.user.skipped',
+                    'subsystem' => 'identity.provision',
+                    'operation' => 'user.directory',
+                    'outcome' => false === is_dir($identityPath) ? 'started' : 'skipped',
+                    'reason' => false === is_dir($identityPath) ? null : 'already_exists',
                     'identity' => $identityName,
                     'path' => $identityPath,
                 ],
             );
 
             if (false === $request->dryRun && false === is_dir($identityPath) && false === mkdir($identityPath, 0o755, true)) {
-                $this->logger->error("SYSTEM: Failed to create '{identity}' directory '{path}'.", [
+                $this->logger->error("Failed to create directory '{path}' for identity '{identity}'.", [
+                    'event_name' => 'identity.provision.user.failed',
+                    'subsystem' => 'identity.provision',
+                    'operation' => 'user.directory',
+                    'outcome' => 'failed',
+                    'reason' => 'mkdir_failed',
                     'identity' => $identityName,
                     'path' => $identityPath,
                 ]);
@@ -563,9 +668,16 @@ final class IdentityProvisionService
             $configFile = "{$identityPath}/servers.yaml";
             $this->logger->notice(
                 file_exists($configFile)
-                    ? "SYSTEM: '{identity}' configuration file '{file}' already exists."
-                    : "SYSTEM: Creating '{identity}' configuration file '{file}'.",
+                    ? "Identity configuration file '{file}' already exists for '{identity}'."
+                    : "Creating identity configuration file '{file}' for '{identity}'.",
                 [
+                    'event_name' => file_exists($configFile)
+                        ? 'identity.provision.user.skipped'
+                        : 'identity.provision.user.started',
+                    'subsystem' => 'identity.provision',
+                    'operation' => 'user.config',
+                    'outcome' => file_exists($configFile) ? 'skipped' : 'started',
+                    'reason' => file_exists($configFile) ? 'already_exists' : null,
                     'identity' => $identityName,
                     'file' => $configFile,
                 ],
@@ -585,8 +697,16 @@ final class IdentityProvisionService
 
                 if (false === is_valid_name($name)) {
                     $this->logger->error(
-                        message: "SYSTEM: Invalid backend name '{name}'. Backend name must be in [a-z_0-9] format. skipping backend.",
-                        context: ['name' => $name],
+                        message: "Skipping backend '{backend_name}' for identity '{identity}': names must use [a-z_0-9].",
+                        context: [
+                            'event_name' => 'identity.provision.backend.ignored',
+                            'subsystem' => 'identity.provision',
+                            'operation' => 'backend.persist',
+                            'outcome' => 'ignored',
+                            'reason' => 'invalid_backend_name',
+                            'identity' => $identityName,
+                            'backend_name' => $name,
+                        ],
                     );
                     continue;
                 }
@@ -632,9 +752,15 @@ final class IdentityProvisionService
                             ]);
                         }
 
-                        $this->logger->info("SYSTEM: Updating identity configuration for '{identity}@{name}' backend.", [
+                        $this->logger->info("Updated backend '{identity}@{backend}' configuration.", [
+                            'event_name' => 'identity.provision.backend.completed',
+                            'subsystem' => 'identity.provision',
+                            'operation' => 'backend.update',
+                            'outcome' => 'completed',
                             'name' => $name,
                             'identity' => $identityName,
+                            'backend' => $name,
+                            'updated' => true,
                         ]);
 
                         foreach ($update as $key => $value) {
@@ -668,8 +794,16 @@ final class IdentityProvisionService
 
                             if (false === $token) {
                                 $this->logger->error(
-                                    message: "Failed to generate access token for '{identity}@{backend}' backend.",
-                                    context: ['identity' => $identityName, 'backend' => $name],
+                                    message: "Failed to generate an access token for '{identity}@{backend}'.",
+                                    context: [
+                                        'event_name' => 'identity.provision.backend.failed',
+                                        'subsystem' => 'identity.provision',
+                                        'operation' => 'backend.token.generate',
+                                        'outcome' => 'failed',
+                                        'reason' => 'token_generation_failed',
+                                        'identity' => $identityName,
+                                        'backend' => $name,
+                                    ],
                                 );
                             } else {
                                 $perIdentity->set("{$name}.token", $token);
@@ -678,22 +812,15 @@ final class IdentityProvisionService
                     }
                 } catch (Throwable $e) {
                     $this->logger->error(
-                        message: "Failed to generate access token for '{identity}@{name}' backend. {error} at '{file}:{line}'.",
+                        message: "Failed to generate an access token for '{identity}@{backend}'.",
                         context: [
-                            'name' => $name,
+                            'event_name' => 'identity.provision.backend.failed',
+                            'subsystem' => 'identity.provision',
+                            'operation' => 'backend.token.generate',
+                            'outcome' => 'failed',
+                            'backend' => $name,
                             'identity' => $identityName,
-                            'error' => [
-                                'kind' => $e::class,
-                                'line' => $e->getLine(),
-                                'message' => $e->getMessage(),
-                                'file' => after($e->getFile(), ROOT_PATH),
-                            ],
-                            'exception' => [
-                                'file' => $e->getFile(),
-                                'line' => $e->getLine(),
-                                'kind' => get_class($e),
-                                'message' => $e->getMessage(),
-                            ],
+                            ...exception_log($e),
                         ],
                     );
                     continue;
@@ -703,9 +830,16 @@ final class IdentityProvisionService
             $dbFile = get_user_db($identityName);
             $this->logger->notice(
                 file_exists($dbFile)
-                    ? "SYSTEM: '{identity}' database file '{db}' already exists."
-                    : "SYSTEM: Creating '{identity}' database file '{db}'.",
+                    ? "Identity database '{db}' already exists for '{identity}'."
+                    : "Creating identity database '{db}' for '{identity}'.",
                 [
+                    'event_name' => file_exists($dbFile)
+                        ? 'identity.provision.user.skipped'
+                        : 'identity.provision.user.started',
+                    'subsystem' => 'identity.provision',
+                    'operation' => 'user.database',
+                    'outcome' => file_exists($dbFile) ? 'skipped' : 'started',
+                    'reason' => file_exists($dbFile) ? 'already_exists' : null,
                     'identity' => $identityName,
                     'db' => $dbFile,
                 ],
@@ -755,7 +889,11 @@ final class IdentityProvisionService
             }
 
             if (true === $request->generateBackup && false === $request->shouldRecreate()) {
-                $this->logger->notice("SYSTEM: Queuing event to backup '{identity}' remote watch state.", [
+                $this->logger->notice("Queued the initial backup for identity '{identity}'.", [
+                    'event_name' => 'identity.provision.user.queued',
+                    'subsystem' => 'identity.provision',
+                    'operation' => 'user.backup.queue',
+                    'outcome' => 'queued',
                     'identity' => $identityName,
                 ]);
 
@@ -797,7 +935,15 @@ final class IdentityProvisionService
             $nameLower = strtolower($user['name']);
 
             if (ag($user, 'id') === ag($user, 'client_data.options.' . Options::ALT_ID)) {
-                $this->logger->debug('Skipping main user "{name}".', ['name' => $user['name']]);
+                $this->logger->debug('Skipping main user during identity matching.', [
+                    'event_name' => 'identity.provision.user.skipped',
+                    'subsystem' => 'identity.provision',
+                    'operation' => 'user.match',
+                    'outcome' => 'skipped',
+                    'reason' => 'main_user',
+                    'user' => $user['name'],
+                    'backend' => $backend,
+                ]);
                 continue;
             }
 
@@ -894,10 +1040,16 @@ final class IdentityProvisionService
                         continue;
                     }
 
-                    $this->logger->notice("Mapper: Found map entry for '{backend}: {user}'", [
+                    $this->logger->notice("Found a mapper entry for '{backend}: {user}'.", [
+                        'event_name' => 'identity.provision.map.matched',
+                        'subsystem' => 'identity.provision',
+                        'operation' => 'map.match',
+                        'outcome' => 'completed',
                         'backend' => $backend,
                         'user' => $nameLower,
-                        'map' => $mapRow,
+                        'stats' => [
+                            'mapped_backend_count' => count($mapRow),
+                        ],
                     ]);
                     $matchedMapEntry = $mapRow;
                     break;
@@ -959,7 +1111,12 @@ final class IdentityProvisionService
                         continue;
                     }
 
-                    $this->logger->error("No partial fallback match via map for '{backend}: {user}'", [
+                    $this->logger->error("Mapper entry for '{backend}: {user}' did not produce a cross-backend match.", [
+                        'event_name' => 'identity.provision.map.failed',
+                        'subsystem' => 'identity.provision',
+                        'operation' => 'map.match',
+                        'outcome' => 'failed',
+                        'reason' => 'insufficient_backend_matches',
                         'backend' => $userObj['backend'],
                         'user' => $userObj['name'],
                     ]);
@@ -989,14 +1146,22 @@ final class IdentityProvisionService
                     continue;
                 }
 
-                $this->logger->error("No other users were found that match '{backend}: {user}{real_name}'.", [
+                $this->logger->error("No matching users were found for '{backend}: {user}{real_name}'.", [
+                    'event_name' => 'identity.provision.user.unmatched',
+                    'subsystem' => 'identity.provision',
+                    'operation' => 'user.match',
+                    'outcome' => 'failed',
+                    'reason' => 'no_cross_backend_match',
                     'backend' => $userObj['backend'],
                     'user' => $userObj['name'],
                     'real_name' => $userObj['real_name'] !== $userObj['name']
                         ? r(' ({rl})', ['rl' => $userObj['real_name']])
                         : '',
-                    'map' => array_to_string($map),
-                    'list' => array_to_string($usersList),
+                    'stats' => [
+                        'mapping_count' => count($map),
+                        'backend_count' => count($allBackends),
+                        'user_count' => count($usersList),
+                    ],
                 ]);
 
                 $unmatched[] = [
@@ -1059,7 +1224,12 @@ final class IdentityProvisionService
         static $reported = [];
 
         if (null === ($username = ag($user, 'name'))) {
-            $this->logger->error("MAPPER: No username was given from one user of '{backend}' backend.", [
+            $this->logger->error("Skipping mapper actions for backend '{backend}': the user name is missing.", [
+                'event_name' => 'identity.provision.map.failed',
+                'subsystem' => 'identity.provision',
+                'operation' => 'map.apply',
+                'outcome' => 'failed',
+                'reason' => 'missing_username',
                 'backend' => $backend,
             ]);
             return;
@@ -1070,7 +1240,12 @@ final class IdentityProvisionService
         if (count($hasMapping) < 1) {
             if (!isset($reported[$backend])) {
                 $reported[$backend] = true;
-                $this->logger->info("MAPPER: No mapping with '{backend}' as backend exists.", [
+                $this->logger->info("No mapper entries reference backend '{backend}'.", [
+                    'event_name' => 'identity.provision.map.skipped',
+                    'subsystem' => 'identity.provision',
+                    'operation' => 'map.apply',
+                    'outcome' => 'skipped',
+                    'reason' => 'backend_not_mapped',
                     'backend' => $backend,
                 ]);
             }
@@ -1098,7 +1273,12 @@ final class IdentityProvisionService
         unset($loopMap, $map);
 
         if (false === $found) {
-            $this->logger->debug("MAPPER: No map exists for '{backend}: {username}'.", [
+            $this->logger->debug("No mapper entry exists for '{backend}: {username}'.", [
+                'event_name' => 'identity.provision.map.skipped',
+                'subsystem' => 'identity.provision',
+                'operation' => 'map.apply',
+                'outcome' => 'skipped',
+                'reason' => 'user_not_mapped',
                 'backend' => $backend,
                 'username' => $username,
             ]);
@@ -1116,8 +1296,13 @@ final class IdentityProvisionService
         if (null !== ($newUsername = ag($userMap, 'replace_with'))) {
             if (false === is_string($newUsername) || false === is_valid_name($newUsername)) {
                 $this->logger->error(
-                    message: "MAPPER: Failed to replace '{backend}: {username}' with '{backend}: {new_username}' name must be in [a-z_0-9] format.",
+                    message: "Cannot rename '{backend}: {username}' to '{backend}: {new_username}': names must use [a-z_0-9].",
                     context: [
+                        'event_name' => 'identity.provision.map.failed',
+                        'subsystem' => 'identity.provision',
+                        'operation' => 'map.apply',
+                        'outcome' => 'failed',
+                        'reason' => 'invalid_replacement_name',
                         'backend' => $backend,
                         'username' => $username,
                         'new_username' => $newUsername,
@@ -1127,8 +1312,12 @@ final class IdentityProvisionService
             }
 
             $this->logger->notice(
-                message: "MAPPER: Renaming '{backend}: {username}' to '{backend}: {new_username}'.",
+                message: "Renamed '{backend}: {username}' to '{backend}: {new_username}' using the mapper.",
                 context: [
+                    'event_name' => 'identity.provision.map.completed',
+                    'subsystem' => 'identity.provision',
+                    'operation' => 'map.apply',
+                    'outcome' => 'completed',
                     'backend' => $backend,
                     'username' => $username,
                     'new_username' => $newUsername,
@@ -1285,7 +1474,11 @@ final class IdentityProvisionService
             return;
         }
 
-        $this->logger->notice("SYSTEM: Deleting identities directory '{path}' contents.", [
+        $this->logger->notice("Deleting existing identity configuration under '{path}'.", [
+            'event_name' => 'identity.provision.purge.started',
+            'subsystem' => 'identity.provision',
+            'operation' => 'provision.purge',
+            'outcome' => 'started',
             'path' => $path,
         ]);
 

--- a/src/Libs/Initializer.php
+++ b/src/Libs/Initializer.php
@@ -11,6 +11,8 @@ use App\Libs\Exceptions\Backends\RuntimeException;
 use App\Libs\Exceptions\HttpException;
 use App\Libs\Extends\ConsoleHandler;
 use App\Libs\Extends\ConsoleOutput;
+use App\Libs\Extends\JsonlFileHandler;
+use App\Libs\Extends\JsonlFormatter;
 use App\Libs\Extends\RemoteHandler;
 use App\Libs\Extends\RouterStrategy;
 use Closure;
@@ -196,6 +198,7 @@ final class Initializer
 
             $this->cli->setCommandLoader(new CommandLoader(Container::getContainer(), $routes, $aliases));
 
+            $this->cliOutput->syncJsonlMode();
             $this->cli->run(output: $this->cliOutput);
         } catch (Throwable $e) {
             $this->cli->renderThrowable($e, $this->cliOutput);
@@ -458,11 +461,14 @@ final class Initializer
         if (null !== ($logfile = Config::get('api.logfile'))) {
             $this->accessLog = $logger
                 ->withName(name: 'http')
-                ->pushHandler($wrap->withHandler(new StreamHandler($logfile, Level::Info, true)));
+                ->pushHandler($wrap->withHandler(new JsonlFileHandler($logfile, Level::Info, true)));
 
             if (true === $inContainer) {
+                $handler = new StreamHandler('php://stderr', Level::Info, true);
+                $handler->setFormatter(new JsonlFormatter());
+
                 assert($this->accessLog instanceof Logger, 'Expected logger instance for access log.');
-                $this->accessLog->pushHandler($wrap->withHandler(new StreamHandler('php://stderr', Level::Info, true)));
+                $this->accessLog->pushHandler($wrap->withHandler($handler));
             }
         }
 
@@ -488,14 +494,20 @@ final class Initializer
 
             switch (ag($context, 'type')) {
                 case 'stream':
+                    $handler = 'jsonl' === ag($context, 'format')
+                        ? new JsonlFileHandler(
+                            ag($context, 'filename'),
+                            ag($context, 'level', Level::Info),
+                            (bool) ag($context, 'bubble', true),
+                        )
+                        : new StreamHandler(
+                            ag($context, 'filename'),
+                            ag($context, 'level', Level::Info),
+                            (bool) ag($context, 'bubble', true),
+                        );
+
                     $logger->pushHandler(
-                        $wrap->withHandler(
-                            new StreamHandler(
-                                ag($context, 'filename'),
-                                ag($context, 'level', Level::Info),
-                                (bool) ag($context, 'bubble', true),
-                            ),
-                        ),
+                        $wrap->withHandler($handler),
                     );
                     break;
                 case 'remote':
@@ -549,7 +561,6 @@ final class Initializer
         int|string|Level $level,
         string $message,
         array $context = [],
-        bool $forceContext = false,
     ): void {
         if (null === $this->accessLog) {
             return;
@@ -586,11 +597,7 @@ final class Initializer
             $context['attributes'] = $attributes;
         }
 
-        if (true === (Config::get('logs.context') || $forceContext)) {
-            $this->accessLog->log($level, $message, $context);
-        } else {
-            $this->accessLog->log($level, r($message, $context));
-        }
+        $this->accessLog->log($level, $message, $context);
     }
 
     private function formatLog(iRequest $request, iResponse $response, ?string $message = null): string

--- a/src/Libs/Initializer.php
+++ b/src/Libs/Initializer.php
@@ -12,7 +12,6 @@ use App\Libs\Exceptions\HttpException;
 use App\Libs\Extends\ConsoleHandler;
 use App\Libs\Extends\ConsoleOutput;
 use App\Libs\Extends\JsonlFileHandler;
-use App\Libs\Extends\JsonlFormatter;
 use App\Libs\Extends\RemoteHandler;
 use App\Libs\Extends\RouterStrategy;
 use Closure;
@@ -20,6 +19,7 @@ use ErrorException;
 use League\Route\Http\Exception as RouterHttpException;
 use League\Route\RouteGroup;
 use League\Route\Router as APIRouter;
+use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogHandler;
 use Monolog\Level;
@@ -465,7 +465,11 @@ final class Initializer
 
             if (true === $inContainer) {
                 $handler = new StreamHandler('php://stderr', Level::Info, true);
-                $handler->setFormatter(new JsonlFormatter());
+                $handler->setFormatter(new LineFormatter(
+                    format: '%message%' . PHP_EOL,
+                    allowInlineLineBreaks: true,
+                    ignoreEmptyContextAndExtra: true,
+                ));
 
                 assert($this->accessLog instanceof Logger, 'Expected logger instance for access log.');
                 $this->accessLog->pushHandler($wrap->withHandler($handler));

--- a/src/Libs/Initializer.php
+++ b/src/Libs/Initializer.php
@@ -143,11 +143,16 @@ final class Initializer
         });
 
         set_exception_handler(static function (Throwable $e) use ($logger) {
-            $logger->error(message: '{class}: {error} ({file}:{line}).' . PHP_EOL, context: [
-                'class' => $e::class,
-                'error' => $e->getMessage(),
-                'file' => $e->getFile(),
-                'line' => $e->getLine(),
+            $logger->error('Unhandled exception: {error.message}.', [
+                'event_name' => 'app.exception.unhandled',
+                'subsystem' => 'app',
+                'operation' => 'exception',
+                'outcome' => 'failed',
+                'sapi' => PHP_SAPI,
+                'request' => [
+                    'uri' => before($_SERVER['REQUEST_URI'] ?? '', '?'),
+                ],
+                ...exception_log($e),
             ]);
             exit(1);
         });
@@ -159,12 +164,22 @@ final class Initializer
 
             gc_collect_cycles();
 
-            $logger->error(message: "{class}: {error} at '{file}:{line}'. '{URI}'", context: [
-                'class' => 'PHP.Engine',
-                'error' => $error['message'] ?? 'Unknown error',
-                'file' => $error['file'] ?? 'Unknown file',
-                'line' => $error['line'] ?? 'Unknown line',
-                'URI' => before($_SERVER['REQUEST_URI'] ?? '', '?'),
+            $logger->error('Fatal shutdown error.', [
+                'event_name' => 'app.shutdown.fatal',
+                'subsystem' => 'app',
+                'operation' => 'shutdown',
+                'outcome' => 'failed',
+                'request' => [
+                    'uri' => before($_SERVER['REQUEST_URI'] ?? '', '?'),
+                ],
+                'php' => [
+                    'error' => [
+                        'type' => $error['type'] ?? null,
+                        'message' => $error['message'] ?? 'Unknown error',
+                        'file' => $error['file'] ?? 'Unknown file',
+                        'line' => $error['line'] ?? 'Unknown line',
+                    ],
+                ],
             ]);
         });
 
@@ -236,6 +251,17 @@ final class Initializer
                 $request,
                 $response->getStatusCode() >= 400 ? Level::Error : Level::Info,
                 $this->formatLog($request, $response),
+                [
+                    'event_name' => 'http.request.completed',
+                    'subsystem' => 'http.request',
+                    'operation' => 'serve',
+                    'outcome' => 'completed',
+                    'response' => [
+                        'status_code' => $response->getStatusCode(),
+                        'size' => $response->getBody()->getSize() ?? 0,
+                    ],
+                    'duration_seconds' => $this->durationSeconds($response),
+                ],
             );
         } catch (HttpException|RouterHttpException $e) {
             $realStatusCode = $e instanceof RouterHttpException ? $e->getStatusCode() : $e->getCode();
@@ -247,11 +273,20 @@ final class Initializer
             );
 
             if (Status::SERVICE_UNAVAILABLE->value === $statusCode) {
-                Container::get(iLogger::class)->error($e->getMessage(), [
-                    'kind' => $e::class,
-                    'file' => $e->getFile(),
-                    'line' => $e->getLine(),
-                    'trace' => $e->getTrace(),
+                Container::get(iLogger::class)->error('HTTP request failed for {request.method} {request.path}.', [
+                    'event_name' => 'http.request.failed',
+                    'subsystem' => 'http.request',
+                    'operation' => 'serve',
+                    'outcome' => 'failed',
+                    'request' => [
+                        'method' => $request->getMethod(),
+                        'path' => $request->getUri()->getPath(),
+                        'uri' => (string) $request->getUri(),
+                    ],
+                    'response' => [
+                        'status_code' => $statusCode,
+                    ],
+                    ...exception_log($e),
                 ]);
             }
 
@@ -259,6 +294,17 @@ final class Initializer
                 $request,
                 $statusCode >= 400 ? Level::Error : Level::Info,
                 $this->formatLog($request, $response),
+                [
+                    'event_name' => 'http.request.failed',
+                    'subsystem' => 'http.request',
+                    'operation' => 'serve',
+                    'outcome' => 'failed',
+                    'response' => [
+                        'status_code' => $response->getStatusCode(),
+                        'size' => $response->getBody()->getSize() ?? 0,
+                    ],
+                    'duration_seconds' => $this->durationSeconds($response),
+                ],
             );
         } catch (Throwable $e) {
             $response = api_error(
@@ -277,14 +323,32 @@ final class Initializer
                     ],
             );
 
-            Container::get(iLogger::class)->error($e->getMessage(), [
-                'kind' => $e::class,
-                'file' => $e->getFile(),
-                'line' => $e->getLine(),
-                'trace' => $e->getTrace(),
+            Container::get(iLogger::class)->error('HTTP request failed for {request.method} {request.path}.', [
+                'event_name' => 'http.request.failed',
+                'subsystem' => 'http.request',
+                'operation' => 'serve',
+                'outcome' => 'failed',
+                'request' => [
+                    'method' => $request->getMethod(),
+                    'path' => $request->getUri()->getPath(),
+                    'uri' => (string) $request->getUri(),
+                ],
+                'response' => [
+                    'status_code' => Status::SERVICE_UNAVAILABLE->value,
+                ],
+                ...exception_log($e),
             ]);
 
-            $this->write($request, Level::Error, $this->formatLog($request, $response));
+            $this->write($request, Level::Error, $this->formatLog($request, $response), [
+                'event_name' => 'http.request.failed',
+                'subsystem' => 'http.request',
+                'operation' => 'serve',
+                'outcome' => 'failed',
+                'response' => [
+                    'status_code' => $response->getStatusCode(),
+                    'size' => $response->getBody()->getSize() ?? 0,
+                ],
+            ]);
         }
 
         return $response;
@@ -607,6 +671,7 @@ final class Initializer
     private function formatLog(iRequest $request, iResponse $response, ?string $message = null): string
     {
         $refer = '-';
+        $duration = $this->durationSeconds($response);
 
         if (true === ag_exists($request->getServerParams(), 'HTTP_REFERER')) {
             $refer = new Uri(ag($request->getServerParams(), 'HTTP_REFERER'))
@@ -615,17 +680,31 @@ final class Initializer
                 ->withUserInfo('');
         }
 
-        return r('{ip} - "{method} {uri} {protocol}" {status} {size} "{refer}" "{agent}" "{message}"', [
-            'ip' => get_client_ip($request),
-            'user' => ag($request->getServerParams(), 'REMOTE_USER', '-'),
-            'method' => $request->getMethod(),
-            'uri' => $request->getUri()->getPath(),
-            'protocol' => 'HTTP/' . $request->getProtocolVersion(),
-            'status' => $response->getStatusCode(),
-            'size' => $response->getBody()->getSize() ?? 0,
-            'agent' => ag($request->getServerParams(), 'HTTP_USER_AGENT', '-'),
-            'refer' => (string) $refer,
-            'message' => $message ?? '-',
-        ]);
+        return r(
+            $response->getStatusCode() >= 400
+                ? '{request.ip} {method} {path} failed with {status}{duration}.'
+                : '{request.ip} {method} {path} completed with {status}{duration}.',
+            [
+                'method' => $request->getMethod(),
+                'path' => $request->getUri()->getPath(),
+                'status' => $response->getStatusCode(),
+                'duration' => null === $duration ? '' : r(' in {duration}s', ['duration' => $duration]),
+                'message' => $message ?? '-',
+                'refer' => (string) $refer,
+            ],
+        );
+    }
+
+    private function durationSeconds(iResponse $response): ?float
+    {
+        $duration = $response->getHeaderLine('X-Application-Finished-In');
+
+        if ('' === $duration) {
+            return null;
+        }
+
+        $duration = rtrim($duration, 's');
+
+        return is_numeric($duration) ? (float) $duration : null;
     }
 }

--- a/src/Libs/Mappers/Import/DirectMapper.php
+++ b/src/Libs/Mappers/Import/DirectMapper.php
@@ -185,6 +185,7 @@ class DirectMapper implements ImportInterface
      */
     public function loadData(?iDate $date = null): self
     {
+        $startedAt = microtime(true);
         $this->fullyLoaded = null === $date;
 
         $opts = [
@@ -211,10 +212,18 @@ class DirectMapper implements ImportInterface
             $this->addPointers($entity, $pointer, true);
         }
 
-        $this->logger->info("{mapper}: Preloaded '{user}: {pointers}' pointers into memory.", [
-            'mapper' => after_last(self::class, '\\'),
-            'pointers' => number_format(count($this->pointers)),
-            'user' => $this->userContext->name ?? 'main',
+        $this->logger->info('Preloaded {pointer_count} pointers and {object_count} objects for \'{user}\' into {mapper}.', [
+            ...$this->mapperContext(),
+            'event_name' => 'mapper.preload.completed',
+            'operation' => 'preload',
+            'outcome' => 'completed',
+            'pointer_count' => count($this->pointers),
+            'object_count' => count($this->objects),
+            'duration_seconds' => round(microtime(true) - $startedAt, 4),
+            'memory' => [
+                'now' => get_memory_usage(),
+                'peak' => get_peak_memory_usage(),
+            ],
         ]);
 
         return $this;
@@ -237,15 +246,15 @@ class DirectMapper implements ImportInterface
             Message::increment("{$entity->via}.{$entity->type}.failed");
 
             $this->logger->notice(
-                "{mapper}: [N] Ignoring '{user}@{backend}' - '{title}'. Not found locally, and backend set as metadata source only.",
-                [
-                    'mapper' => after_last(self::class, '\\'),
-                    'metaOnly' => true,
-                    'backend' => $entity->via,
-                    'title' => $entity->getName(),
-                    'data' => $entity->getAll(),
-                    'user' => $this->userContext->name ?? 'main',
-                ],
+                'Ignoring {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\': backend is metadata-only.',
+                $this->itemContext($entity, [
+                    'event_name' => 'mapper.item.ignored',
+                    'operation' => 'add',
+                    'outcome' => 'ignored',
+                    'reason' => 'metadata_source_only',
+                    'meta_only' => true,
+                    'state' => $entity->getAll(),
+                ]),
             );
 
             return $this;
@@ -283,12 +292,11 @@ class DirectMapper implements ImportInterface
                 }
             }
 
-            $this->logger->notice("{mapper}: [N] '{user}@{backend}' added '#{item_id}: {title}'.", [
-                'item_id' => $entity->id ?? 'New',
-                'user' => $this->userContext->name ?? 'main',
-                'mapper' => after_last(self::class, '\\'),
-                'backend' => $entity->via,
-                'title' => $entity->getName(),
+            $this->logger->notice('Added {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\' to local state.', [
+                ...$this->itemContext($entity),
+                'event_name' => 'mapper.item.added',
+                'operation' => 'add',
+                'outcome' => 'added',
                 'metadata' => $data,
             ]);
 
@@ -322,12 +330,12 @@ class DirectMapper implements ImportInterface
             Message::increment("{$entity->via}.{$entity->type}.failed");
             $this->logger->error(
                 ...lw(
-                    message: "{mapper}: [N] Exception '{error.kind}' was thrown unhandled during '{user}@{backend}' - '{title}' add as new item. {error.message} at '{error.file}:{error.line}'.",
+                    message: 'Failed to map {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\' during add.',
                     context: [
-                        'user' => $this->userContext->name ?? 'main',
-                        'mapper' => after_last(self::class, '\\'),
-                        'backend' => $entity->via,
-                        'title' => $entity->getName(),
+                        ...$this->itemContext($entity),
+                        'event_name' => 'mapper.item.failed',
+                        'operation' => 'add',
+                        'outcome' => 'failed',
                         'state' => $entity->getAll(),
                         ...exception_log($e),
                     ],
@@ -387,18 +395,18 @@ class DirectMapper implements ImportInterface
                         $changeLog = $local->diff(fields: $_keys);
                     }
 
-                    $message = "{mapper}: [T] '{user}@{backend}' updated '#{item_id}: {title}' ";
-
                     $this->logger->log(
                         true === $progressChange ? LogLevel::NOTICE : LogLevel::INFO,
-                        $message . (true === $progressChange ? 'due to play progress change.' : 'metadata.'),
+                        true === $progressChange
+                            ? 'Updated {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\' due to play progress change.'
+                            : 'Updated metadata for {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\'.',
                         [
-                            'user' => $this->userContext->name ?? 'main',
-                            'mapper' => after_last(self::class, '\\'),
-                            'item_id' => $local->id ?? 'New',
-                            'backend' => $entity->via,
-                            'title' => $local->getName(),
+                            ...$this->itemContext($local, ['backend' => $entity->via]),
+                            'event_name' => 'mapper.item.updated',
+                            'operation' => true === $progressChange ? 'progress' : 'metadata',
+                            'outcome' => 'updated',
                             'changes' => $changeLog,
+                            'changed_fields' => array_keys($changeLog),
                         ],
                     );
                 }
@@ -439,13 +447,12 @@ class DirectMapper implements ImportInterface
                 Message::increment("{$entity->via}.{$local->type}.failed");
                 $this->logger->error(
                     ...lw(
-                        message: "{mapper}: [T] Exception '{error.kind}' was thrown unhandled during '{user}@{backend}' - '{title}' metadata-only handling. {error.message} at '{error.file}:{error.line}'.",
+                        message: 'Failed to map {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\' during metadata update.',
                         context: [
-                            'user' => $this->userContext->name ?? 'main',
-                            'mapper' => after_last(self::class, '\\'),
-                            'item_id' => $local->id ?? 'New',
-                            'backend' => $entity->via,
-                            'title' => $local->getName(),
+                            ...$this->itemContext($local, ['backend' => $entity->via]),
+                            'event_name' => 'mapper.item.failed',
+                            'operation' => 'metadata',
+                            'outcome' => 'failed',
                             'state' => [
                                 'database' => $local->getAll(),
                                 'backend' => $entity->getAll(),
@@ -460,14 +467,14 @@ class DirectMapper implements ImportInterface
             return $this;
         }
 
-        $msg = "{mapper}: [T] Ignoring '{user}@{backend}' - '#{item_id}: {title}'. No metadata changes detected.";
-        $context = [
-            'user' => $this->userContext->name ?? 'main',
-            'mapper' => after_last(self::class, '\\'),
-            'item_id' => $local->id ?? 'New',
+        $msg = 'No metadata changes for {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\'.';
+        $context = $this->itemContext($local, [
             'backend' => $entity->via,
-            'title' => $local->getName(),
-        ];
+            'event_name' => 'mapper.item.unchanged',
+            'operation' => 'metadata',
+            'outcome' => 'completed',
+            'reason' => 'no_metadata_changes',
+        ]);
 
         if (true === $metadataOnly) {
             if (null !== $writer) {
@@ -488,15 +495,15 @@ class DirectMapper implements ImportInterface
             }
 
             $this->logger->notice(
-                "{mapper}: [T] '{user}@{backend}' item '#{item_id}: {title}' reported '{state}' vs local '{local_state}', but the state change was ignored due to '{reasons}'.",
+                'Ignoring state change for {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\': remote state {state} differs from local {local_state}.',
                 [
-                    'user' => $this->userContext->name ?? 'main',
-                    'mapper' => after_last(self::class, '\\'),
-                    'item_id' => $local->id ?? 'New',
-                    'backend' => $entity->via,
+                    ...$this->itemContext($local, ['backend' => $entity->via]),
+                    'event_name' => 'mapper.item.ignored',
+                    'operation' => 'state',
+                    'outcome' => 'ignored',
+                    'reason' => 'state_change_ignored',
                     'state' => $entity->isWatched() ? 'played' : 'unplayed',
                     'local_state' => $local->isWatched() ? 'played' : 'unplayed',
-                    'title' => $entity->getName(),
                     'reasons' => implode(', ', $reasons),
                 ],
             );
@@ -551,13 +558,15 @@ class DirectMapper implements ImportInterface
                     }
                 }
 
-                $this->logger->notice("{mapper}: [O] '{user}@{backend}' marked '#{item_id}: {title}' as 'unplayed'.", [
-                    'mapper' => after_last(self::class, '\\'),
-                    'item_id' => $cloned->id ?? 'New',
-                    'backend' => $entity->via,
-                    'title' => $cloned->getName(),
+                $this->logger->notice('Marked {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\' as unplayed.', [
+                    ...$this->itemContext($cloned, ['backend' => $entity->via]),
+                    'event_name' => 'mapper.item.state_changed',
+                    'operation' => 'state',
+                    'outcome' => 'completed',
+                    'old_state' => $cloned->isWatched() ? 'played' : 'unplayed',
+                    'new_state' => 'unplayed',
                     'changes' => $local->diff(),
-                    'user' => $this->userContext->name ?? 'main',
+                    'changed_fields' => array_keys($local->diff()),
                 ]);
 
                 if (null === ($this->changed[$local->id] ?? null)) {
@@ -575,13 +584,12 @@ class DirectMapper implements ImportInterface
                 Message::increment("{$entity->via}.{$local->type}.failed");
                 $this->logger->error(
                     ...lw(
-                        message: "{mapper}: [O] Exception '{error.kind}' was thrown unhandled during '{user}@{backend}' - '{title}' handle old entity unplayed. {error.message} at '{error.file}:{error.line}'.",
+                        message: 'Failed to map {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\' during state update.',
                         context: [
-                            'user' => $this->userContext->name ?? 'main',
-                            'mapper' => after_last(self::class, '\\'),
-                            'item_id' => $cloned->id ?? 'New',
-                            'backend' => $entity->via,
-                            'title' => $cloned->getName(),
+                            ...$this->itemContext($cloned, ['backend' => $entity->via]),
+                            'event_name' => 'mapper.item.failed',
+                            'operation' => 'state',
+                            'outcome' => 'failed',
                             'state' => [
                                 'database' => $cloned->getAll(),
                                 'backend' => $entity->getAll(),
@@ -636,17 +644,18 @@ class DirectMapper implements ImportInterface
                             $changeLog = $local->diff(fields: $_keys);
                         }
 
-                        $message = "{mapper}: [O] '{user}@{backend}' updated '#{item_id}: {title}'";
                         $this->logger->log(
                             true === $progressChange ? LogLevel::NOTICE : LogLevel::INFO,
-                            $message . (true === $progressChange ? ' due to play progress change.' : ' metadata.'),
+                            true === $progressChange
+                                ? 'Updated {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\' due to play progress change.'
+                                : 'Updated metadata for {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\'.',
                             [
-                                'user' => $this->userContext->name ?? 'main',
-                                'mapper' => after_last(self::class, '\\'),
-                                'item_id' => $cloned->id ?? 'New',
-                                'backend' => $entity->via,
-                                'title' => $cloned->getName(),
+                                ...$this->itemContext($cloned, ['backend' => $entity->via]),
+                                'event_name' => 'mapper.item.updated',
+                                'operation' => true === $progressChange ? 'progress' : 'metadata',
+                                'outcome' => 'updated',
                                 'changes' => $changeLog,
+                                'changed_fields' => array_keys($changeLog),
                             ],
                         );
                     }
@@ -687,13 +696,12 @@ class DirectMapper implements ImportInterface
                     Message::increment("{$entity->via}.{$local->type}.failed");
                     $this->logger->error(
                         ...lw(
-                            message: "{mapper}: [O] Exception '{error.kind}' was thrown unhandled during '{user}@{backend}' - '{title}' handle old entity always update metadata. {error.message} at '{error.file}:{error.line}'.",
+                            message: 'Failed to map {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\' during metadata update.',
                             context: [
-                                'user' => $this->userContext->name ?? 'main',
-                                'mapper' => after_last(self::class, '\\'),
-                                'item_id' => $cloned->id ?? 'New',
-                                'backend' => $entity->via,
-                                'title' => $cloned->getName(),
+                                ...$this->itemContext($cloned, ['backend' => $entity->via]),
+                                'event_name' => 'mapper.item.failed',
+                                'operation' => 'metadata',
+                                'outcome' => 'failed',
                                 'state' => [
                                     'database' => $cloned->getAll(),
                                     'backend' => $entity->getAll(),
@@ -722,17 +730,17 @@ class DirectMapper implements ImportInterface
             $enable = Config::get('clients.jellyfin.fix_played', false);
             if ($enable && $entity->isWatched() && true === $entity->getContext('should_mark', false)) {
                 $this->logger->notice(
-                    "{mapper}: [O] '{user}@{backend}' item '#{item_id}: {title}' date '{remote_date}' is older than last sync date '{local_date}'. Due to bug in jellyfin API a special case handling is applied to mark the item as played.",
+                    'Queued {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\' for reprocessing because Jellyfin reported a stale played date.',
                     [
-                        'user' => $this->userContext->name ?? 'main',
-                        'mapper' => after_last(self::class, '\\'),
-                        'item_id' => $cloned->id ?? 'New',
-                        'backend' => $entity->via,
+                        ...$this->itemContext($cloned, ['backend' => $entity->via]),
+                        'event_name' => 'mapper.item.requeued',
+                        'operation' => 'state',
+                        'outcome' => 'requeued',
+                        'reason' => 'jellyfin_played_date_bug',
                         'remote_date' => make_date($entity->updated),
                         'local_date' => make_date($opts[Options::AFTER]),
                         'state' => $entity->isWatched() ? 'played' : 'unplayed',
                         'local_state' => $local->isWatched() ? 'played' : 'unplayed',
-                        'title' => $entity->getName(),
                     ],
                 );
                 $entity->updated = $opts[Options::AFTER]->getTimestamp() + 1;
@@ -743,17 +751,18 @@ class DirectMapper implements ImportInterface
             }
 
             $this->logger->notice(
-                "[CODE:DM001] {mapper}: [O] '{user}@{backend}' item '#{item_id}: {title}' [R: {state}] date '{remote_date}' is older than backend last sync date '{local_date}' [L: {local_state}]. Queueing item for re-processing. Check FAQ.",
+                'Queued {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\' for reprocessing because remote data changed before last sync.',
                 [
-                    'user' => $this->userContext->name ?? 'main',
-                    'mapper' => after_last(self::class, '\\'),
-                    'item_id' => $cloned->id ?? 'New',
-                    'backend' => $entity->via,
+                    ...$this->itemContext($cloned, ['backend' => $entity->via]),
+                    'event_name' => 'mapper.item.requeued',
+                    'operation' => 'state',
+                    'outcome' => 'requeued',
+                    'reason' => 'remote_updated_before_last_sync',
+                    'code' => 'DM001',
                     'remote_date' => make_date($entity->updated),
                     'local_date' => make_date($opts[Options::AFTER]),
                     'state' => $entity->isWatched() ? 'played' : 'unplayed',
                     'local_state' => $local->isWatched() ? 'played' : 'unplayed',
-                    'title' => $entity->getName(),
                 ],
             );
 
@@ -770,14 +779,14 @@ class DirectMapper implements ImportInterface
             return $this->add($entity, $opts);
         }
 
-        $msg = "{mapper}: [O] Ignoring '{user}@{backend}' - '#{item_id}: {title}'. No changes detected.";
-        $context = [
-            'user' => $this->userContext->name ?? 'main',
-            'mapper' => after_last(self::class, '\\'),
-            'item_id' => $cloned->id ?? 'New',
+        $msg = 'Ignoring {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\': no changes detected.';
+        $context = $this->itemContext($cloned, [
             'backend' => $entity->via,
-            'title' => $cloned->getName(),
-        ];
+            'event_name' => 'mapper.item.ignored',
+            'operation' => 'state',
+            'outcome' => 'ignored',
+            'reason' => 'no_changes',
+        ]);
 
         if (true === $this->inTraceMode()) {
             $this->logger->info($msg, $context);
@@ -806,14 +815,14 @@ class DirectMapper implements ImportInterface
 
         if (!$entity->hasGuids() && !$entity->hasRelativeGuid()) {
             $this->logger->warning(
-                "{mapper}: [A] Ignoring '{user}@{backend}' - '{title}'. No valid/supported external ids.",
-                [
-                    'mapper' => after_last(self::class, '\\'),
-                    'item_id' => $entity->id ?? 'New',
-                    'backend' => $entity->via,
-                    'title' => $entity->getName(),
-                    'user' => $this->userContext->name ?? 'main',
-                ],
+                'Ignoring {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\': no supported external ids.',
+                $this->itemContext($entity, [
+                    'event_name' => 'mapper.item.ignored',
+                    'operation' => 'add',
+                    'outcome' => 'ignored',
+                    'reason' => 'no_supported_external_ids',
+                    'guid_count' => count($entity->getGuids()),
+                ]),
             );
             Message::increment("{$entity->via}.{$entity->type}.failed_no_guid");
             return $this;
@@ -821,15 +830,14 @@ class DirectMapper implements ImportInterface
 
         if (true === $entity->isEpisode() && $entity->episode < 1) {
             $this->logger->notice(
-                "{mapper}: [A] Ignoring '{user}@{backend}' '{item_id}: {title}'. Item was marked as episode but no episode number was provided.",
-                [
-                    'user' => $this->userContext->name ?? 'main',
-                    'mapper' => after_last(self::class, '\\'),
-                    'item_id' => $entity->id ?? ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '??'),
-                    'backend' => $entity->via,
-                    'title' => $entity->getName(),
-                    'data' => $entity->getAll(),
-                ],
+                'Ignoring {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\': episode number is missing.',
+                $this->itemContext($entity, [
+                    'event_name' => 'mapper.item.ignored',
+                    'operation' => 'add',
+                    'outcome' => 'ignored',
+                    'reason' => 'missing_episode_number',
+                    'state' => $entity->getAll(),
+                ]),
             );
             Message::increment("{$entity->via}.{$entity->type}.failed_no_episode_number");
             return $this;
@@ -865,27 +873,23 @@ class DirectMapper implements ImportInterface
          * 3 - mark entity as tainted and re-process it.
          */
         if (true === $hasAfter && true === $local->isWatched() && false === $entity->isWatched()) {
-            $message = "{mapper}: [A] Conflict detected in '{user}@{backend}: {title}' '{new_state}' vs local '#{item_id}: {current_state}'.";
             $hasMeta = count($local->getMetadata($entity->via)) >= 1;
             $hasDate = $entity->updated === ag($local->getMetadata($entity->via), iState::COLUMN_META_DATA_PLAYED_AT);
 
-            if (false === $hasMeta) {
-                $message .= ' No metadata. Queueing item for re-processing.';
-            }
+            $reason = false === $hasMeta ? 'missing_metadata' : 'played_at_matches_updated';
 
-            if (true === $hasMeta && true === $hasDate) {
-                $message .= ' db.metadata.played_at matches entity.updated. Queueing item for re-processing.';
-            }
-
-            $this->logger->warning($message, [
-                'user' => $this->userContext->name ?? 'main',
-                'mapper' => after_last(self::class, '\\'),
-                'item_id' => $local->id ?? 'New',
-                'backend' => $entity->via,
-                'title' => $entity->getName(),
-                'current_state' => $local->isWatched() ? 'played' : 'unplayed',
-                'new_state' => $entity->isWatched() ? 'played' : 'unplayed',
-            ]);
+            $this->logger->warning(
+                'Queued {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\' for reprocessing because remote state conflicts with local metadata.',
+                [
+                    ...$this->itemContext($local, ['backend' => $entity->via]),
+                    'event_name' => 'mapper.item.requeued',
+                    'operation' => 'state',
+                    'outcome' => 'requeued',
+                    'reason' => $reason,
+                    'current_state' => $local->isWatched() ? 'played' : 'unplayed',
+                    'new_state' => $entity->isWatched() ? 'played' : 'unplayed',
+                ],
+            );
 
             if (false === $hasMeta || true === $hasDate) {
                 $metadata = $entity->getMetadata();
@@ -927,15 +931,15 @@ class DirectMapper implements ImportInterface
         $changedKeys = true === $forceChange ? $this->getMetaChanges($cloned, $entity) : $local->diff(fields: $keys);
 
         if (false === $progressChange && false === $shouldMark && count($changedKeys) < 1) {
-            $msg = "{mapper}: [U] Ignoring '{user}@{backend}' - '#{item_id}: {title}'. Metadata & play state are identical.";
+            $msg = 'Ignoring {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\': metadata and play state are identical.';
 
-            $context = [
-                'mapper' => after_last(self::class, '\\'),
-                'item_id' => $cloned->id ?? 'New',
+            $context = $this->itemContext($cloned, [
                 'backend' => $entity->via,
-                'title' => $cloned->getName(),
-                'user' => $this->userContext->name ?? 'main',
-            ];
+                'event_name' => 'mapper.item.ignored',
+                'operation' => 'update',
+                'outcome' => 'ignored',
+                'reason' => 'no_changes',
+            ]);
 
             if (true === $this->inTraceMode()) {
                 $context['state'] = [
@@ -973,28 +977,29 @@ class DirectMapper implements ImportInterface
                 $this->removePointers($cloned)->addPointers($local, $local->id);
             }
 
-            $message = "{mapper}: [U] '{user}@{backend}' Updated '#{item_id}: {title}'.";
-
             $stateChange = $cloned->isWatched() !== $local->isWatched();
 
-            if (true === $progressChange) {
-                $message .= ' Due to play progress change.';
-            }
-
-            if (true === $stateChange) {
-                $message = "{mapper}: [U] '{user}@{backend}' Updated and marked '#{item_id}: {title}' as '{state}'.";
-            }
-
             if (true === $progressChange || count($changes) >= 1) {
-                $this->logger->log($progressChange || $stateChange ? LogLevel::NOTICE : LogLevel::INFO, $message, [
-                    'user' => $this->userContext->name ?? 'main',
-                    'mapper' => after_last(self::class, '\\'),
-                    'item_id' => $cloned->id ?? 'New',
-                    'backend' => $entity->via,
-                    'title' => $cloned->getName(),
-                    'state' => $local->isWatched() ? 'played' : 'unplayed',
-                    'changes' => $changes,
-                ]);
+                $message = "Updated {item_type} '#{item_id}: {item_title}' from '{user}@{backend}'.";
+                if (true === $stateChange) {
+                    $message .= ' And marked it as {state}.';
+                } elseif (true === $progressChange) {
+                    $message .= ' Due to play progress change.';
+                }
+
+                $this->logger->log(
+                    $progressChange || $stateChange ? LogLevel::NOTICE : LogLevel::INFO,
+                    $message,
+                    [
+                        ...$this->itemContext($cloned, ['backend' => $entity->via]),
+                        'event_name' => 'mapper.item.updated',
+                        'operation' => true === $progressChange ? 'progress' : 'update',
+                        'outcome' => 'updated',
+                        'state' => $local->isWatched() ? 'played' : 'unplayed',
+                        'changes' => $changes,
+                        'changed_fields' => array_keys($changes),
+                    ],
+                );
             }
 
             if (false === $inDryRunMode) {
@@ -1036,13 +1041,12 @@ class DirectMapper implements ImportInterface
             Message::increment("{$entity->via}.{$local->type}.failed");
             $this->logger->error(
                 ...lw(
-                    message: "{mapper}: [U] Exception '{error.kind}' was thrown unhandled during '{user}@{backend}' - '{title}' add. {error.message} at '{error.file}:{error.line}'.",
+                    message: 'Failed to map {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\' during update.',
                     context: [
-                        'user' => $this->userContext->name ?? 'main',
-                        'mapper' => after_last(self::class, '\\'),
-                        'item_id' => $cloned->id ?? 'New',
-                        'backend' => $entity->via,
-                        'title' => $cloned->getName(),
+                        ...$this->itemContext($cloned, ['backend' => $entity->via]),
+                        'event_name' => 'mapper.item.failed',
+                        'operation' => 'update',
+                        'outcome' => 'failed',
                         'state' => [
                             'database' => $cloned->getAll(),
                             'backend' => $entity->getAll(),
@@ -1134,9 +1138,12 @@ class DirectMapper implements ImportInterface
             } catch (CacheInvalidArgumentException $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{mapper}: Exception '{error.kind}' was thrown unhandled during progress queueing. {error.message} at '{error.file}:{error.line}'.",
+                        message: 'Failed to queue progress updates during mapper commit.',
                         context: [
-                            'mapper' => after_last(self::class, '\\'),
+                            ...$this->mapperContext(),
+                            'event_name' => 'mapper.commit.failed',
+                            'operation' => 'queue_progress',
+                            'outcome' => 'failed',
                             ...exception_log($e),
                         ],
                         e: $e,
@@ -1447,7 +1454,15 @@ class DirectMapper implements ImportInterface
 
         if (true === $new->isWatched() && $allowUpdate < $minThreshold) {
             if (true === $this->inTraceMode()) {
-                $this->logger->info('play progress update not allowed. threshold is too low.');
+                $this->logger->info('Skipping progress update for {item_type} \'#{item_id}: {item_title}\': progress {progress} is below threshold {threshold}.', [
+                    ...$this->itemContext($new),
+                    'event_name' => 'mapper.progress.skipped',
+                    'operation' => 'progress',
+                    'outcome' => 'skipped',
+                    'reason' => 'threshold_too_low',
+                    'threshold' => $allowUpdate,
+                    'progress' => $newPlayProgress,
+                ]);
             }
             return false;
         }
@@ -1557,5 +1572,34 @@ class DirectMapper implements ImportInterface
     private function rethrowLock(Throwable $e, array $opts = []): bool
     {
         return true === (bool) ag($opts, Options::FAIL_FAST_ON_LOCK, false) && false !== stripos($e->getMessage(), 'database is locked');
+    }
+
+    /**
+     * @param array<string,mixed> $extra
+     *
+     * @return array<string,mixed>
+     */
+    private function mapperContext(array $extra = []): array
+    {
+        return array_merge([
+            'mapper' => after_last(self::class, '\\'),
+            'subsystem' => 'mapper',
+            'user' => $this->userContext->name ?? 'main',
+        ], $extra);
+    }
+
+    /**
+     * @param array<string,mixed> $extra
+     *
+     * @return array<string,mixed>
+     */
+    private function itemContext(iState $entity, array $extra = []): array
+    {
+        return $this->mapperContext(array_merge([
+            'backend' => $entity->via,
+            'item_id' => $entity->id ?? ag($entity->getMetadata($entity->via), iState::COLUMN_ID, 'New'),
+            'item_type' => $entity->type,
+            'item_title' => $entity->getName(),
+        ], $extra));
     }
 }

--- a/src/Libs/Mappers/Import/DirectMapper.php
+++ b/src/Libs/Mappers/Import/DirectMapper.php
@@ -283,8 +283,8 @@ class DirectMapper implements ImportInterface
                 }
             }
 
-            $this->logger->notice("{mapper}: [N] '{user}@{backend}' added '#{id}: {title}'.", [
-                'id' => $entity->id ?? 'New',
+            $this->logger->notice("{mapper}: [N] '{user}@{backend}' added '#{item_id}: {title}'.", [
+                'item_id' => $entity->id ?? 'New',
                 'user' => $this->userContext->name ?? 'main',
                 'mapper' => after_last(self::class, '\\'),
                 'backend' => $entity->via,
@@ -387,7 +387,7 @@ class DirectMapper implements ImportInterface
                         $changeLog = $local->diff(fields: $_keys);
                     }
 
-                    $message = "{mapper}: [T] '{user}@{backend}' updated '#{id}: {title}' ";
+                    $message = "{mapper}: [T] '{user}@{backend}' updated '#{item_id}: {title}' ";
 
                     $this->logger->log(
                         true === $progressChange ? LogLevel::NOTICE : LogLevel::INFO,
@@ -395,7 +395,7 @@ class DirectMapper implements ImportInterface
                         [
                             'user' => $this->userContext->name ?? 'main',
                             'mapper' => after_last(self::class, '\\'),
-                            'id' => $local->id ?? 'New',
+                            'item_id' => $local->id ?? 'New',
                             'backend' => $entity->via,
                             'title' => $local->getName(),
                             'changes' => $changeLog,
@@ -443,7 +443,7 @@ class DirectMapper implements ImportInterface
                         context: [
                             'user' => $this->userContext->name ?? 'main',
                             'mapper' => after_last(self::class, '\\'),
-                            'id' => $local->id ?? 'New',
+                            'item_id' => $local->id ?? 'New',
                             'backend' => $entity->via,
                             'title' => $local->getName(),
                             'state' => [
@@ -460,11 +460,11 @@ class DirectMapper implements ImportInterface
             return $this;
         }
 
-        $msg = "{mapper}: [T] Ignoring '{user}@{backend}' - '#{id}: {title}'. No metadata changes detected.";
+        $msg = "{mapper}: [T] Ignoring '{user}@{backend}' - '#{item_id}: {title}'. No metadata changes detected.";
         $context = [
             'user' => $this->userContext->name ?? 'main',
             'mapper' => after_last(self::class, '\\'),
-            'id' => $local->id ?? 'New',
+            'item_id' => $local->id ?? 'New',
             'backend' => $entity->via,
             'title' => $local->getName(),
         ];
@@ -488,11 +488,11 @@ class DirectMapper implements ImportInterface
             }
 
             $this->logger->notice(
-                "{mapper}: [T] '{user}@{backend}' item '#{id}: {title}' reported '{state}' vs local '{local_state}', but the state change was ignored due to '{reasons}'.",
+                "{mapper}: [T] '{user}@{backend}' item '#{item_id}: {title}' reported '{state}' vs local '{local_state}', but the state change was ignored due to '{reasons}'.",
                 [
                     'user' => $this->userContext->name ?? 'main',
                     'mapper' => after_last(self::class, '\\'),
-                    'id' => $local->id ?? 'New',
+                    'item_id' => $local->id ?? 'New',
                     'backend' => $entity->via,
                     'state' => $entity->isWatched() ? 'played' : 'unplayed',
                     'local_state' => $local->isWatched() ? 'played' : 'unplayed',
@@ -551,9 +551,9 @@ class DirectMapper implements ImportInterface
                     }
                 }
 
-                $this->logger->notice("{mapper}: [O] '{user}@{backend}' marked '#{id}: {title}' as 'unplayed'.", [
+                $this->logger->notice("{mapper}: [O] '{user}@{backend}' marked '#{item_id}: {title}' as 'unplayed'.", [
                     'mapper' => after_last(self::class, '\\'),
-                    'id' => $cloned->id ?? 'New',
+                    'item_id' => $cloned->id ?? 'New',
                     'backend' => $entity->via,
                     'title' => $cloned->getName(),
                     'changes' => $local->diff(),
@@ -579,7 +579,7 @@ class DirectMapper implements ImportInterface
                         context: [
                             'user' => $this->userContext->name ?? 'main',
                             'mapper' => after_last(self::class, '\\'),
-                            'id' => $cloned->id ?? 'New',
+                            'item_id' => $cloned->id ?? 'New',
                             'backend' => $entity->via,
                             'title' => $cloned->getName(),
                             'state' => [
@@ -636,14 +636,14 @@ class DirectMapper implements ImportInterface
                             $changeLog = $local->diff(fields: $_keys);
                         }
 
-                        $message = "{mapper}: [O] '{user}@{backend}' updated '#{id}: {title}'";
+                        $message = "{mapper}: [O] '{user}@{backend}' updated '#{item_id}: {title}'";
                         $this->logger->log(
                             true === $progressChange ? LogLevel::NOTICE : LogLevel::INFO,
                             $message . (true === $progressChange ? ' due to play progress change.' : ' metadata.'),
                             [
                                 'user' => $this->userContext->name ?? 'main',
                                 'mapper' => after_last(self::class, '\\'),
-                                'id' => $cloned->id ?? 'New',
+                                'item_id' => $cloned->id ?? 'New',
                                 'backend' => $entity->via,
                                 'title' => $cloned->getName(),
                                 'changes' => $changeLog,
@@ -691,7 +691,7 @@ class DirectMapper implements ImportInterface
                             context: [
                                 'user' => $this->userContext->name ?? 'main',
                                 'mapper' => after_last(self::class, '\\'),
-                                'id' => $cloned->id ?? 'New',
+                                'item_id' => $cloned->id ?? 'New',
                                 'backend' => $entity->via,
                                 'title' => $cloned->getName(),
                                 'state' => [
@@ -722,11 +722,11 @@ class DirectMapper implements ImportInterface
             $enable = Config::get('clients.jellyfin.fix_played', false);
             if ($enable && $entity->isWatched() && true === $entity->getContext('should_mark', false)) {
                 $this->logger->notice(
-                    "{mapper}: [O] '{user}@{backend}' item '#{id}: {title}' date '{remote_date}' is older than last sync date '{local_date}'. Due to bug in jellyfin API a special case handling is applied to mark the item as played.",
+                    "{mapper}: [O] '{user}@{backend}' item '#{item_id}: {title}' date '{remote_date}' is older than last sync date '{local_date}'. Due to bug in jellyfin API a special case handling is applied to mark the item as played.",
                     [
                         'user' => $this->userContext->name ?? 'main',
                         'mapper' => after_last(self::class, '\\'),
-                        'id' => $cloned->id ?? 'New',
+                        'item_id' => $cloned->id ?? 'New',
                         'backend' => $entity->via,
                         'remote_date' => make_date($entity->updated),
                         'local_date' => make_date($opts[Options::AFTER]),
@@ -743,11 +743,11 @@ class DirectMapper implements ImportInterface
             }
 
             $this->logger->notice(
-                "[CODE:DM001] {mapper}: [O] '{user}@{backend}' item '#{id}: {title}' [R: {state}] date '{remote_date}' is older than backend last sync date '{local_date}' [L: {local_state}]. Queueing item for re-processing. Check FAQ.",
+                "[CODE:DM001] {mapper}: [O] '{user}@{backend}' item '#{item_id}: {title}' [R: {state}] date '{remote_date}' is older than backend last sync date '{local_date}' [L: {local_state}]. Queueing item for re-processing. Check FAQ.",
                 [
                     'user' => $this->userContext->name ?? 'main',
                     'mapper' => after_last(self::class, '\\'),
-                    'id' => $cloned->id ?? 'New',
+                    'item_id' => $cloned->id ?? 'New',
                     'backend' => $entity->via,
                     'remote_date' => make_date($entity->updated),
                     'local_date' => make_date($opts[Options::AFTER]),
@@ -770,11 +770,11 @@ class DirectMapper implements ImportInterface
             return $this->add($entity, $opts);
         }
 
-        $msg = "{mapper}: [O] Ignoring '{user}@{backend}' - '#{id}: {title}'. No changes detected.";
+        $msg = "{mapper}: [O] Ignoring '{user}@{backend}' - '#{item_id}: {title}'. No changes detected.";
         $context = [
             'user' => $this->userContext->name ?? 'main',
             'mapper' => after_last(self::class, '\\'),
-            'id' => $cloned->id ?? 'New',
+            'item_id' => $cloned->id ?? 'New',
             'backend' => $entity->via,
             'title' => $cloned->getName(),
         ];
@@ -809,7 +809,7 @@ class DirectMapper implements ImportInterface
                 "{mapper}: [A] Ignoring '{user}@{backend}' - '{title}'. No valid/supported external ids.",
                 [
                     'mapper' => after_last(self::class, '\\'),
-                    'id' => $entity->id ?? 'New',
+                    'item_id' => $entity->id ?? 'New',
                     'backend' => $entity->via,
                     'title' => $entity->getName(),
                     'user' => $this->userContext->name ?? 'main',
@@ -821,11 +821,11 @@ class DirectMapper implements ImportInterface
 
         if (true === $entity->isEpisode() && $entity->episode < 1) {
             $this->logger->notice(
-                "{mapper}: [A] Ignoring '{user}@{backend}' '{id}: {title}'. Item was marked as episode but no episode number was provided.",
+                "{mapper}: [A] Ignoring '{user}@{backend}' '{item_id}: {title}'. Item was marked as episode but no episode number was provided.",
                 [
                     'user' => $this->userContext->name ?? 'main',
                     'mapper' => after_last(self::class, '\\'),
-                    'id' => $entity->id ?? ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '??'),
+                    'item_id' => $entity->id ?? ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '??'),
                     'backend' => $entity->via,
                     'title' => $entity->getName(),
                     'data' => $entity->getAll(),
@@ -865,7 +865,7 @@ class DirectMapper implements ImportInterface
          * 3 - mark entity as tainted and re-process it.
          */
         if (true === $hasAfter && true === $local->isWatched() && false === $entity->isWatched()) {
-            $message = "{mapper}: [A] Conflict detected in '{user}@{backend}: {title}' '{new_state}' vs local '#{id}: {current_state}'.";
+            $message = "{mapper}: [A] Conflict detected in '{user}@{backend}: {title}' '{new_state}' vs local '#{item_id}: {current_state}'.";
             $hasMeta = count($local->getMetadata($entity->via)) >= 1;
             $hasDate = $entity->updated === ag($local->getMetadata($entity->via), iState::COLUMN_META_DATA_PLAYED_AT);
 
@@ -880,7 +880,7 @@ class DirectMapper implements ImportInterface
             $this->logger->warning($message, [
                 'user' => $this->userContext->name ?? 'main',
                 'mapper' => after_last(self::class, '\\'),
-                'id' => $local->id ?? 'New',
+                'item_id' => $local->id ?? 'New',
                 'backend' => $entity->via,
                 'title' => $entity->getName(),
                 'current_state' => $local->isWatched() ? 'played' : 'unplayed',
@@ -927,11 +927,11 @@ class DirectMapper implements ImportInterface
         $changedKeys = true === $forceChange ? $this->getMetaChanges($cloned, $entity) : $local->diff(fields: $keys);
 
         if (false === $progressChange && false === $shouldMark && count($changedKeys) < 1) {
-            $msg = "{mapper}: [U] Ignoring '{user}@{backend}' - '#{id}: {title}'. Metadata & play state are identical.";
+            $msg = "{mapper}: [U] Ignoring '{user}@{backend}' - '#{item_id}: {title}'. Metadata & play state are identical.";
 
             $context = [
                 'mapper' => after_last(self::class, '\\'),
-                'id' => $cloned->id ?? 'New',
+                'item_id' => $cloned->id ?? 'New',
                 'backend' => $entity->via,
                 'title' => $cloned->getName(),
                 'user' => $this->userContext->name ?? 'main',
@@ -973,7 +973,7 @@ class DirectMapper implements ImportInterface
                 $this->removePointers($cloned)->addPointers($local, $local->id);
             }
 
-            $message = "{mapper}: [U] '{user}@{backend}' Updated '#{id}: {title}'.";
+            $message = "{mapper}: [U] '{user}@{backend}' Updated '#{item_id}: {title}'.";
 
             $stateChange = $cloned->isWatched() !== $local->isWatched();
 
@@ -982,14 +982,14 @@ class DirectMapper implements ImportInterface
             }
 
             if (true === $stateChange) {
-                $message = "{mapper}: [U] '{user}@{backend}' Updated and marked '#{id}: {title}' as '{state}'.";
+                $message = "{mapper}: [U] '{user}@{backend}' Updated and marked '#{item_id}: {title}' as '{state}'.";
             }
 
             if (true === $progressChange || count($changes) >= 1) {
                 $this->logger->log($progressChange || $stateChange ? LogLevel::NOTICE : LogLevel::INFO, $message, [
                     'user' => $this->userContext->name ?? 'main',
                     'mapper' => after_last(self::class, '\\'),
-                    'id' => $cloned->id ?? 'New',
+                    'item_id' => $cloned->id ?? 'New',
                     'backend' => $entity->via,
                     'title' => $cloned->getName(),
                     'state' => $local->isWatched() ? 'played' : 'unplayed',
@@ -1040,7 +1040,7 @@ class DirectMapper implements ImportInterface
                     context: [
                         'user' => $this->userContext->name ?? 'main',
                         'mapper' => after_last(self::class, '\\'),
-                        'id' => $cloned->id ?? 'New',
+                        'item_id' => $cloned->id ?? 'New',
                         'backend' => $entity->via,
                         'title' => $cloned->getName(),
                         'state' => [

--- a/src/Libs/Mappers/Import/MemoryMapper.php
+++ b/src/Libs/Mappers/Import/MemoryMapper.php
@@ -274,10 +274,10 @@ class MemoryMapper implements ImportInterface
             $changes = $this->objects[$pointer]->diff(fields: $keys);
 
             if (count($changes) >= 1) {
-                $this->logger->notice("{mapper}: [T] Updated '{user}@{backend}' - '#{id}: {title}' metadata.", [
+                $this->logger->notice("{mapper}: [T] Updated '{user}@{backend}' - '#{item_id}: {title}' metadata.", [
                     'user' => $this->userContext->name ?? 'main',
                     'mapper' => after_last(self::class, '\\'),
-                    'id' => $cloned->id ?? 'New',
+                    'item_id' => $cloned->id ?? 'New',
                     'backend' => $entity->via,
                     'title' => $cloned->getName(),
                     'changes' => $changes,
@@ -301,11 +301,11 @@ class MemoryMapper implements ImportInterface
             }
 
             $this->logger->notice(
-                "{mapper}: [T] Item '{user}@{backend}' - '#{id}: {title}' reported '{state}' vs local '{local_state}', but the state change was ignored due to '{reasons}'.",
+                "{mapper}: [T] Item '{user}@{backend}' - '#{item_id}: {title}' reported '{state}' vs local '{local_state}', but the state change was ignored due to '{reasons}'.",
                 [
                     'user' => $this->userContext->name ?? 'main',
                     'mapper' => after_last(self::class, '\\'),
-                    'id' => $this->objects[$pointer]->id ?? 'New',
+                    'item_id' => $this->objects[$pointer]->id ?? 'New',
                     'backend' => $entity->via,
                     'state' => $entity->isWatched() ? 'played' : 'unplayed',
                     'local_state' => $this->objects[$pointer]->isWatched() ? 'played' : 'unplayed',
@@ -319,11 +319,11 @@ class MemoryMapper implements ImportInterface
 
         if (true === $this->inTraceMode()) {
             $this->logger->info(
-                "{mapper}: [T] Ignoring '{user}@{backend}' - '#{id}: {title}'. No metadata changes detected.",
+                "{mapper}: [T] Ignoring '{user}@{backend}' - '#{item_id}: {title}'. No metadata changes detected.",
                 [
                     'user' => $this->userContext->name ?? 'main',
                     'mapper' => after_last(self::class, '\\'),
-                    'id' => $cloned->id ?? 'New',
+                    'item_id' => $cloned->id ?? 'New',
                     'backend' => $entity->via,
                     'title' => $cloned->getName(),
                 ],
@@ -357,7 +357,7 @@ class MemoryMapper implements ImportInterface
                 $this->logger->notice("{mapper}: [O] '{user}@{backend}' marked '{title}' as 'unplayed'.", [
                     'user' => $this->userContext->name ?? 'main',
                     'mapper' => after_last(self::class, '\\'),
-                    'id' => $cloned->id ?? 'New',
+                    'item_id' => $cloned->id ?? 'New',
                     'backend' => $entity->via,
                     'title' => $cloned->getName(),
                     'changes' => $changes,
@@ -404,12 +404,12 @@ class MemoryMapper implements ImportInterface
 
                     $this->logger->notice(
                         $progress
-                            ? "{mapper}: [O] '{user}@{backend}' updated '#{id}: {title}' due to play progress change."
-                            : "{mapper}: [O] '{user}@{backend}' updated '#{id}: {title}' metadata.",
+                            ? "{mapper}: [O] '{user}@{backend}' updated '#{item_id}: {title}' due to play progress change."
+                            : "{mapper}: [O] '{user}@{backend}' updated '#{item_id}: {title}' metadata.",
                         [
                             'user' => $this->userContext->name ?? 'main',
                             'mapper' => after_last(self::class, '\\'),
-                            'id' => $cloned->id ?? 'New',
+                            'item_id' => $cloned->id ?? 'New',
                             'backend' => $entity->via,
                             'title' => $cloned->getName(),
                             'changes' => $progress ? $this->objects[$pointer]->diff(fields: $_keys) : $changes,
@@ -441,11 +441,11 @@ class MemoryMapper implements ImportInterface
         if ($entity->isWatched() !== $this->objects[$pointer]->isWatched()) {
             if ($this->inTraceMode()) {
                 $this->logger->debug(
-                    "{mapper}: [O] Item '{user}@{backend}' - '#{id}: {title}' is marked as '{state}' vs local '{local_state}', however due to the remote item date '{remote_date}' being older than the last backend sync date '{local_date}'. it was not considered as valid state.",
+                    "{mapper}: [O] Item '{user}@{backend}' - '#{item_id}: {title}' is marked as '{state}' vs local '{local_state}', however due to the remote item date '{remote_date}' being older than the last backend sync date '{local_date}'. it was not considered as valid state.",
                     [
                         'user' => $this->userContext->name ?? 'main',
                         'mapper' => after_last(self::class, '\\'),
-                        'id' => $this->objects[$pointer]->id ?? 'New',
+                        'item_id' => $this->objects[$pointer]->id ?? 'New',
                         'backend' => $entity->via,
                         'remote_date' => make_date($entity->updated),
                         'local_date' => make_date($opts['after']),
@@ -459,10 +459,10 @@ class MemoryMapper implements ImportInterface
         }
 
         if ($this->inTraceMode()) {
-            $this->logger->debug("{mapper}: [O] Ignoring '{user}@{backend}' - '#{id}: {title}'. No changes detected.", [
+            $this->logger->debug("{mapper}: [O] Ignoring '{user}@{backend}' - '#{item_id}: {title}'. No changes detected.", [
                 'user' => $this->userContext->name ?? 'main',
                 'mapper' => after_last(self::class, '\\'),
-                'id' => $cloned->id ?? 'New',
+                'item_id' => $cloned->id ?? 'New',
                 'backend' => $entity->via,
                 'title' => $cloned->getName(),
             ]);
@@ -482,7 +482,7 @@ class MemoryMapper implements ImportInterface
                 [
                     'user' => $this->userContext->name ?? 'main',
                     'mapper' => after_last(self::class, '\\'),
-                    'id' => $entity->id ?? 'New',
+                    'item_id' => $entity->id ?? 'New',
                     'backend' => $entity->via,
                     'title' => $entity->getName(),
                 ],
@@ -493,11 +493,11 @@ class MemoryMapper implements ImportInterface
 
         if (true === $entity->isEpisode() && $entity->episode < 1) {
             $this->logger->notice(
-                "{mapper}: [N] Ignoring '{user}@{backend}' - '{id}: {title}'. Item was marked as episode but no episode number was provided.",
+                "{mapper}: [N] Ignoring '{user}@{backend}' - '{item_id}: {title}'. Item was marked as episode but no episode number was provided.",
                 [
                     'user' => $this->userContext->name ?? 'main',
                     'mapper' => after_last(self::class, '\\'),
-                    'id' => $entity->id ?? ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '??'),
+                    'item_id' => $entity->id ?? ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '??'),
                     'backend' => $entity->via,
                     'title' => $entity->getName(),
                     'data' => $entity->getAll(),
@@ -543,7 +543,7 @@ class MemoryMapper implements ImportInterface
          * 3 - mark entity as tainted and re-process it.
          */
         if (true === $hasAfter && true === $cloned->isWatched() && false === $entity->isWatched()) {
-            $message = "{mapper}: [N] Conflict detected in '{user}@{backend}' - '{title}' '{new_state}' vs local '#{id}: {current_state}'.";
+            $message = "{mapper}: [N] Conflict detected in '{user}@{backend}' - '{title}' '{new_state}' vs local '#{item_id}: {current_state}'.";
             $hasMeta = count($cloned->getMetadata($entity->via)) >= 1;
             $hasDate = $entity->updated === ag($cloned->getMetadata($entity->via), iState::COLUMN_META_DATA_PLAYED_AT);
 
@@ -556,7 +556,7 @@ class MemoryMapper implements ImportInterface
             $this->logger->warning($message, [
                 'user' => $this->userContext->name ?? 'main',
                 'mapper' => after_last(self::class, '\\'),
-                'id' => $cloned->id ?? 'New',
+                'item_id' => $cloned->id ?? 'New',
                 'backend' => $entity->via,
                 'title' => $entity->getName(),
                 'current_state' => $cloned->isWatched() ? 'played' : 'unplayed',
@@ -593,17 +593,17 @@ class MemoryMapper implements ImportInterface
 
             $changes = $this->objects[$pointer]->diff(fields: $keys);
 
-            $message = "{mapper}: [N] '{user}@{backend}' Updated '#{id}: {title}'.";
+            $message = "{mapper}: [N] '{user}@{backend}' Updated '#{item_id}: {title}'.";
 
             if ($cloned->isWatched() !== $this->objects[$pointer]->isWatched()) {
-                $message = "{mapper}: [N] '{user}@{backend}' Updated and marked '#{id}: {title}' as '{state}'.";
+                $message = "{mapper}: [N] '{user}@{backend}' Updated and marked '#{item_id}: {title}' as '{state}'.";
             }
 
             if (count($changes) >= 1) {
                 $this->logger->notice($message, [
                     'user' => $this->userContext->name ?? 'main',
                     'mapper' => after_last(self::class, '\\'),
-                    'id' => $cloned->id ?? 'New',
+                    'item_id' => $cloned->id ?? 'New',
                     'backend' => $entity->via,
                     'title' => $cloned->getName(),
                     'changes' => $changes,
@@ -617,7 +617,7 @@ class MemoryMapper implements ImportInterface
 
         $context = [
             'mapper' => after_last(self::class, '\\'),
-            'id' => $cloned->id ?? 'New',
+            'item_id' => $cloned->id ?? 'New',
             'backend' => $entity->via,
             'title' => $cloned->getName(),
             'user' => $this->userContext->name ?? 'main',
@@ -631,7 +631,7 @@ class MemoryMapper implements ImportInterface
         }
 
         $this->logger->debug(
-            "{mapper}: [N] Ignoring '{user}@{backend}' - '#{id}: {title}'. Metadata & play state are identical.",
+            "{mapper}: [N] Ignoring '{user}@{backend}' - '#{item_id}: {title}'. Metadata & play state are identical.",
             $context,
         );
 

--- a/src/Libs/Mappers/Import/MemoryMapper.php
+++ b/src/Libs/Mappers/Import/MemoryMapper.php
@@ -154,6 +154,7 @@ class MemoryMapper implements ImportInterface
      */
     public function loadData(?iDate $date = null): self
     {
+        $startedAt = microtime(true);
         $this->fullyLoaded = null === $date;
 
         foreach ($this->db->getAll($date, opts: ['class' => $this->options['class'] ?? null]) as $entity) {
@@ -168,12 +169,19 @@ class MemoryMapper implements ImportInterface
         }
 
         $this->logger->info(
-            "{mapper}: '{user}' Preloaded '{pointers}' pointers, and '{objects}' objects into memory.",
+            'Preloaded {pointer_count} pointers and {object_count} objects for \'{user}\' into {mapper}.',
             [
-                'user' => $this->userContext->name ?? 'main',
-                'mapper' => after_last(self::class, '\\'),
-                'pointers' => number_format(count($this->pointers)),
-                'objects' => number_format(count($this->objects)),
+                ...$this->mapperContext(),
+                'event_name' => 'mapper.preload.completed',
+                'operation' => 'preload',
+                'outcome' => 'completed',
+                'pointer_count' => count($this->pointers),
+                'object_count' => count($this->objects),
+                'duration_seconds' => round(microtime(true) - $startedAt, 4),
+                'memory' => [
+                    'now' => get_memory_usage(),
+                    'peak' => get_peak_memory_usage(),
+                ],
             ],
         );
 
@@ -193,15 +201,15 @@ class MemoryMapper implements ImportInterface
         if (true === (bool) ag($opts, Options::IMPORT_METADATA_ONLY)) {
             Message::increment("{$entity->via}.{$entity->type}.failed");
             $this->logger->notice(
-                "{mapper}: [N] Ignoring '{user}@{backend}' - '{title}'. Does not exist locally, and backend set as metadata source only.",
-                [
-                    'user' => $this->userContext->name ?? 'main',
-                    'mapper' => after_last(self::class, '\\'),
-                    'metaOnly' => true,
-                    'backend' => $entity->via,
-                    'title' => $entity->getName(),
-                    'data' => $entity->getAll(),
-                ],
+                'Ignoring {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\': backend is metadata-only.',
+                $this->itemContext($entity, [
+                    'event_name' => 'mapper.item.ignored',
+                    'operation' => 'add',
+                    'outcome' => 'ignored',
+                    'reason' => 'metadata_source_only',
+                    'meta_only' => true,
+                    'state' => $entity->getAll(),
+                ]),
             );
             return $this;
         }
@@ -235,11 +243,11 @@ class MemoryMapper implements ImportInterface
             ];
         }
 
-        $this->logger->notice("{mapper}: [N] Added '{user}@{backend}' - '{title}' as new item.", [
-            'user' => $this->userContext->name ?? 'main',
-            'mapper' => after_last(self::class, '\\'),
-            'backend' => $entity->via,
-            'title' => $entity->getName(),
+        $this->logger->notice('Added {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\' to local state.', [
+            ...$this->itemContext($entity),
+            'event_name' => 'mapper.item.added',
+            'operation' => 'add',
+            'outcome' => 'added',
             true === $this->inTraceMode() ? 'trace' : 'metadata' => $data,
         ]);
 
@@ -274,13 +282,13 @@ class MemoryMapper implements ImportInterface
             $changes = $this->objects[$pointer]->diff(fields: $keys);
 
             if (count($changes) >= 1) {
-                $this->logger->notice("{mapper}: [T] Updated '{user}@{backend}' - '#{item_id}: {title}' metadata.", [
-                    'user' => $this->userContext->name ?? 'main',
-                    'mapper' => after_last(self::class, '\\'),
-                    'item_id' => $cloned->id ?? 'New',
-                    'backend' => $entity->via,
-                    'title' => $cloned->getName(),
+                $this->logger->notice('Updated metadata for {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\'.', [
+                    ...$this->itemContext($cloned, ['backend' => $entity->via]),
+                    'event_name' => 'mapper.item.updated',
+                    'operation' => 'metadata',
+                    'outcome' => 'updated',
                     'changes' => $changes,
+                    'changed_fields' => array_keys($changes),
                 ]);
             }
             return $this;
@@ -301,15 +309,15 @@ class MemoryMapper implements ImportInterface
             }
 
             $this->logger->notice(
-                "{mapper}: [T] Item '{user}@{backend}' - '#{item_id}: {title}' reported '{state}' vs local '{local_state}', but the state change was ignored due to '{reasons}'.",
+                'Ignoring state change for {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\': remote state {state} differs from local {local_state}.',
                 [
-                    'user' => $this->userContext->name ?? 'main',
-                    'mapper' => after_last(self::class, '\\'),
-                    'item_id' => $this->objects[$pointer]->id ?? 'New',
-                    'backend' => $entity->via,
+                    ...$this->itemContext($this->objects[$pointer], ['backend' => $entity->via]),
+                    'event_name' => 'mapper.item.ignored',
+                    'operation' => 'state',
+                    'outcome' => 'ignored',
+                    'reason' => 'state_change_ignored',
                     'state' => $entity->isWatched() ? 'played' : 'unplayed',
                     'local_state' => $this->objects[$pointer]->isWatched() ? 'played' : 'unplayed',
-                    'title' => $entity->getName(),
                     'reasons' => implode(', ', $reasons),
                 ],
             );
@@ -319,14 +327,14 @@ class MemoryMapper implements ImportInterface
 
         if (true === $this->inTraceMode()) {
             $this->logger->info(
-                "{mapper}: [T] Ignoring '{user}@{backend}' - '#{item_id}: {title}'. No metadata changes detected.",
-                [
-                    'user' => $this->userContext->name ?? 'main',
-                    'mapper' => after_last(self::class, '\\'),
-                    'item_id' => $cloned->id ?? 'New',
+                'No metadata changes for {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\'.',
+                $this->itemContext($cloned, [
                     'backend' => $entity->via,
-                    'title' => $cloned->getName(),
-                ],
+                    'event_name' => 'mapper.item.unchanged',
+                    'operation' => 'metadata',
+                    'outcome' => 'completed',
+                    'reason' => 'no_metadata_changes',
+                ]),
             );
         }
 
@@ -354,13 +362,15 @@ class MemoryMapper implements ImportInterface
             );
 
             if (count($changes) >= 1) {
-                $this->logger->notice("{mapper}: [O] '{user}@{backend}' marked '{title}' as 'unplayed'.", [
-                    'user' => $this->userContext->name ?? 'main',
-                    'mapper' => after_last(self::class, '\\'),
-                    'item_id' => $cloned->id ?? 'New',
-                    'backend' => $entity->via,
-                    'title' => $cloned->getName(),
+                $this->logger->notice('Marked {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\' as unplayed.', [
+                    ...$this->itemContext($cloned, ['backend' => $entity->via]),
+                    'event_name' => 'mapper.item.state_changed',
+                    'operation' => 'state',
+                    'outcome' => 'completed',
+                    'old_state' => $cloned->isWatched() ? 'played' : 'unplayed',
+                    'new_state' => 'unplayed',
                     'changes' => $changes,
+                    'changed_fields' => array_keys($changes),
                 ]);
             }
 
@@ -404,16 +414,16 @@ class MemoryMapper implements ImportInterface
 
                     $this->logger->notice(
                         $progress
-                            ? "{mapper}: [O] '{user}@{backend}' updated '#{item_id}: {title}' due to play progress change."
-                            : "{mapper}: [O] '{user}@{backend}' updated '#{item_id}: {title}' metadata.",
+                            ? 'Updated {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\' due to play progress change.'
+                            : 'Updated metadata for {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\'.',
                         [
-                            'user' => $this->userContext->name ?? 'main',
-                            'mapper' => after_last(self::class, '\\'),
-                            'item_id' => $cloned->id ?? 'New',
-                            'backend' => $entity->via,
-                            'title' => $cloned->getName(),
+                            ...$this->itemContext($cloned, ['backend' => $entity->via]),
+                            'event_name' => 'mapper.item.updated',
+                            'operation' => $progress ? 'progress' : 'metadata',
+                            'outcome' => 'updated',
                             'changes' => $progress ? $this->objects[$pointer]->diff(fields: $_keys) : $changes,
                             'fields' => implode(',', $keys),
+                            'changed_fields' => array_keys($progress ? $this->objects[$pointer]->diff(fields: $_keys) : $changes),
                         ],
                     );
 
@@ -441,17 +451,17 @@ class MemoryMapper implements ImportInterface
         if ($entity->isWatched() !== $this->objects[$pointer]->isWatched()) {
             if ($this->inTraceMode()) {
                 $this->logger->debug(
-                    "{mapper}: [O] Item '{user}@{backend}' - '#{item_id}: {title}' is marked as '{state}' vs local '{local_state}', however due to the remote item date '{remote_date}' being older than the last backend sync date '{local_date}'. it was not considered as valid state.",
+                    'Ignoring state change for {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\': remote item date is older than last sync.',
                     [
-                        'user' => $this->userContext->name ?? 'main',
-                        'mapper' => after_last(self::class, '\\'),
-                        'item_id' => $this->objects[$pointer]->id ?? 'New',
-                        'backend' => $entity->via,
+                        ...$this->itemContext($this->objects[$pointer], ['backend' => $entity->via]),
+                        'event_name' => 'mapper.item.ignored',
+                        'operation' => 'state',
+                        'outcome' => 'ignored',
+                        'reason' => 'remote_older_than_last_sync',
                         'remote_date' => make_date($entity->updated),
                         'local_date' => make_date($opts['after']),
                         'state' => $entity->isWatched() ? 'played' : 'unplayed',
                         'local_state' => $this->objects[$pointer]->isWatched() ? 'played' : 'unplayed',
-                        'title' => $entity->getName(),
                     ],
                 );
             }
@@ -459,13 +469,13 @@ class MemoryMapper implements ImportInterface
         }
 
         if ($this->inTraceMode()) {
-            $this->logger->debug("{mapper}: [O] Ignoring '{user}@{backend}' - '#{item_id}: {title}'. No changes detected.", [
-                'user' => $this->userContext->name ?? 'main',
-                'mapper' => after_last(self::class, '\\'),
-                'item_id' => $cloned->id ?? 'New',
+            $this->logger->debug('Ignoring {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\': no changes detected.', $this->itemContext($cloned, [
                 'backend' => $entity->via,
-                'title' => $cloned->getName(),
-            ]);
+                'event_name' => 'mapper.item.ignored',
+                'operation' => 'state',
+                'outcome' => 'ignored',
+                'reason' => 'no_changes',
+            ]));
         }
 
         return $this;
@@ -478,14 +488,14 @@ class MemoryMapper implements ImportInterface
     {
         if (false === $entity->hasGuids() && false === $entity->hasRelativeGuid()) {
             $this->logger->warning(
-                "{mapper}: [O] Ignoring '{user}@{backend}' - '{title}'. No valid/supported external ids.",
-                [
-                    'user' => $this->userContext->name ?? 'main',
-                    'mapper' => after_last(self::class, '\\'),
-                    'item_id' => $entity->id ?? 'New',
-                    'backend' => $entity->via,
-                    'title' => $entity->getName(),
-                ],
+                'Ignoring {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\': no supported external ids.',
+                $this->itemContext($entity, [
+                    'event_name' => 'mapper.item.ignored',
+                    'operation' => 'add',
+                    'outcome' => 'ignored',
+                    'reason' => 'no_supported_external_ids',
+                    'guid_count' => count($entity->getGuids()),
+                ]),
             );
             Message::increment("{$entity->via}.{$entity->type}.failed_no_guid");
             return $this;
@@ -493,15 +503,14 @@ class MemoryMapper implements ImportInterface
 
         if (true === $entity->isEpisode() && $entity->episode < 1) {
             $this->logger->notice(
-                "{mapper}: [N] Ignoring '{user}@{backend}' - '{item_id}: {title}'. Item was marked as episode but no episode number was provided.",
-                [
-                    'user' => $this->userContext->name ?? 'main',
-                    'mapper' => after_last(self::class, '\\'),
-                    'item_id' => $entity->id ?? ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '??'),
-                    'backend' => $entity->via,
-                    'title' => $entity->getName(),
-                    'data' => $entity->getAll(),
-                ],
+                'Ignoring {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\': episode number is missing.',
+                $this->itemContext($entity, [
+                    'event_name' => 'mapper.item.ignored',
+                    'operation' => 'add',
+                    'outcome' => 'ignored',
+                    'reason' => 'missing_episode_number',
+                    'state' => $entity->getAll(),
+                ]),
             );
             Message::increment("{$entity->via}.{$entity->type}.failed_no_episode_number");
             return $this;
@@ -543,22 +552,17 @@ class MemoryMapper implements ImportInterface
          * 3 - mark entity as tainted and re-process it.
          */
         if (true === $hasAfter && true === $cloned->isWatched() && false === $entity->isWatched()) {
-            $message = "{mapper}: [N] Conflict detected in '{user}@{backend}' - '{title}' '{new_state}' vs local '#{item_id}: {current_state}'.";
             $hasMeta = count($cloned->getMetadata($entity->via)) >= 1;
             $hasDate = $entity->updated === ag($cloned->getMetadata($entity->via), iState::COLUMN_META_DATA_PLAYED_AT);
 
-            if (false === $hasMeta) {
-                $message .= ' No metadata. Queueing item for re-processing.';
-            } elseif (true === $hasDate) {
-                $message .= ' db.metadata.played_at matches entity.updated. Queueing item for re-processing.';
-            }
+            $reason = false === $hasMeta ? 'missing_metadata' : 'played_at_matches_updated';
 
-            $this->logger->warning($message, [
-                'user' => $this->userContext->name ?? 'main',
-                'mapper' => after_last(self::class, '\\'),
-                'item_id' => $cloned->id ?? 'New',
-                'backend' => $entity->via,
-                'title' => $entity->getName(),
+            $this->logger->warning('Queued {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\' for reprocessing because remote state conflicts with local metadata.', [
+                ...$this->itemContext($cloned, ['backend' => $entity->via]),
+                'event_name' => 'mapper.item.requeued',
+                'operation' => 'state',
+                'outcome' => 'requeued',
+                'reason' => $reason,
                 'current_state' => $cloned->isWatched() ? 'played' : 'unplayed',
                 'new_state' => $entity->isWatched() ? 'played' : 'unplayed',
             ]);
@@ -593,23 +597,22 @@ class MemoryMapper implements ImportInterface
 
             $changes = $this->objects[$pointer]->diff(fields: $keys);
 
-            $message = "{mapper}: [N] '{user}@{backend}' Updated '#{item_id}: {title}'.";
-
-            if ($cloned->isWatched() !== $this->objects[$pointer]->isWatched()) {
-                $message = "{mapper}: [N] '{user}@{backend}' Updated and marked '#{item_id}: {title}' as '{state}'.";
-            }
-
             if (count($changes) >= 1) {
-                $this->logger->notice($message, [
-                    'user' => $this->userContext->name ?? 'main',
-                    'mapper' => after_last(self::class, '\\'),
-                    'item_id' => $cloned->id ?? 'New',
-                    'backend' => $entity->via,
-                    'title' => $cloned->getName(),
-                    'changes' => $changes,
-                    'state' => $this->objects[$pointer]->isWatched() ? 'played' : 'unplayed',
-                    'fields' => implode(', ', $keys),
-                ]);
+                $this->logger->notice(
+                    $cloned->isWatched() !== $this->objects[$pointer]->isWatched()
+                        ? 'Updated {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\' and marked it as {state}.'
+                        : 'Updated {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\'.',
+                    [
+                        ...$this->itemContext($cloned, ['backend' => $entity->via]),
+                        'event_name' => 'mapper.item.updated',
+                        'operation' => 'update',
+                        'outcome' => 'updated',
+                        'changes' => $changes,
+                        'state' => $this->objects[$pointer]->isWatched() ? 'played' : 'unplayed',
+                        'fields' => implode(', ', $keys),
+                        'changed_fields' => array_keys($changes),
+                    ],
+                );
             }
 
             return $this;
@@ -631,8 +634,14 @@ class MemoryMapper implements ImportInterface
         }
 
         $this->logger->debug(
-            "{mapper}: [N] Ignoring '{user}@{backend}' - '#{item_id}: {title}'. Metadata & play state are identical.",
-            $context,
+            'Ignoring {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\': metadata and play state are identical.',
+            [
+                ...$context,
+                'event_name' => 'mapper.item.ignored',
+                'operation' => 'update',
+                'outcome' => 'ignored',
+                'reason' => 'no_changes',
+            ],
         );
 
         Message::increment("{$entity->via}.{$entity->type}.ignored_no_change");
@@ -686,15 +695,24 @@ class MemoryMapper implements ImportInterface
             $count = count($this->changed);
 
             if (0 === $count) {
-                $this->logger->notice(after_last(__class__, '\\') . ': No changes detected.');
+                $this->logger->notice('Skipping mapper commit for \'{user}\': no changes detected.', [
+                    ...$this->mapperContext(),
+                    'event_name' => 'mapper.commit.skipped',
+                    'operation' => 'commit',
+                    'outcome' => 'skipped',
+                    'reason' => 'no_changes',
+                ]);
                 return $list;
             }
             $inDryRunMode = $this->inDryRunMode();
 
             if (true === $inDryRunMode) {
-                $this->logger->notice("{mapper}: Recorded '{total}' object changes for '{user}'.", [
-                    'user' => $this->userContext->name ?? 'main',
-                    'mapper' => after_last(self::class, '\\'),
+                $this->logger->notice('Recorded {total} mapper changes for \'{user}\' without committing them.', [
+                    ...$this->mapperContext(),
+                    'event_name' => 'mapper.commit.skipped',
+                    'operation' => 'commit',
+                    'outcome' => 'skipped',
+                    'reason' => 'dry_run',
                     'total' => $count,
                 ]);
             }
@@ -718,20 +736,14 @@ class MemoryMapper implements ImportInterface
                     $list[$entity->type]['failed']++;
                     $this->logger->error(
                         ...lw(
-                            message: "{mapper}: Exception '{error.kind}' was thrown unhandled during '{user}@{backend}' - '{title}' {mode}. {error.message} at '{error.file}:{error.line}'.",
+                            message: 'Failed to map {item_type} \'#{item_id}: {item_title}\' from \'{user}@{backend}\' during {operation}.',
                             context: [
-                                'user' => $this->userContext->name ?? 'main',
-                                'mapper' => after_last(self::class, '\\'),
-                                'error' => [
-                                    'kind' => $e::class,
-                                    'line' => $e->getLine(),
-                                    'message' => $e->getMessage(),
-                                    'file' => after($e->getFile(), ROOT_PATH),
-                                ],
+                                ...$this->itemContext($entity),
+                                'event_name' => 'mapper.item.failed',
+                                'operation' => $entity->id === null ? 'add' : 'update',
+                                'outcome' => 'failed',
                                 'state' => $entity->getAll(),
-                                'backend' => $entity->via,
-                                'title' => $entity->getName(),
-                                'mode' => $entity->id === null ? 'add' : 'update',
+                                ...exception_log($e),
                             ],
                             e: $e,
                         ),
@@ -764,9 +776,12 @@ class MemoryMapper implements ImportInterface
             } catch (\Psr\SimpleCache\InvalidArgumentException $e) {
                 $this->logger->error(
                     ...lw(
-                        message: "{mapper}: Exception '{error.kind}' was thrown unhandled during progress queueing. {error.message} at '{error.file}:{error.line}'.",
+                        message: 'Failed to queue progress updates during mapper commit.',
                         context: [
-                            'mapper' => after_last(self::class, '\\'),
+                            ...$this->mapperContext(),
+                            'event_name' => 'mapper.commit.failed',
+                            'operation' => 'queue_progress',
+                            'outcome' => 'failed',
                             ...exception_log($e),
                         ],
                         e: $e,
@@ -1007,5 +1022,34 @@ class MemoryMapper implements ImportInterface
         }
 
         return $this;
+    }
+
+    /**
+     * @param array<string,mixed> $extra
+     *
+     * @return array<string,mixed>
+     */
+    private function mapperContext(array $extra = []): array
+    {
+        return array_merge([
+            'mapper' => after_last(self::class, '\\'),
+            'subsystem' => 'mapper',
+            'user' => $this->userContext->name ?? 'main',
+        ], $extra);
+    }
+
+    /**
+     * @param array<string,mixed> $extra
+     *
+     * @return array<string,mixed>
+     */
+    private function itemContext(iState $entity, array $extra = []): array
+    {
+        return $this->mapperContext(array_merge([
+            'backend' => $entity->via,
+            'item_id' => $entity->id ?? ag($entity->getMetadata($entity->via), iState::COLUMN_ID, 'New'),
+            'item_type' => $entity->type,
+            'item_title' => $entity->getName(),
+        ], $extra));
     }
 }

--- a/src/Libs/Mappers/Import/RestoreMapper.php
+++ b/src/Libs/Mappers/Import/RestoreMapper.php
@@ -188,8 +188,14 @@ final class RestoreMapper implements iImport
     public function add(iState $entity, array $opts = []): self
     {
         if (false === $entity->hasGuids() && false === $entity->hasRelativeGuid()) {
-            $this->logger->debug('MAPPER: Ignoring [{title}] no valid/supported external ids.', [
-                'title' => $entity->getName(),
+            $this->logger->debug("Ignoring restore item '{item_title}': no supported external ids.", [
+                'event_name' => 'mapper.restore.item.ignored',
+                'subsystem' => 'mapper.restore',
+                'operation' => 'add',
+                'outcome' => 'ignored',
+                'mapper' => after_last(self::class, '\\'),
+                'item_title' => $entity->getName(),
+                'reason' => 'no_supported_external_ids',
             ]);
             return $this;
         }

--- a/src/Libs/Middlewares/ExceptionHandlerMiddleware.php
+++ b/src/Libs/Middlewares/ExceptionHandlerMiddleware.php
@@ -4,20 +4,57 @@ declare(strict_types=1);
 
 namespace App\Libs\Middlewares;
 
+use App\Libs\Container;
 use App\Libs\Enums\Http\Status;
 use Psr\Http\Message\ResponseInterface as iResponse;
 use Psr\Http\Message\ServerRequestInterface as iRequest;
 use Psr\Http\Server\MiddlewareInterface as iMiddleware;
 use Psr\Http\Server\RequestHandlerInterface as iHandler;
+use Psr\Log\LoggerInterface as iLogger;
 
 final class ExceptionHandlerMiddleware implements iMiddleware
 {
+    public function __construct(
+        private readonly ?iLogger $logger = null,
+    ) {}
+
     public function process(iRequest $request, iHandler $handler): iResponse
     {
         try {
             return $handler->handle($request);
         } catch (\Throwable $e) {
-            return api_error($e->getMessage(), Status::tryFrom($e->getCode()) ?? Status::INTERNAL_SERVER_ERROR);
+            $status = Status::tryFrom($e->getCode()) ?? Status::INTERNAL_SERVER_ERROR;
+
+            $logger = $this->logger;
+
+            if (null === $logger) {
+                try {
+                    $logger = Container::get(iLogger::class);
+                } catch (\Throwable) {
+                    $logger = null;
+                }
+            }
+
+            $logger?->error('API request failed for {request.method} {request.path}.', [
+                'event_name' => 'http.request.failed',
+                'subsystem' => 'http.request',
+                'operation' => 'middleware',
+                'outcome' => 'failed',
+                'request' => [
+                    'method' => $request->getMethod(),
+                    'path' => $request->getUri()->getPath(),
+                    'uri' => (string) $request->getUri(),
+                ],
+                'response' => [
+                    'status_code' => $status->value,
+                ],
+                ...exception_log($e),
+            ]);
+
+            return api_error(
+                $status->value >= 500 ? 'Request handling failed.' : $e->getMessage(),
+                $status,
+            );
         }
     }
 }

--- a/src/Libs/Playlists/PlaylistStore.php
+++ b/src/Libs/Playlists/PlaylistStore.php
@@ -6,11 +6,13 @@ namespace App\Libs\Playlists;
 
 use App\Libs\Database\DBLayer;
 use PDO;
+use Psr\Log\LoggerInterface as iLogger;
 
 final class PlaylistStore
 {
     public function __construct(
         private readonly DBLayer $db,
+        private readonly ?iLogger $logger = null,
     ) {}
 
     /**
@@ -44,6 +46,19 @@ final class PlaylistStore
                 $seen[(string) $playlist['id']] = true;
 
                 $this->replacePlaylistItems($playlistId, $playlist['items'] ?? [], $stats);
+
+                $this->logger?->info("Stored playlist snapshot '{playlist_title}' from '{backend}' with {item_count} items.", [
+                    'event_name' => 'playlist.snapshot.stored',
+                    'subsystem' => 'playlist',
+                    'operation' => 'store_snapshot',
+                    'outcome' => 'completed',
+                    'backend' => $backend,
+                    'playlist_id' => (string) ($playlist['id'] ?? ''),
+                    'playlist_title' => (string) ($playlist['title'] ?? 'Untitled playlist'),
+                    'item_count' => count($playlist['items'] ?? []),
+                    'hash' => $this->makeContentHash($playlist),
+                    'changed' => true,
+                ]);
             }
 
             foreach ($this->getExistingBackendMap($backend) as $backendId => $playlistId) {

--- a/src/Libs/Playlists/PlaylistSyncService.php
+++ b/src/Libs/Playlists/PlaylistSyncService.php
@@ -30,7 +30,7 @@ class PlaylistSyncService
     public function sync(UserContext $userContext, array $clients, array $opts = []): array
     {
         $syncStart = microtime(true);
-        $store = new PlaylistStore($userContext->db->getDBLayer());
+        $store = new PlaylistStore($userContext->db->getDBLayer(), $this->logger);
         $planner = new PlaylistSyncPlanner();
         $dryRun = true === (bool) ($opts[Options::DRY_RUN] ?? false);
         $forceFull = true === (bool) ($opts[Options::FORCE_FULL] ?? false);
@@ -42,9 +42,14 @@ class PlaylistSyncService
         $fetchedBackends = [];
         $fetchTotals = $this->makeFetchStats();
 
-        $this->logger->notice("PLAYLIST: Starting playlist reconciliation for '{user}' across '{total}' backend clients.", [
+        $this->logger->notice("Reconciling playlists for '{user}' across {backend_count} backends.", [
+            'event_name' => 'playlist.sync.started',
+            'subsystem' => 'playlist',
+            'operation' => 'sync',
+            'outcome' => 'started',
             'user' => $userContext->name,
-            'total' => count($clients),
+            'backend_count' => count($clients),
+            'backends' => array_keys($clients),
             'dry_run' => $dryRun,
             'force_full' => $forceFull,
             'source_backends' => $sourceBackends,
@@ -98,9 +103,13 @@ class PlaylistSyncService
             static fn(string $backendName): bool => true === isset($fetchedBackends[$backendName]),
         ));
 
-        $this->logger->notice("PLAYLIST: Completed playlist snapshot fetch phase for '{user}' in '{duration}'s.", [
+        $this->logger->notice("Fetched playlist snapshots for '{user}' in {duration_seconds}s.", [
+            'event_name' => 'playlist.fetch.completed',
+            'subsystem' => 'playlist',
+            'operation' => 'fetch',
+            'outcome' => 'completed',
             'user' => $userContext->name,
-            'duration' => round(microtime(true) - $fetchStart, 4),
+            'duration_seconds' => round(microtime(true) - $fetchStart, 4),
             'fetched_backends' => array_keys($fetchedBackends),
             'source_backends' => $sourceBackends,
             'target_backends' => $targetBackends,
@@ -111,11 +120,15 @@ class PlaylistSyncService
         if (true === $dryRun || [] === $targetBackends || [] === $sourceBackends) {
             $summary = $this->summarizeBackends($clients, $store, $results, $syncStats, $dryRun);
 
-            $this->logger->notice("PLAYLIST: Playlist reconciliation for '{user}' stopped after fetch phase.", [
+            $this->logger->notice("Playlist reconciliation for '{user}' stopped after the fetch phase.", [
+                'event_name' => 'playlist.sync.stopped',
+                'subsystem' => 'playlist',
+                'operation' => 'sync',
+                'outcome' => 'completed',
                 'user' => $userContext->name,
                 'reason' => $this->resolveEarlyStopReason($dryRun, $sourceBackends, $targetBackends),
                 'results' => $this->summarizeResultTotals($summary),
-                'duration' => round(microtime(true) - $syncStart, 4),
+                'duration_seconds' => round(microtime(true) - $syncStart, 4),
                 'memory' => $this->getMemoryContext(),
             ]);
 
@@ -133,9 +146,13 @@ class PlaylistSyncService
         $operationSummary = $this->summarizeOperations($operations);
         $applyStart = microtime(true);
 
-        $this->logger->notice("PLAYLIST: Applying '{total}' planned playlist operations for '{user}'.", [
+        $this->logger->notice("Applying {operation_count} planned playlist operations for '{user}'.", [
+            'event_name' => 'playlist.operation.apply.started',
+            'subsystem' => 'playlist',
+            'operation' => 'apply',
+            'outcome' => 'started',
             'user' => $userContext->name,
-            'total' => count($operations),
+            'operation_count' => count($operations),
             'actions' => $operationSummary['actions'],
             'backends' => $operationSummary['backends'],
             'memory' => $this->getMemoryContext(),
@@ -157,9 +174,13 @@ class PlaylistSyncService
             $exportSyncedBackends[] = $backendName;
         }
 
-        $this->logger->notice("PLAYLIST: Applied playlist operations for '{user}' in '{duration}'s.", [
+        $this->logger->notice("Applied playlist operations for '{user}' in {duration_seconds}s.", [
+            'event_name' => 'playlist.operation.apply.completed',
+            'subsystem' => 'playlist',
+            'operation' => 'apply',
+            'outcome' => 'completed',
             'user' => $userContext->name,
-            'duration' => round(microtime(true) - $applyStart, 4),
+            'duration_seconds' => round(microtime(true) - $applyStart, 4),
             'stats' => $this->summarizeSyncStats($applied['stats']),
             'touched_backends' => $applied['touched_backends'],
             'failed_backends' => array_keys($applied['failed_backends']),
@@ -171,9 +192,13 @@ class PlaylistSyncService
         $refreshStart = microtime(true);
 
         if ([] !== $applied['touched_backends']) {
-            $this->logger->notice("PLAYLIST: Refreshing '{total}' touched playlist backends for '{user}'.", [
+            $this->logger->notice("Refreshing {backend_count} touched playlist backends for '{user}'.", [
+                'event_name' => 'playlist.refresh.started',
+                'subsystem' => 'playlist',
+                'operation' => 'refresh',
+                'outcome' => 'started',
                 'user' => $userContext->name,
-                'total' => count($applied['touched_backends']),
+                'backend_count' => count($applied['touched_backends']),
                 'backends' => $applied['touched_backends'],
                 'memory' => $this->getMemoryContext(),
             ]);
@@ -203,9 +228,13 @@ class PlaylistSyncService
         }
 
         if ([] !== $applied['touched_backends']) {
-            $this->logger->notice("PLAYLIST: Refreshed touched playlist backends for '{user}' in '{duration}'s.", [
+            $this->logger->notice("Refreshed touched playlist backends for '{user}' in {duration_seconds}s.", [
+                'event_name' => 'playlist.refresh.completed',
+                'subsystem' => 'playlist',
+                'operation' => 'refresh',
+                'outcome' => 'completed',
                 'user' => $userContext->name,
-                'duration' => round(microtime(true) - $refreshStart, 4),
+                'duration_seconds' => round(microtime(true) - $refreshStart, 4),
                 'backends' => $applied['touched_backends'],
                 'stats' => $refreshTotals,
                 'memory' => $this->getMemoryContext(),
@@ -214,9 +243,13 @@ class PlaylistSyncService
 
         $summary = $this->summarizeBackends($clients, $store, $results, $syncStats, false);
 
-        $this->logger->notice("PLAYLIST: Playlist reconciliation for '{user}' completed in '{duration}'s.", [
+        $this->logger->notice("Playlist reconciliation for '{user}' completed in {duration_seconds}s.", [
+            'event_name' => 'playlist.sync.completed',
+            'subsystem' => 'playlist',
+            'operation' => 'sync',
+            'outcome' => 'completed',
             'user' => $userContext->name,
-            'duration' => round(microtime(true) - $syncStart, 4),
+            'duration_seconds' => round(microtime(true) - $syncStart, 4),
             'results' => $this->summarizeResultTotals($summary),
             'memory' => $this->getMemoryContext(),
         ]);
@@ -274,7 +307,11 @@ class PlaylistSyncService
 
         $stats['forced_ids'] = count($forceIds);
 
-        $this->logger->notice("PLAYLIST: Starting '{phase}' fetch for '{user}@{backend}' playlists ({mode}, {direction}).", [
+        $this->logger->notice("Fetching {mode} playlist snapshot from '{user}@{backend}' ({direction}, {phase}).", [
+            'event_name' => 'playlist.fetch.started',
+            'subsystem' => 'playlist',
+            'operation' => 'fetch',
+            'outcome' => 'started',
             'phase' => $phase,
             'user' => $userContext->name,
             'backend' => $backendName,
@@ -289,7 +326,14 @@ class PlaylistSyncService
             $playlistSummaries = $client->getPlaylistsList([Options::RAW_RESPONSE => true]);
         } catch (Throwable $e) {
             $stats['list_failures'] = 1;
-            $this->logBackendThrowable($e, $backendName, 'get playlists list');
+            $this->logBackendThrowable(
+                e: $e,
+                backendName: $backendName,
+                user: $userContext->name,
+                operation: 'fetch_playlists_list',
+                eventName: 'playlist.fetch.failed',
+                operationLabel: 'fetch the playlist list',
+            );
 
             return [
                 'ok' => false,
@@ -333,7 +377,16 @@ class PlaylistSyncService
                 $playlist = $client->getPlaylist($playlistId, [Options::RAW_RESPONSE => true]);
             } catch (Throwable $e) {
                 $stats['detail_failures']++;
-                $this->logBackendThrowable($e, $backendName, 'get playlist');
+                $this->logBackendThrowable(
+                    e: $e,
+                    backendName: $backendName,
+                    user: $userContext->name,
+                    operation: 'fetch_playlist',
+                    playlistId: $playlistId,
+                    playlistTitle: (string) ag($playlistSummary, 'title', 'Untitled playlist'),
+                    eventName: 'playlist.fetch.failed',
+                    operationLabel: 'fetch',
+                );
                 continue;
             }
 
@@ -363,11 +416,15 @@ class PlaylistSyncService
             }
         }
 
-        $this->logger->info("PLAYLIST: Completed '{phase}' fetch for '{user}@{backend}' playlists in '{duration}'s.", [
+        $this->logger->info("Fetched {phase} playlist snapshot from '{user}@{backend}' in {duration_seconds}s.", [
+            'event_name' => 'playlist.fetch.backend.completed',
+            'subsystem' => 'playlist',
+            'operation' => 'fetch',
+            'outcome' => 'completed',
             'phase' => $phase,
             'user' => $userContext->name,
             'backend' => $backendName,
-            'duration' => round(microtime(true) - $start, 4),
+            'duration_seconds' => round(microtime(true) - $start, 4),
             'direction' => $direction,
             'mode' => true === $forceFull ? 'full' : 'incremental',
             'stats' => $stats,
@@ -416,11 +473,17 @@ class PlaylistSyncService
                 $resolvedItems = [];
 
                 $this->logger->info(
-                    "PLAYLIST: Skipping '{user}@{backend}' playlist '{title}'. Some items did not resolve to local state.",
+                    "Skipping playlist '{playlist_title}' from '{user}@{backend}': some items did not resolve to local state.",
                     [
+                        'event_name' => 'playlist.snapshot.skipped',
+                        'subsystem' => 'playlist',
+                        'operation' => 'snapshot',
+                        'outcome' => 'skipped',
                         'user' => $userContext->name,
                         'backend' => $client->getContext()->backendName,
-                        'title' => ag($playlist, 'title', 'unknown'),
+                        'playlist_id' => (string) ag($playlist, 'id', ''),
+                        'playlist_title' => (string) ag($playlist, 'title', 'Untitled playlist'),
+                        'reason' => 'unresolved_items',
                     ],
                 );
             }
@@ -490,11 +553,16 @@ class PlaylistSyncService
             $entity = $client->toEntity($item, [Options::NO_CACHE => true]);
         } catch (Throwable $e) {
             $this->logger->warning(
-                "PLAYLIST: Failed to map '{backend}' playlist item '{title}'. {error}",
+                "Failed to map playlist item '{item_title}' on backend '{backend}'.",
                 [
+                    'event_name' => 'playlist.item.map.failed',
+                    'subsystem' => 'playlist',
+                    'operation' => 'map_item',
+                    'outcome' => 'failed',
+                    'user' => $userContext->name,
                     'backend' => $client->getName(),
-                    'title' => ag($item, ['title', 'Name', 'OriginalTitle'], 'unknown'),
-                    'error' => $e->getMessage(),
+                    'item_title' => (string) ag($item, ['title', 'Name', 'OriginalTitle'], 'Unknown item'),
+                    ...exception_log($e),
                 ],
             );
 
@@ -554,9 +622,14 @@ class PlaylistSyncService
             return $operations;
         }
 
-        $this->logger->notice("PLAYLIST: Planning playlist sync operations for '{user}' across '{total}' sync groups.", [
+        $this->logger->notice("Planning playlist operations for '{user}' from {snapshot_count} sync groups.", [
+            'event_name' => 'playlist.plan.started',
+            'subsystem' => 'playlist',
+            'operation' => 'plan',
+            'outcome' => 'started',
             'user' => $userContext->name,
-            'total' => count($groups),
+            'snapshot_count' => count($groups),
+            'backend_count' => count($targetBackends),
             'source_backends' => $sourceBackends,
             'target_backends' => $targetBackends,
             'memory' => $this->getMemoryContext(),
@@ -578,8 +651,32 @@ class PlaylistSyncService
 
             if (null === $winner) {
                 $skipped['no_winner']++;
+
+                $sample = $collapsed[array_key_first($collapsed)] ?? $group[array_key_first($group)] ?? [];
+                $this->logger->info("No source available for playlist '{playlist_title}' on '{target_backend}'.", [
+                    'event_name' => 'playlist.plan.winner_unavailable',
+                    'subsystem' => 'playlist',
+                    'operation' => 'plan',
+                    'outcome' => 'skipped',
+                    'user' => $userContext->name,
+                    'playlist_id' => (string) ag($sample, 'sync_id', ag($sample, 'backend_id', '')),
+                    'playlist_title' => (string) ag($sample, 'title', 'Untitled playlist'),
+                    'target_backend' => implode(',', $targetBackends),
+                    'reason' => 'no_winner',
+                ]);
                 continue;
             }
+
+            $this->logger->info("Selected '{source_backend}' as source for playlist '{playlist_title}'.", [
+                'event_name' => 'playlist.plan.winner_selected',
+                'subsystem' => 'playlist',
+                'operation' => 'plan',
+                'outcome' => 'completed',
+                'user' => $userContext->name,
+                'playlist_id' => (string) ag($winner, 'sync_id', ag($winner, 'backend_id', '')),
+                'playlist_title' => (string) ag($winner, 'title', 'Untitled playlist'),
+                'source_backend' => (string) ag($winner, 'backend', 'unknown'),
+            ]);
 
             foreach ($targetBackends as $backendName) {
                 if ($backendName === (string) ($winner['backend'] ?? '')) {
@@ -615,13 +712,21 @@ class PlaylistSyncService
                     $skipped['zero_available']++;
 
                     $this->logger->info(
-                        "PLAYLIST: Waiting to sync '{backend}' playlist '{title}'. No winner items are available on target backend yet.",
+                        "Waiting to sync playlist '{playlist_title}' for '{user}@{backend}': no source items are available on the target backend yet.",
                         [
+                            'event_name' => 'playlist.sync.waiting',
+                            'subsystem' => 'playlist',
+                            'operation' => 'sync',
+                            'outcome' => 'waiting',
+                            'user' => $userContext->name,
                             'backend' => $backendName,
-                            'title' => ag($winner, 'title', 'unknown'),
+                            'playlist_id' => (string) ag($winner, 'sync_id', ag($winner, 'backend_id', '')),
+                            'playlist_title' => (string) ag($winner, 'title', 'Untitled playlist'),
                             'winner_backend' => ag($winner, 'backend', 'unknown'),
-                            'total' => $resolution['total_count'],
+                            'available_count' => $resolution['available_count'],
+                            'total_count' => $resolution['total_count'],
                             'missing_titles' => $resolution['missing_titles'],
+                            'reason' => 'no_winner_items',
                         ],
                     );
 
@@ -636,13 +741,20 @@ class PlaylistSyncService
                     $skipped['partial_waiting']++;
 
                     $this->logger->info(
-                        "PLAYLIST: Waiting to complete '{backend}' playlist '{title}'. '{available}' of '{total}' items are currently available on target backend.",
+                        "Waiting to complete playlist '{playlist_title}' for '{user}@{backend}': {available_count} of {total_count} items are available on the target backend.",
                         [
+                            'event_name' => 'playlist.sync.waiting',
+                            'subsystem' => 'playlist',
+                            'operation' => 'sync',
+                            'outcome' => 'waiting',
+                            'user' => $userContext->name,
                             'backend' => $backendName,
-                            'title' => ag($winner, 'title', 'unknown'),
-                            'available' => $resolution['available_count'],
-                            'total' => $resolution['total_count'],
+                            'playlist_id' => (string) ag($winner, 'sync_id', ag($winner, 'backend_id', '')),
+                            'playlist_title' => (string) ag($winner, 'title', 'Untitled playlist'),
+                            'available_count' => $resolution['available_count'],
+                            'total_count' => $resolution['total_count'],
                             'missing_titles' => $resolution['missing_titles'],
+                            'reason' => 'partial_target_waiting',
                         ],
                     );
 
@@ -657,17 +769,37 @@ class PlaylistSyncService
                     $perBackend[$backendName]['partial'] = ($perBackend[$backendName]['partial'] ?? 0) + 1;
 
                     $this->logger->info(
-                        "PLAYLIST: Planning partial '{action}' for '{backend}' playlist '{title}'. '{available}' of '{total}' items are available on target backend.",
+                        "Planning partial {action} for playlist '{playlist_title}' on '{user}@{backend}': {available_count} of {total_count} items are available.",
                         [
+                            'event_name' => 'playlist.operation.planned',
+                            'subsystem' => 'playlist',
+                            'operation' => 'plan',
+                            'outcome' => 'completed',
+                            'user' => $userContext->name,
                             'action' => $action,
                             'backend' => $backendName,
-                            'title' => ag($winner, 'title', 'unknown'),
-                            'available' => $resolution['available_count'],
-                            'total' => $resolution['total_count'],
+                            'playlist_id' => (string) ag($winner, 'sync_id', ag($winner, 'backend_id', '')),
+                            'playlist_title' => (string) ag($winner, 'title', 'Untitled playlist'),
+                            'available_count' => $resolution['available_count'],
+                            'total_count' => $resolution['total_count'],
                             'missing_titles' => $resolution['missing_titles'],
+                            'reason' => 'partial_target_items',
                         ],
                     );
                 }
+
+                $this->logger->info("Planned {action} for playlist '{playlist_title}' on '{user}@{backend}' ({item_count} items).", [
+                    'event_name' => 'playlist.operation.planned',
+                    'subsystem' => 'playlist',
+                    'operation' => 'plan',
+                    'outcome' => 'completed',
+                    'action' => $action,
+                    'user' => $userContext->name,
+                    'backend' => $backendName,
+                    'playlist_id' => (string) ag($winner, 'sync_id', ag($winner, 'backend_id', '')),
+                    'playlist_title' => (string) ag($winner, 'title', 'Untitled playlist'),
+                    'item_count' => count($resolution['items']),
+                ]);
 
                 $operations[] = [
                     'action' => $action,
@@ -681,10 +813,14 @@ class PlaylistSyncService
             }
         }
 
-        $this->logger->info("PLAYLIST: Planned '{total}' playlist sync operations for '{user}' in '{duration}'s.", [
+        $this->logger->info("Planned {operation_count} playlist operations for '{user}' in {duration_seconds}s.", [
+            'event_name' => 'playlist.plan.completed',
+            'subsystem' => 'playlist',
+            'operation' => 'plan',
+            'outcome' => 'completed',
             'user' => $userContext->name,
-            'total' => count($operations),
-            'duration' => round(microtime(true) - $start, 4),
+            'operation_count' => count($operations),
+            'duration_seconds' => round(microtime(true) - $start, 4),
             'actions' => $planned,
             'backends' => $perBackend,
             'skipped' => $skipped,
@@ -731,7 +867,14 @@ class PlaylistSyncService
                 try {
                     $client->deletePlaylist((string) ($target['backend_id'] ?? ''));
                 } catch (Throwable $e) {
-                    $this->logBackendThrowable($e, $backendName, 'delete playlist');
+                    $this->logBackendThrowable(
+                        e: $e,
+                        backendName: $backendName,
+                        user: $client->getContext()->userContext->name,
+                        operation: 'delete',
+                        playlistId: (string) ($target['backend_id'] ?? ''),
+                        playlistTitle: (string) ($target['title'] ?? 'Untitled playlist'),
+                    );
                     $failedBackends[$backendName] = true;
                     continue;
                 }
@@ -739,6 +882,17 @@ class PlaylistSyncService
                 $store->markDeleted((int) $target['id']);
                 $touchedBackends[$backendName] = true;
                 $stats[$backendName]['removed'] = ($stats[$backendName]['removed'] ?? 0) + 1;
+                $this->logger->notice("Applied {operation} to playlist '{playlist_title}' on '{user}@{backend}'.", [
+                    'event_name' => 'playlist.operation.applied',
+                    'subsystem' => 'playlist',
+                    'operation' => 'delete',
+                    'outcome' => 'completed',
+                    'user' => $client->getContext()->userContext->name,
+                    'backend' => $backendName,
+                    'playlist_id' => (string) ($target['backend_id'] ?? $target['sync_id'] ?? ''),
+                    'playlist_title' => (string) ($target['title'] ?? 'Untitled playlist'),
+                    'item_count' => count($target['items'] ?? []),
+                ]);
                 continue;
             }
 
@@ -746,7 +900,15 @@ class PlaylistSyncService
                 try {
                     $client->deletePlaylist((string) ($target['backend_id'] ?? ''));
                 } catch (Throwable $e) {
-                    $this->logBackendThrowable($e, $backendName, 'delete playlist before replace');
+                    $this->logBackendThrowable(
+                        e: $e,
+                        backendName: $backendName,
+                        user: $client->getContext()->userContext->name,
+                        operation: 'delete_before_replace',
+                        playlistId: (string) ($target['backend_id'] ?? ''),
+                        playlistTitle: (string) ($target['title'] ?? 'Untitled playlist'),
+                        operationLabel: 'delete before replace',
+                    );
                     $failedBackends[$backendName] = true;
                     continue;
                 }
@@ -761,7 +923,14 @@ class PlaylistSyncService
                     itemIds: array_map(static fn(array $item) => (string) ($item['backend_item_id'] ?? ''), $operation['items'] ?? []),
                 );
             } catch (Throwable $e) {
-                $this->logBackendThrowable($e, $backendName, 'create playlist');
+                $this->logBackendThrowable(
+                    e: $e,
+                    backendName: $backendName,
+                    user: $client->getContext()->userContext->name,
+                    operation: 'create',
+                    playlistId: '',
+                    playlistTitle: (string) ($winner['title'] ?? 'Untitled playlist'),
+                );
                 $failedBackends[$backendName] = true;
                 continue;
             }
@@ -770,8 +939,17 @@ class PlaylistSyncService
             $createdId = trim((string) ag($createResult, 'id', ''));
             if ('' === $createdId) {
                 $this->logger->warning(
-                    "PLAYLIST: Backend '{backend}' create request completed without a playlist id.",
-                    ['backend' => $backendName],
+                    "Create playlist request for '{user}@{backend}' returned no playlist id for '{playlist_title}'.",
+                    [
+                        'event_name' => 'playlist.operation.response_invalid',
+                        'subsystem' => 'playlist',
+                        'operation' => 'create',
+                        'outcome' => 'failed',
+                        'user' => $client->getContext()->userContext->name,
+                        'backend' => $backendName,
+                        'playlist_title' => (string) ($winner['title'] ?? 'Untitled playlist'),
+                        'reason' => 'missing_playlist_id',
+                    ],
                 );
                 $failedBackends[$backendName] = true;
                 continue;
@@ -789,6 +967,18 @@ class PlaylistSyncService
                 items: $operation['items'] ?? [],
                 syncMetadata: $operation['sync_metadata'] ?? [],
             ));
+
+            $this->logger->notice("Applied {operation} to playlist '{playlist_title}' on '{user}@{backend}'.", [
+                'event_name' => 'playlist.operation.applied',
+                'subsystem' => 'playlist',
+                'operation' => (string) $operation['action'],
+                'outcome' => 'completed',
+                'user' => $client->getContext()->userContext->name,
+                'backend' => $backendName,
+                'playlist_id' => $createdId,
+                'playlist_title' => (string) ($winner['title'] ?? 'Untitled playlist'),
+                'item_count' => count($operation['items'] ?? []),
+            ]);
         }
 
         return [
@@ -903,11 +1093,17 @@ class PlaylistSyncService
             $entity = $this->getLocalStateById($userContext, (int) $stateId);
             if (null === $entity) {
                 $this->logger->info(
-                    "PLAYLIST: Skipping '{backend}' sync for '{title}'. Local state '{state_id}' no longer exists.",
+                    "Skipping playlist '{playlist_title}' on '{backend}': local state '{state_id}' no longer exists.",
                     [
+                        'event_name' => 'playlist.target.item.skipped',
+                        'subsystem' => 'playlist',
+                        'operation' => 'resolve_target_item',
+                        'outcome' => 'skipped',
                         'backend' => $backend,
-                        'title' => ag($winner, 'title', 'unknown'),
+                        'playlist_id' => (string) ag($winner, 'sync_id', ag($winner, 'backend_id', '')),
+                        'playlist_title' => (string) ag($winner, 'title', 'Untitled playlist'),
                         'state_id' => $stateId,
+                        'reason' => 'missing_local_state',
                     ],
                 );
                 $missingStateIds[] = (int) $stateId;
@@ -918,11 +1114,18 @@ class PlaylistSyncService
             $backendId = trim((string) ag($entity->getMetadata($backend), iState::COLUMN_ID, ''));
             if ('' === $backendId) {
                 $this->logger->info(
-                    "PLAYLIST: Skipping '{backend}' sync for '{title}'. Item '{item}' is not available on target backend.",
+                    "Skipping item '{item_title}' for playlist '{playlist_title}' on '{backend}': it is not available on the target backend.",
                     [
+                        'event_name' => 'playlist.target.item.skipped',
+                        'subsystem' => 'playlist',
+                        'operation' => 'resolve_target_item',
+                        'outcome' => 'skipped',
                         'backend' => $backend,
-                        'title' => ag($winner, 'title', 'unknown'),
-                        'item' => $entity->getName(),
+                        'playlist_id' => (string) ag($winner, 'sync_id', ag($winner, 'backend_id', '')),
+                        'playlist_title' => (string) ag($winner, 'title', 'Untitled playlist'),
+                        'item_title' => $entity->getName(),
+                        'state_id' => $stateId,
+                        'reason' => 'missing_target_item',
                     ],
                 );
                 $missingStateIds[] = (int) $stateId;
@@ -1111,10 +1314,15 @@ class PlaylistSyncService
         $store->updateMetadata((int) $target['id'], $cleared['metadata'] ?? []);
 
         $this->logger->info(
-            "PLAYLIST: Clearing partial sync marker for '{backend}' playlist '{title}'. Target playlist now matches the current desired state.",
+            "Cleared the partial sync marker for playlist '{playlist_title}' on '{backend}'; the target playlist now matches the desired state.",
             [
-                'backend' => ag($target, 'backend', 'unknown'),
-                'title' => ag($target, 'title', 'unknown'),
+                'event_name' => 'playlist.partial_marker.cleared',
+                'subsystem' => 'playlist',
+                'operation' => 'clear_partial_marker',
+                'outcome' => 'completed',
+                'backend' => (string) ag($target, 'backend', 'unknown'),
+                'playlist_id' => (string) ag($target, 'backend_id', ag($target, 'sync_id', '')),
+                'playlist_title' => (string) ag($target, 'title', 'Untitled playlist'),
             ],
         );
 
@@ -1464,20 +1672,41 @@ class PlaylistSyncService
         return 0;
     }
 
-    private function logBackendThrowable(Throwable $e, string $backendName, string $action): void
-    {
+    private function logBackendThrowable(
+        Throwable $e,
+        string $backendName,
+        string $user,
+        string $operation,
+        string $playlistId = '',
+        string $playlistTitle = '',
+        string $eventName = 'playlist.operation.failed',
+        ?string $operationLabel = null,
+    ): void {
+        $operationLabel ??= str_replace('_', ' ', $operation);
+        $message = '' !== trim($playlistId . $playlistTitle)
+            ? "Failed to {operation_label} playlist '{playlist_title}' on '{user}@{backend}'."
+            : "Failed to {operation_label} for '{user}@{backend}'.";
+
         $this->logger->error(
-            "PLAYLIST: Failed to {action} for '{backend}'. '{error.message}' at '{error.file}:{error.line}'.",
-            [
-                'action' => $action,
-                'backend' => $backendName,
-                'error' => [
-                    'message' => $e->getMessage(),
-                    'file' => after($e->getFile(), ROOT_PATH),
-                    'line' => $e->getLine(),
-                    'kind' => $e::class,
-                ],
-            ],
+            ...lw(
+                message: $message,
+                context: array_filter(
+                    [
+                        'event_name' => $eventName,
+                        'subsystem' => 'playlist',
+                        'operation' => $operation,
+                        'operation_label' => $operationLabel,
+                        'outcome' => 'failed',
+                        'user' => $user,
+                        'backend' => $backendName,
+                        'playlist_id' => '' !== $playlistId ? $playlistId : null,
+                        'playlist_title' => '' !== $playlistTitle ? $playlistTitle : null,
+                        ...exception_log($e),
+                    ],
+                    static fn(mixed $value): bool => null !== $value,
+                ),
+                e: $e,
+            ),
         );
     }
 }

--- a/src/Libs/Prune/FilePruner.php
+++ b/src/Libs/Prune/FilePruner.php
@@ -25,7 +25,7 @@ final class FilePruner
                 'name' => 'logs_remover',
                 'path' => Config::get('tmpDir') . '/logs',
                 'base' => Config::get('tmpDir'),
-                'filter' => '/\.log$/',
+                'filter' => '/\.(jsonl|log)$/',
                 'time' => strtotime((string) Config::get('logs.prune.after', '-7 DAYS'), $time),
             ],
             [
@@ -46,7 +46,7 @@ final class FilePruner
                 'name' => 'debug_remover',
                 'path' => Config::get('tmpDir') . '/debug',
                 'base' => Config::get('tmpDir'),
-                'filter' => '/\.json$/',
+                'filter' => '/\.(json|txt)$/',
                 'time' => strtotime('-3 DAYS', $time),
             ],
             [

--- a/src/Libs/Utils.php
+++ b/src/Libs/Utils.php
@@ -784,7 +784,14 @@ if (!function_exists('register_events')) {
                     $dispatcher->addListener(ag($event, 'on'), ag($event, 'callable'));
                 }
             } catch (Throwable $e) {
-                $logger->error($e->getMessage(), []);
+                $logger->error("Failed to register event listeners from '{file}'.", [
+                    'event_name' => 'app.exception.event_registration_failed',
+                    'subsystem' => 'app',
+                    'operation' => 'register_events',
+                    'outcome' => 'failed',
+                    'file' => $eventsFile,
+                    ...exception_log($e),
+                ]);
             }
         }
 
@@ -1622,12 +1629,16 @@ if (!function_exists('exception_log')) {
      *
      * @param Throwable $e The exception.
      *
-     * @return array{error: array,excpetion: array} The exception formatted in standard way.
+     * @return array{
+     *     error: array{type: class-string<Throwable>, kind: class-string<Throwable>, line: int, message: string, file: string},
+     *     exception: array{file: string, line: int, type: class-string<Throwable>, kind: class-string<Throwable>, message: string, trace: array<mixed>}
+     * } The exception formatted in standard way.
      */
     function exception_log(Throwable $e): array
     {
         return [
             'error' => [
+                'type' => $e::class,
                 'kind' => $e::class,
                 'line' => $e->getLine(),
                 'message' => $e->getMessage(),
@@ -1636,6 +1647,7 @@ if (!function_exists('exception_log')) {
             'exception' => [
                 'file' => $e->getFile(),
                 'line' => $e->getLine(),
+                'type' => $e::class,
                 'kind' => $e::class,
                 'message' => $e->getMessage(),
                 'trace' => $e->getTrace(),

--- a/src/Libs/Utils.php
+++ b/src/Libs/Utils.php
@@ -215,7 +215,7 @@ if (!function_exists('api_request')) {
             'SERVER_NAME' => 'localhost',
             'SERVER_PORT' => 80,
             'HTTP_USER_AGENT' => Config::get('http.default.options.headers.User-Agent', 'APIRequest'),
-            'X_REQUEST_ID' => generate_uuid('intr'),
+            'X_REQUEST_ID' => generate_uuid(),
             ...ag($opts, 'server', []),
         ];
 

--- a/src/Libs/helpers.php
+++ b/src/Libs/helpers.php
@@ -82,6 +82,100 @@ if (!function_exists('get_value')) {
     }
 }
 
+if (!function_exists('get_log_server_params')) {
+    /**
+     * Return only server params that are safe enough to include in structured logs.
+     *
+     * @param array<string,mixed> $server
+     * @return array<string,mixed>
+     */
+    function get_log_server_params(array $server): array
+    {
+        $allowed = [];
+        $whitelist = [
+            'REQUEST_' => 'starts_with',
+            'SERVER_' => 'starts_with',
+            'REMOTE_' => 'starts_with',
+            'HTTP_' => 'starts_with',
+            'CONTENT_' => 'starts_with',
+            'APP_VERSION' => 'exact',
+            'PHP_VERSION' => 'exact',
+            'PHP_VERSION_ID' => 'exact',
+            'PHP_OS' => 'exact',
+            'DOCUMENT_ROOT' => 'exact',
+            'SCRIPT_NAME' => 'exact',
+            'PHP_SELF' => 'exact',
+            'HTTPS' => 'exact',
+            'SYSTEM' => 'exact',
+            'argc' => 'exact',
+        ];
+        $deny = [
+            'AUTHORIZATION',
+            'COOKIE',
+            'TOKEN',
+            'PASSWORD',
+            'PASSWD',
+            'SECRET',
+            'APIKEY',
+            'API_KEY',
+            'ACCESSKEY',
+            'PRIVATEKEY',
+            'SESSION',
+            'PHP_AUTH',
+        ];
+
+        foreach ($server as $key => $value) {
+            $normalized = strtoupper((string) $key);
+            $normalizedCompact = str_replace(['-', '_'], '', $normalized);
+
+            $denied = false;
+            foreach ($deny as $field) {
+                if (false === str_contains($normalizedCompact, str_replace('_', '', $field))) {
+                    continue;
+                }
+
+                $denied = true;
+                break;
+            }
+
+            if (true === $denied) {
+                continue;
+            }
+
+            $matched = false;
+            foreach ($whitelist as $field => $mode) {
+                $field = strtoupper((string) $field);
+
+                if ('' === $field) {
+                    continue;
+                }
+
+                $matched = match ($mode) {
+                    'contains' => str_contains($normalized, $field),
+                    'ends_with' => str_ends_with($normalized, $field),
+                    'exact' => $normalized === $field,
+                    'starts_with' => str_starts_with($normalized, $field),
+                    default => false,
+                };
+
+                if (true === $matched) {
+                    break;
+                }
+            }
+
+            if (false === $matched) {
+                continue;
+            }
+
+            if (is_scalar($value) || null === $value) {
+                $allowed[$key] = $value;
+            }
+        }
+
+        return $allowed;
+    }
+}
+
 if (!function_exists('make_date')) {
     /**
      * Make date time object.

--- a/src/Libs/helpers.php
+++ b/src/Libs/helpers.php
@@ -683,8 +683,8 @@ if (!function_exists('queue_push')) {
         }
 
         if (!$entity->hasGuids() && !$entity->hasRelativeGuid()) {
-            $logger->error("Unable to push '{id}' event '{via}: {entity}'. It has no GUIDs.", [
-                'id' => $entity->id,
+            $logger->error("Unable to push '{item_id}' event '{via}: {entity}'. It has no GUIDs.", [
+                'item_id' => $entity->id,
                 'via' => $entity->via,
                 'entity' => $entity->getName(),
             ]);

--- a/src/Listeners/ProcessProfileEvent.php
+++ b/src/Listeners/ProcessProfileEvent.php
@@ -38,6 +38,7 @@ final readonly class ProcessProfileEvent
 
     public function __invoke(DataEvent $e): DataEvent
     {
+        $profileId = (string) ag($e->getData(), 'meta.id', '??');
         $writer = function (Level $level, string $message, array $context = []) use ($e) {
             $e->addLogEntry($level, $message, $context);
             $this->logger->log($level, $message, $context);
@@ -48,29 +49,54 @@ final readonly class ProcessProfileEvent
         $hasCollector = null !== ($url = ag($this->config, 'collector'));
         $saveProfile = (bool) ag($this->config, 'save', false);
         if (false === $hasCollector && false === $saveProfile) {
-            $writer(Level::Info, 'No profile collector url was set and save is disabled.');
+            $writer(Level::Info, "Profile '{profile_id}' export skipped: collector URL is not set and local save is disabled.", [
+                'event_name' => 'profile.export.disabled',
+                'subsystem' => 'profile',
+                'operation' => 'export',
+                'outcome' => 'skipped',
+                'profile_id' => $profileId,
+                'collector_configured' => false,
+                'save_enabled' => false,
+                'reason' => 'collector_not_configured_and_save_disabled',
+            ]);
             return $e;
         }
 
         $data = json_encode($e->getData());
         if (false === $data) {
-            $writer(Level::Error, 'Failed to encode profile data.');
+            $writer(Level::Error, "Failed to encode profile '{profile_id}'.", [
+                'event_name' => 'profile.encode.failed',
+                'subsystem' => 'profile',
+                'operation' => 'encode',
+                'outcome' => 'failed',
+                'profile_id' => $profileId,
+                'error' => [
+                    'message' => json_last_error_msg(),
+                ],
+            ]);
             return $e;
         }
 
         if (true === (bool) ag($this->config, 'save', false)) {
+            $path = r('{path}/{date}-{uuid}.json', [
+                'path' => rtrim(Config::get('profiler.path'), sys_get_temp_dir()),
+                'date' => gmdate('YmdHis'),
+                'uuid' => ag($e->getData(), 'meta.id', generate_uuid(...)),
+            ]);
+
             try {
-                $stream = new Stream(r('{path}/{date}-{uuid}.json', [
-                    'path' => rtrim(Config::get('profiler.path'), sys_get_temp_dir()),
-                    'date' => gmdate('YmdHis'),
-                    'uuid' => ag($e->getData(), 'meta.id', generate_uuid(...)),
-                ]), 'w');
+                $stream = new Stream($path, 'w');
                 $stream->write($data);
                 $stream->close();
-            } catch (Throwable $e) {
-                $writer(Level::Error, 'Failed to save profile data. {message}', [
-                    'message' => $e->getMessage(),
-                    'exception' => $e,
+            } catch (Throwable $ex) {
+                $writer(Level::Error, "Failed to save profile '{profile_id}' to '{path}'.", [
+                    'event_name' => 'profile.save.failed',
+                    'subsystem' => 'profile',
+                    'operation' => 'save',
+                    'outcome' => 'failed',
+                    'profile_id' => $profileId,
+                    'path' => $path,
+                    ...exception_log($ex),
                 ]);
             }
         }
@@ -82,20 +108,46 @@ final readonly class ProcessProfileEvent
                 $statusCode = $response->getStatusCode();
 
                 if (Status::OK !== Status::tryFrom($statusCode)) {
-                    $this->logger->error("Failed to process profile '{profile_id}'. Status: '{status}'.", [
-                        'profile_id' => ag($e->getData(), 'meta.id', '??'),
-                        'status' => $statusCode,
+                    $writer(Level::Error, "Profile collector returned status {http.status_code} for '{profile_id}'.", [
+                        'event_name' => 'profile.collector.unexpected_status',
+                        'subsystem' => 'profile',
+                        'operation' => 'collect',
+                        'outcome' => 'failed',
+                        'profile_id' => $profileId,
+                        'collector' => [
+                            'url' => $url,
+                        ],
+                        'http' => [
+                            'status_code' => $statusCode,
+                        ],
                     ]);
                     return $e;
                 }
 
-                $this->logger->notice("Successfully Processed '{profile_id}'.", [
-                    'profile_id' => ag($e->getData(), 'meta.id', '??'),
+                $writer(Level::Notice, "Sent profile '{profile_id}' to collector with status {http.status_code}.", [
+                    'event_name' => 'profile.collector.completed',
+                    'subsystem' => 'profile',
+                    'operation' => 'collect',
+                    'outcome' => 'completed',
+                    'profile_id' => $profileId,
+                    'collector' => [
+                        'url' => $url,
+                    ],
+                    'http' => [
+                        'status_code' => $statusCode,
+                    ],
                 ]);
-            } catch (TransportExceptionInterface $e) {
-                $writer(Level::Error, 'Error sending profile data to collector. {message}', [
-                    'message' => $e->getMessage(),
-                    'exception' => $e,
+            } catch (TransportExceptionInterface $ex) {
+                $writer(Level::Error, "Failed to send profile '{profile_id}' to collector.", [
+                    'event_name' => 'profile.collector.failed',
+                    'subsystem' => 'profile',
+                    'operation' => 'collect',
+                    'outcome' => 'failed',
+                    'profile_id' => $profileId,
+                    'collector' => [
+                        'url' => $url,
+                    ],
+                    ...exception_log($ex),
                 ]);
             }
         }

--- a/src/Listeners/ProcessProfileEvent.php
+++ b/src/Listeners/ProcessProfileEvent.php
@@ -27,7 +27,7 @@ final readonly class ProcessProfileEvent
      * Class constructor.
      *
      * @param iLogger $logger The logger object.
-     * @param iHttp $client The http client object.
+     * @param iHttp&\App\Libs\Extends\HttpClient $client The http client object.
      */
     public function __construct(
         private iLogger $logger,
@@ -39,7 +39,7 @@ final readonly class ProcessProfileEvent
     public function __invoke(DataEvent $e): DataEvent
     {
         $writer = function (Level $level, string $message, array $context = []) use ($e) {
-            $e->addLog($level->getName() . ': ' . r($message, $context));
+            $e->addLogEntry($level, $message, $context);
             $this->logger->log($level, $message, $context);
         };
 
@@ -82,15 +82,15 @@ final readonly class ProcessProfileEvent
                 $statusCode = $response->getStatusCode();
 
                 if (Status::OK !== Status::tryFrom($statusCode)) {
-                    $this->logger->error("Failed to process profile '{id}'. Status: '{status}'.", [
-                        'id' => ag($e->getData(), 'meta.id', '??'),
+                    $this->logger->error("Failed to process profile '{profile_id}'. Status: '{status}'.", [
+                        'profile_id' => ag($e->getData(), 'meta.id', '??'),
                         'status' => $statusCode,
                     ]);
                     return $e;
                 }
 
-                $this->logger->notice("Successfully Processed '{id}'.", [
-                    'id' => ag($e->getData(), 'meta.id', '??'),
+                $this->logger->notice("Successfully Processed '{profile_id}'.", [
+                    'profile_id' => ag($e->getData(), 'meta.id', '??'),
                 ]);
             } catch (TransportExceptionInterface $e) {
                 $writer(Level::Error, 'Error sending profile data to collector. {message}', [

--- a/src/Listeners/ProcessProgressEvent.php
+++ b/src/Listeners/ProcessProgressEvent.php
@@ -53,9 +53,6 @@ final readonly class ProcessProgressEvent
             $event->addLogEntry($level, $message, $context);
             $this->logger->log($level, $message, $context);
         };
-        $eventWriter = static function (Level $level, string $message, array $context = []) use ($event): void {
-            $event->addLogEntry($level, $message, $context);
-        };
 
         $event->stopPropagation();
 
@@ -216,7 +213,7 @@ final readonly class ProcessProgressEvent
         foreach ($list as $name => &$backend) {
             try {
                 $opts = ag($backend, 'options', []);
-                $backendLogger = LoggerProxy::create($eventWriter);
+                $backendLogger = LoggerProxy::create($writer);
 
                 if (ag($options, Options::IGNORE_DATE)) {
                     $opts[Options::IGNORE_DATE] = true;
@@ -319,7 +316,6 @@ final readonly class ProcessProgressEvent
             client: $http,
             opts: [
                 'ok' => static function (Request $request, ResponseInterface $response) use (
-                    $eventWriter,
                     $writer,
                     $options,
                     $userContext,
@@ -355,7 +351,7 @@ final readonly class ProcessProgressEvent
                     }
 
                     if (false === in_array(Status::tryFrom($statusCode), [Status::OK, Status::NO_CONTENT], true)) {
-                        $eventWriter(
+                        $writer(
                             Level::Error,
                             "Progress update for '#{item_id}' on '{user}@{backend}' failed.",
                             [
@@ -373,7 +369,7 @@ final readonly class ProcessProgressEvent
                         return [];
                     }
 
-                    $eventWriter(
+                    $writer(
                         Level::Notice,
                         "Progress update for '#{item_id}' on '{user}@{backend}' completed.",
                         [
@@ -390,14 +386,14 @@ final readonly class ProcessProgressEvent
 
                     return [];
                 },
-                'error' => static function (Request $request, Throwable $ex) use ($eventWriter, $userContext, $item, $progress): array {
+                'error' => static function (Request $request, Throwable $ex) use ($writer, $userContext, $item, $progress): array {
                     if (true === (bool) ag($request->options, 'user_data.' . Options::NO_LOGGING, false)) {
                         return [];
                     }
 
                     $context = ag($request->extras, 'context', []);
 
-                    $eventWriter(
+                    $writer(
                         Level::Error,
                         "Progress update for '#{item_id}' on '{user}@{backend}' failed.",
                         [

--- a/src/Listeners/ProcessProgressEvent.php
+++ b/src/Listeners/ProcessProgressEvent.php
@@ -66,7 +66,14 @@ final readonly class ProcessProgressEvent
         try {
             $userContext = get_user_context(user: $user, mapper: $this->mapper, logger: $this->logger);
         } catch (RuntimeException $ex) {
-            $writer(Level::Error, $ex->getMessage());
+            $writer(Level::Error, "Failed to load progress user context for '{user}'.", [
+                'event_name' => 'progress.user_context.failed',
+                'subsystem' => 'progress',
+                'operation' => 'load_user_context',
+                'outcome' => 'failed',
+                'user' => $user,
+                ...exception_log($ex),
+            ]);
             return $event;
         }
 
@@ -75,7 +82,12 @@ final readonly class ProcessProgressEvent
         $hasProgressValue = ag_exists($options, Options::STATE_PROGRESS_VALUE);
 
         if (null === ($item = $userContext->db->get(Container::get(iState::class)::fromArray($event->getData())))) {
-            $writer(Level::Error, "'{user}' item '{item_id}' is not referenced locally yet.", [
+            $writer(Level::Error, "Cannot update progress for '#{item_id}' and '{user}': item is not referenced locally.", [
+                'event_name' => 'progress.item.missing',
+                'subsystem' => 'progress',
+                'operation' => 'load_item',
+                'outcome' => 'failed',
+                'reason' => 'missing_local_reference',
                 'user' => $userContext->name,
                 'item_id' => ag($event->getData(), 'id', '?'),
             ]);
@@ -88,12 +100,18 @@ final readonly class ProcessProgressEvent
             if (false === ($allowUpdate >= $minThreshold && time() > ($item->updated + $allowUpdate))) {
                 $writer(
                     level: Level::Info,
-                    message: "'{user}' item - '#{item_id}: {title}' is marked as watched. Not updating watch progress. {comp}",
+                    message: "Skipping progress update for '#{item_id}: {item_title}': item is already watched.",
                     context: [
+                        'event_name' => 'progress.item.skipped',
+                        'subsystem' => 'progress',
+                        'operation' => 'queue',
+                        'outcome' => 'skipped',
+                        'reason' => 'item_watched',
                         'item_id' => $item->id,
-                        'title' => $item->getName(),
+                        'item_title' => $item->getName(),
                         'user' => $userContext->name,
-                        'comp' => $allowUpdate > $minThreshold
+                        'progress' => $item->getPlayProgress(),
+                        'comparison' => $allowUpdate > $minThreshold
                             ? array_to_string([
                                 'threshold' => $allowUpdate,
                                 'now' => ['secs' => time(), 'time' => make_date(time())],
@@ -107,10 +125,16 @@ final readonly class ProcessProgressEvent
         }
 
         if (false === $hasProgressValue && false === $item->hasPlayProgress()) {
-            $writer(Level::Info, "'{user}' item '#{item_id}: {title}' has no watch progress to export.", [
+            $writer(Level::Info, "No progress updates queued for '{user}'.", [
+                'event_name' => 'progress.queue.empty',
+                'subsystem' => 'progress',
+                'operation' => 'queue',
+                'outcome' => 'completed',
+                'reason' => 'no_progress_to_export',
                 'item_id' => $item->id,
-                'title' => $item->title,
+                'item_title' => $item->title,
                 'user' => $userContext->name,
+                'queue_count' => 0,
             ]);
             return $event;
         }
@@ -128,7 +152,12 @@ final readonly class ProcessProgressEvent
             $type = strtolower(ag($backend, 'type', 'unknown'));
 
             if (true !== (bool) ag($backend, 'export.enabled')) {
-                $writer(Level::Notice, "Ignoring '{user}@{backend}'. Export is disabled.", [
+                $writer(Level::Notice, "Skipping progress target '{user}@{backend}': export is disabled.", [
+                    'event_name' => 'progress.backend.skipped',
+                    'subsystem' => 'progress',
+                    'operation' => 'queue',
+                    'outcome' => 'skipped',
+                    'reason' => 'export_disabled',
                     'backend' => $backendName,
                     'user' => $userContext->name,
                 ]);
@@ -136,7 +165,12 @@ final readonly class ProcessProgressEvent
             }
 
             if (!isset($supported[$type])) {
-                $writer(Level::Error, "Ignoring '{user}@{backend}'. Invalid type '{type}'.", [
+                $writer(Level::Error, "Skipping progress target '{user}@{backend}': backend type '{type}' is unsupported.", [
+                    'event_name' => 'progress.backend.skipped',
+                    'subsystem' => 'progress',
+                    'operation' => 'queue',
+                    'outcome' => 'skipped',
+                    'reason' => 'unsupported_type',
                     'type' => $type,
                     'backend' => $backendName,
                     'condition' => [
@@ -149,7 +183,12 @@ final readonly class ProcessProgressEvent
             }
 
             if (null === ($url = ag($backend, 'url')) || false === is_valid_url($url)) {
-                $writer(Level::Error, "Ignoring '{user}@{backend}'. Invalid URL '{url}'.", [
+                $writer(Level::Error, "Skipping progress target '{user}@{backend}': URL '{url}' is invalid.", [
+                    'event_name' => 'progress.backend.skipped',
+                    'subsystem' => 'progress',
+                    'operation' => 'queue',
+                    'outcome' => 'skipped',
+                    'reason' => 'invalid_url',
                     'backend' => $backendName,
                     'url' => $url ?? 'None',
                     'user' => $userContext->name,
@@ -162,7 +201,15 @@ final readonly class ProcessProgressEvent
         }
 
         if (empty($list)) {
-            $writer(Level::Warning, 'There are no backends to send the events to.');
+            $writer(Level::Warning, "No progress updates queued for '{user}'.", [
+                'event_name' => 'progress.queue.empty',
+                'subsystem' => 'progress',
+                'operation' => 'queue',
+                'outcome' => 'failed',
+                'reason' => 'no_eligible_backends',
+                'user' => $userContext->name,
+                'queue_count' => 0,
+            ]);
             return $event;
         }
 
@@ -200,21 +247,34 @@ final readonly class ProcessProgressEvent
             } catch (UnexpectedVersionException|NotImplementedException $ex) {
                 $writer(
                     Level::Notice,
-                    "This feature is not available for '{user}@{backend}'. '{error.message}' at '{error.file}:{error.line}'.",
+                    "Skipping progress update for '#{item_id}: {item_title}' on '{user}@{backend}': backend feature is unavailable.",
                     [
+                        'event_name' => 'progress.item.skipped',
+                        'subsystem' => 'progress',
+                        'operation' => 'queue',
+                        'outcome' => 'skipped',
+                        'reason' => 'feature_unavailable',
                         'user' => $userContext->name,
                         'backend' => $name,
+                        'item_id' => $item->id,
+                        'item_type' => $item->type,
+                        'item_title' => $item->getName(),
                         ...exception_log($ex),
                     ],
                 );
             } catch (Throwable $ex) {
                 $writer(
                     Level::Error,
-                    "Exception '{error.kind}' was thrown unhandled during '{user}@{backend}' request to sync '#{item_id}: {title}' progress. '{error.message}' at '{error.file}:{error.line}'.",
+                    "Failed to queue progress update for '#{item_id}: {item_title}' on '{user}@{backend}'.",
                     [
+                        'event_name' => 'progress.item.failed',
+                        'subsystem' => 'progress',
+                        'operation' => 'queue',
+                        'outcome' => 'failed',
                         'item_id' => $item->id,
                         'backend' => $name,
-                        'title' => $item->getName(),
+                        'item_type' => $item->type,
+                        'item_title' => $item->getName(),
                         'user' => $userContext->name,
                         ...exception_log($ex),
                     ],
@@ -225,16 +285,30 @@ final readonly class ProcessProgressEvent
         unset($backend);
 
         if (count($this->queue) < 1) {
-            $writer(Level::Notice, "Backend clients didn't queue items to be updated.");
+            $writer(Level::Notice, "No progress updates queued for '{user}'.", [
+                'event_name' => 'progress.queue.empty',
+                'subsystem' => 'progress',
+                'operation' => 'queue',
+                'outcome' => 'completed',
+                'reason' => 'no_updates_queued',
+                'user' => $userContext->name,
+                'queue_count' => 0,
+            ]);
             return $event;
         }
 
-        $writer(Level::Notice, "Processing '{user}@{backend}' - '#{item_id}: {title}' watch progress '{progress}' event.", [
+        $writer(Level::Notice, "Processing progress '{progress}' for '#{item_id}: {item_title}' from '{user}@{backend}'.", [
+            'event_name' => 'progress.item.processing',
+            'subsystem' => 'progress',
+            'operation' => 'dispatch',
+            'outcome' => 'started',
             'item_id' => $item->id,
             'backend' => $item->via,
             'user' => $userContext->name,
-            'title' => $item->getName(),
+            'item_type' => $item->type,
+            'item_title' => $item->getName(),
             'progress' => $progress,
+            'progress_seconds' => $progressValue / 1000,
         ]);
 
         $http = Container::get(iHttp::class);
@@ -264,10 +338,16 @@ final readonly class ProcessProgressEvent
                     $statusCode = $response->getStatusCode();
 
                     if (true === (bool) ag($options, 'trace')) {
-                        $writer(Level::Debug, "Processing '{user}@{backend}' - '#{item_id}: {item.title}' response.", [
+                        $writer(Level::Debug, "Processing progress response for '#{item_id}' from '{user}@{backend}'.", [
+                            'event_name' => 'progress.request.response',
+                            'subsystem' => 'progress',
+                            'operation' => 'dispatch',
+                            'outcome' => 'received',
                             'item_id' => $context['item_id'],
-                            'url' => ag($context, 'remote.url', '??'),
-                            'status_code' => $statusCode,
+                            'http' => [
+                                'url' => ag($context, 'remote.url', '??'),
+                                'status_code' => $statusCode,
+                            ],
                             'headers' => $response->getHeaders(false),
                             'response' => $response->getContent(false),
                             ...$context,
@@ -277,10 +357,16 @@ final readonly class ProcessProgressEvent
                     if (false === in_array(Status::tryFrom($statusCode), [Status::OK, Status::NO_CONTENT], true)) {
                         $eventWriter(
                             Level::Error,
-                            "Request to change '{user}@{backend}' - '#{item_id}: {item.title}' watch progress returned with unexpected '{status_code}' status code.",
+                            "Progress update for '#{item_id}' on '{user}@{backend}' failed.",
                             [
                                 ...$context,
-                                'status_code' => $statusCode,
+                                'event_name' => 'progress.request.failed',
+                                'subsystem' => 'progress',
+                                'operation' => 'dispatch',
+                                'outcome' => 'failed',
+                                'http' => [
+                                    'status_code' => $statusCode,
+                                ],
                             ],
                         );
 
@@ -289,10 +375,16 @@ final readonly class ProcessProgressEvent
 
                     $eventWriter(
                         Level::Notice,
-                        "Updated '{user}@{backend}' '#{item_id}: {item.title}' watch progress to '{progress}'.",
+                        "Progress update for '#{item_id}' on '{user}@{backend}' completed.",
                         [
                             ...$context,
-                            'status_code' => $statusCode,
+                            'event_name' => 'progress.request.completed',
+                            'subsystem' => 'progress',
+                            'operation' => 'dispatch',
+                            'outcome' => 'completed',
+                            'http' => [
+                                'status_code' => $statusCode,
+                            ],
                         ],
                     );
 
@@ -307,9 +399,13 @@ final readonly class ProcessProgressEvent
 
                     $eventWriter(
                         Level::Error,
-                        "Exception '{error.kind}' was thrown unhandled during '{user}@{backend}' request to change watch progress of {item.type} '#{item_id}: {item.title}'. '{error.message}' at '{error.file}:{error.line}'.",
+                        "Progress update for '#{item_id}' on '{user}@{backend}' failed.",
                         [
                             ...$context,
+                            'event_name' => 'progress.request.failed',
+                            'subsystem' => 'progress',
+                            'operation' => 'dispatch',
+                            'outcome' => 'failed',
                             'item_id' => ag($context, 'item.id', $item->id),
                             'user' => $userContext->name,
                             'progress' => ag($context, 'item.progress', $progress),

--- a/src/Listeners/ProcessProgressEvent.php
+++ b/src/Listeners/ProcessProgressEvent.php
@@ -50,11 +50,11 @@ final readonly class ProcessProgressEvent
     public function __invoke(DataEvent $event): DataEvent
     {
         $writer = function (Level $level, string $message, array $context = []) use ($event) {
-            $event->addLog($level->getName() . ': ' . r($message, $context));
+            $event->addLogEntry($level, $message, $context);
             $this->logger->log($level, $message, $context);
         };
         $eventWriter = static function (Level $level, string $message, array $context = []) use ($event): void {
-            $event->addLog($level->getName() . ': ' . r($message, $context));
+            $event->addLogEntry($level, $message, $context);
         };
 
         $event->stopPropagation();
@@ -75,9 +75,9 @@ final readonly class ProcessProgressEvent
         $hasProgressValue = ag_exists($options, Options::STATE_PROGRESS_VALUE);
 
         if (null === ($item = $userContext->db->get(Container::get(iState::class)::fromArray($event->getData())))) {
-            $writer(Level::Error, "'{user}' item '{id}' is not referenced locally yet.", [
+            $writer(Level::Error, "'{user}' item '{item_id}' is not referenced locally yet.", [
                 'user' => $userContext->name,
-                'id' => ag($event->getData(), 'id', '?'),
+                'item_id' => ag($event->getData(), 'id', '?'),
             ]);
             return $event;
         }
@@ -88,9 +88,9 @@ final readonly class ProcessProgressEvent
             if (false === ($allowUpdate >= $minThreshold && time() > ($item->updated + $allowUpdate))) {
                 $writer(
                     level: Level::Info,
-                    message: "'{user}' item - '#{id}: {title}' is marked as watched. Not updating watch progress. {comp}",
+                    message: "'{user}' item - '#{item_id}: {title}' is marked as watched. Not updating watch progress. {comp}",
                     context: [
-                        'id' => $item->id,
+                        'item_id' => $item->id,
                         'title' => $item->getName(),
                         'user' => $userContext->name,
                         'comp' => $allowUpdate > $minThreshold
@@ -107,8 +107,8 @@ final readonly class ProcessProgressEvent
         }
 
         if (false === $hasProgressValue && false === $item->hasPlayProgress()) {
-            $writer(Level::Info, "'{user}' item '#{id}: {title}' has no watch progress to export.", [
-                'id' => $item->id,
+            $writer(Level::Info, "'{user}' item '#{item_id}: {title}' has no watch progress to export.", [
+                'item_id' => $item->id,
                 'title' => $item->title,
                 'user' => $userContext->name,
             ]);
@@ -210,9 +210,9 @@ final readonly class ProcessProgressEvent
             } catch (Throwable $ex) {
                 $writer(
                     Level::Error,
-                    "Exception '{error.kind}' was thrown unhandled during '{user}@{backend}' request to sync '#{id}: {title}' progress. '{error.message}' at '{error.file}:{error.line}'.",
+                    "Exception '{error.kind}' was thrown unhandled during '{user}@{backend}' request to sync '#{item_id}: {title}' progress. '{error.message}' at '{error.file}:{error.line}'.",
                     [
-                        'id' => $item->id,
+                        'item_id' => $item->id,
                         'backend' => $name,
                         'title' => $item->getName(),
                         'user' => $userContext->name,
@@ -229,8 +229,8 @@ final readonly class ProcessProgressEvent
             return $event;
         }
 
-        $writer(Level::Notice, "Processing '{user}@{backend}' - '#{id}: {title}' watch progress '{progress}' event.", [
-            'id' => $item->id,
+        $writer(Level::Notice, "Processing '{user}@{backend}' - '#{item_id}: {title}' watch progress '{progress}' event.", [
+            'item_id' => $item->id,
             'backend' => $item->via,
             'user' => $userContext->name,
             'title' => $item->getName(),
@@ -258,13 +258,14 @@ final readonly class ProcessProgressEvent
 
                     $context = ag($request->extras, 'context', []);
                     $context['user'] = $userContext->name;
-                    $context['id'] = ag($context, 'item.id', $item->id);
+                    $context['item_id'] = ag($context, 'item.id', $item->id);
+                    unset($context['id']);
                     $context['progress'] = ag($context, 'item.progress', $progress);
                     $statusCode = $response->getStatusCode();
 
                     if (true === (bool) ag($options, 'trace')) {
-                        $writer(Level::Debug, "Processing '{user}@{backend}' - '#{id}: {item.title}' response.", [
-                            'id' => $context['id'],
+                        $writer(Level::Debug, "Processing '{user}@{backend}' - '#{item_id}: {item.title}' response.", [
+                            'item_id' => $context['item_id'],
                             'url' => ag($context, 'remote.url', '??'),
                             'status_code' => $statusCode,
                             'headers' => $response->getHeaders(false),
@@ -276,7 +277,7 @@ final readonly class ProcessProgressEvent
                     if (false === in_array(Status::tryFrom($statusCode), [Status::OK, Status::NO_CONTENT], true)) {
                         $eventWriter(
                             Level::Error,
-                            "Request to change '{user}@{backend}' - '#{id}: {item.title}' watch progress returned with unexpected '{status_code}' status code.",
+                            "Request to change '{user}@{backend}' - '#{item_id}: {item.title}' watch progress returned with unexpected '{status_code}' status code.",
                             [
                                 ...$context,
                                 'status_code' => $statusCode,
@@ -288,7 +289,7 @@ final readonly class ProcessProgressEvent
 
                     $eventWriter(
                         Level::Notice,
-                        "Updated '{user}@{backend}' '#{id}: {item.title}' watch progress to '{progress}'.",
+                        "Updated '{user}@{backend}' '#{item_id}: {item.title}' watch progress to '{progress}'.",
                         [
                             ...$context,
                             'status_code' => $statusCode,
@@ -306,10 +307,10 @@ final readonly class ProcessProgressEvent
 
                     $eventWriter(
                         Level::Error,
-                        "Exception '{error.kind}' was thrown unhandled during '{user}@{backend}' request to change watch progress of {item.type} '#{id}: {item.title}'. '{error.message}' at '{error.file}:{error.line}'.",
+                        "Exception '{error.kind}' was thrown unhandled during '{user}@{backend}' request to change watch progress of {item.type} '#{item_id}: {item.title}'. '{error.message}' at '{error.file}:{error.line}'.",
                         [
                             ...$context,
-                            'id' => ag($context, 'item.id', $item->id),
+                            'item_id' => ag($context, 'item.id', $item->id),
                             'user' => $userContext->name,
                             'progress' => ag($context, 'item.progress', $progress),
                             ...exception_log($ex),

--- a/src/Listeners/ProcessPushEvent.php
+++ b/src/Listeners/ProcessPushEvent.php
@@ -48,11 +48,11 @@ final readonly class ProcessPushEvent
     public function __invoke(DataEvent $e): DataEvent
     {
         $writer = function (Level $level, string $message, array $context = []) use ($e) {
-            $e->addLog($level->getName() . ': ' . r($message, $context));
+            $e->addLogEntry($level, $message, $context);
             $this->logger->log($level, $message, $context);
         };
         $eventWriter = static function (Level $level, string $message, array $context = []) use ($e): void {
-            $e->addLog($level->getName() . ': ' . r($message, $context));
+            $e->addLogEntry($level, $message, $context);
         };
 
         $e->stopPropagation();
@@ -68,16 +68,16 @@ final readonly class ProcessPushEvent
         }
 
         if (null === ($item = $userContext->db->get(Container::get(iState::class)::fromArray($e->getData())))) {
-            $writer(Level::Error, "Item '{user}: {id}' is not found or has been deleted.", [
+            $writer(Level::Error, "Item '{user}: {item_id}' is not found or has been deleted.", [
                 'user' => $user,
-                'id' => ag($e->getData(), 'id', '?'),
+                'item_id' => ag($e->getData(), 'id', '?'),
             ]);
             return $e;
         }
 
-        $writer(Level::Notice, "Processing '{user}@{via}' - '#{id}: {title}' push event.", [
+        $writer(Level::Notice, "Processing '{user}@{via}' - '#{item_id}: {title}' push event.", [
             'user' => $user,
-            'id' => $item->id,
+            'item_id' => $item->id,
             'via' => $item->via,
             'title' => $item->getName(),
         ]);
@@ -154,10 +154,11 @@ final readonly class ProcessPushEvent
             } catch (Throwable $e) {
                 $writer(
                     Level::Error,
-                    "Exception '{error.kind}' was thrown unhandled during '{user}@{backend}' - '#{item.id}: {item.title}' push event handling. {error.message} at '{error.file}:{error.line}'.",
+                    "Exception '{error.kind}' was thrown unhandled during '{user}@{backend}' - '#{item_id}: {item.title}' push event handling. {error.message} at '{error.file}:{error.line}'.",
                     [
                         'user' => $user,
                         'backend' => $name,
+                        'item_id' => $item->id,
                         'item' => [
                             'id' => $item->id,
                             'title' => $item->getName(),
@@ -186,14 +187,12 @@ final readonly class ProcessPushEvent
             return $e;
         }
 
-        $writer(Level::Notice, "Processing '{user}@{via}' - '#{id}: {title}' push event. {data}", [
+        $writer(Level::Notice, "Processing '{user}@{via}' - '#{item_id}: {title}' push event.", [
             'user' => $user,
-            'id' => $item->id,
+            'item_id' => $item->id,
             'via' => $item->via,
             'title' => $item->getName(),
-            'data' => array_to_string([
-                'played' => $item->isWatched(),
-            ]),
+            'played' => $item->isWatched(),
         ]);
 
         $http = Container::get(iHttp::class);
@@ -203,19 +202,20 @@ final readonly class ProcessPushEvent
             requests: $this->queue->getQueue(),
             client: $http,
             opts: [
-                'ok' => static function (Request $request, ResponseInterface $response) use ($eventWriter, $user): array {
+                'ok' => static function (Request $request, ResponseInterface $response) use ($eventWriter, $item, $user): array {
                     if (true === (bool) ag($request->options, 'user_data.' . Options::NO_LOGGING, false)) {
                         return [];
                     }
 
                     $context = ag($request->extras, 'context', []);
                     $context['user'] = $user;
+                    $context['item_id'] = $item->id;
                     $context['status_code'] = $response->getStatusCode();
 
                     if (Status::OK !== Status::tryFrom($context['status_code'])) {
                         $eventWriter(
                             Level::Error,
-                            "Request to change '{user}@{backend}' - '#{item.id}: {item.title}' play state returned with unexpected '{status_code}' status code.",
+                            "Request to change '{user}@{backend}' - '#{item_id}: {item.title}' play state returned with unexpected '{status_code}' status code.",
                             $context,
                         );
 
@@ -224,23 +224,24 @@ final readonly class ProcessPushEvent
 
                     $eventWriter(
                         Level::Notice,
-                        "Updated '{user}@{backend}' - '#{item.id}: {item.title}' watch state to '{play_state}'.",
+                        "Updated '{user}@{backend}' - '#{item_id}: {item.title}' watch state to '{play_state}'.",
                         $context,
                     );
 
                     return [];
                 },
-                'error' => static function (Request $request, Throwable $ex) use ($eventWriter, $user): array {
+                'error' => static function (Request $request, Throwable $ex) use ($eventWriter, $item, $user): array {
                     if (true === (bool) ag($request->options, 'user_data.' . Options::NO_LOGGING, false)) {
                         return [];
                     }
 
                     $context = ag($request->extras, 'context', []);
                     $context['user'] = $user;
+                    $context['item_id'] = $item->id;
 
                     $eventWriter(
                         Level::Error,
-                        "Exception '{error.kind}' was thrown unhandled during '{user}@{backend}' request to change play state of {item.type} '#{item.id}: {item.title}'. {error.message} at '{error.file}:{error.line}'.",
+                        "Exception '{error.kind}' was thrown unhandled during '{user}@{backend}' request to change play state of {item.type} '#{item_id}: {item.title}'. {error.message} at '{error.file}:{error.line}'.",
                         [
                             ...$context,
                             'error' => [

--- a/src/Listeners/ProcessPushEvent.php
+++ b/src/Listeners/ProcessPushEvent.php
@@ -63,23 +63,41 @@ final readonly class ProcessPushEvent
         try {
             $userContext = get_user_context(user: $user, mapper: $this->mapper, logger: $this->logger);
         } catch (RuntimeException $ex) {
-            $writer(Level::Error, $ex->getMessage());
+            $writer(Level::Error, "Failed to load push user context for '{user}'.", [
+                'event_name' => 'push.user_context.failed',
+                'subsystem' => 'push',
+                'operation' => 'load_user_context',
+                'outcome' => 'failed',
+                'user' => $user,
+                ...exception_log($ex),
+            ]);
             return $e;
         }
 
         if (null === ($item = $userContext->db->get(Container::get(iState::class)::fromArray($e->getData())))) {
-            $writer(Level::Error, "Item '{user}: {item_id}' is not found or has been deleted.", [
+            $writer(Level::Error, "Cannot push item '#{item_id}' for '{user}': item is missing or deleted.", [
+                'event_name' => 'push.item.missing',
+                'subsystem' => 'push',
+                'operation' => 'load_item',
+                'outcome' => 'failed',
+                'reason' => 'missing_or_deleted',
                 'user' => $user,
                 'item_id' => ag($e->getData(), 'id', '?'),
             ]);
             return $e;
         }
 
-        $writer(Level::Notice, "Processing '{user}@{via}' - '#{item_id}: {title}' push event.", [
+        $writer(Level::Notice, "Processing push for '#{item_id}: {item_title}' from '{user}@{backend}'.", [
+            'event_name' => 'push.item.processing',
+            'subsystem' => 'push',
+            'operation' => 'queue',
+            'outcome' => 'started',
             'user' => $user,
             'item_id' => $item->id,
-            'via' => $item->via,
-            'title' => $item->getName(),
+            'backend' => $item->via,
+            'item_type' => $item->type,
+            'item_title' => $item->getName(),
+            'state' => $item->isWatched() ? 'played' : 'unplayed',
         ]);
 
         $options = $e->getOptions();
@@ -90,7 +108,12 @@ final readonly class ProcessPushEvent
             $type = strtolower(ag($backend, 'type', 'unknown'));
 
             if (true !== (bool) ag($backend, 'export.enabled')) {
-                $writer(Level::Notice, "Export to '{user}@{backend}' is disabled by user.", [
+                $writer(Level::Notice, "Skipping push target '{user}@{backend}': export is disabled.", [
+                    'event_name' => 'push.backend.skipped',
+                    'subsystem' => 'push',
+                    'operation' => 'queue',
+                    'outcome' => 'skipped',
+                    'reason' => 'export_disabled',
                     'user' => $user,
                     'backend' => $backendName,
                 ]);
@@ -98,7 +121,12 @@ final readonly class ProcessPushEvent
             }
 
             if (!isset($supported[$type])) {
-                $writer(Level::Error, "Ignoring '{user}@{backend}'. Invalid type '{type}'.", [
+                $writer(Level::Error, "Skipping push target '{user}@{backend}': backend type '{type}' is unsupported.", [
+                    'event_name' => 'push.backend.skipped',
+                    'subsystem' => 'push',
+                    'operation' => 'queue',
+                    'outcome' => 'skipped',
+                    'reason' => 'unsupported_type',
                     'type' => $type,
                     'user' => $user,
                     'backend' => $backendName,
@@ -111,7 +139,12 @@ final readonly class ProcessPushEvent
             }
 
             if (null === ($url = ag($backend, 'url')) || false === is_valid_url($url)) {
-                $writer(Level::Error, "Ignoring '{user}@{backend}'. Invalid URL '{url}'.", [
+                $writer(Level::Error, "Skipping push target '{user}@{backend}': URL '{url}' is invalid.", [
+                    'event_name' => 'push.backend.skipped',
+                    'subsystem' => 'push',
+                    'operation' => 'queue',
+                    'outcome' => 'skipped',
+                    'reason' => 'invalid_url',
                     'user' => $user,
                     'backend' => $backendName,
                     'url' => $url ?? 'None',
@@ -124,7 +157,15 @@ final readonly class ProcessPushEvent
         }
 
         if (empty($list)) {
-            $writer(Level::Error, 'There are no eligible backends receive the event.');
+            $writer(Level::Error, "No eligible push targets found for '{user}'.", [
+                'event_name' => 'push.queue.empty',
+                'subsystem' => 'push',
+                'operation' => 'queue',
+                'outcome' => 'failed',
+                'reason' => 'no_eligible_backends',
+                'user' => $user,
+                'backend_count' => 0,
+            ]);
             return $e;
         }
 
@@ -154,28 +195,18 @@ final readonly class ProcessPushEvent
             } catch (Throwable $e) {
                 $writer(
                     Level::Error,
-                    "Exception '{error.kind}' was thrown unhandled during '{user}@{backend}' - '#{item_id}: {item.title}' push event handling. {error.message} at '{error.file}:{error.line}'.",
+                    "Push queueing failed for '#{item_id}: {item_title}' on '{user}@{backend}'.",
                     [
+                        'event_name' => 'push.item.failed',
+                        'subsystem' => 'push',
+                        'operation' => 'queue',
+                        'outcome' => 'failed',
                         'user' => $user,
                         'backend' => $name,
                         'item_id' => $item->id,
-                        'item' => [
-                            'id' => $item->id,
-                            'title' => $item->getName(),
-                        ],
-                        'error' => [
-                            'kind' => $e::class,
-                            'line' => $e->getLine(),
-                            'message' => $e->getMessage(),
-                            'file' => after($e->getFile(), ROOT_PATH),
-                        ],
-                        'exception' => [
-                            'file' => $e->getFile(),
-                            'line' => $e->getLine(),
-                            'kind' => get_class($e),
-                            'message' => $e->getMessage(),
-                            'trace' => $e->getTrace(),
-                        ],
+                        'item_type' => $item->type,
+                        'item_title' => $item->getName(),
+                        ...exception_log($e),
                     ],
                 );
             }
@@ -183,16 +214,28 @@ final readonly class ProcessPushEvent
         unset($backend);
 
         if (count($this->queue) < 1) {
-            $writer(Level::Notice, 'SYSTEM: No play state changes detected.');
+            $writer(Level::Notice, "No play-state changes queued for '{user}'.", [
+                'event_name' => 'push.queue.no_changes',
+                'subsystem' => 'push',
+                'operation' => 'queue',
+                'outcome' => 'completed',
+                'user' => $user,
+                'queue_count' => 0,
+            ]);
             return $e;
         }
 
-        $writer(Level::Notice, "Processing '{user}@{via}' - '#{item_id}: {title}' push event.", [
+        $writer(Level::Notice, "Processing push for '#{item_id}: {item_title}' from '{user}@{backend}'.", [
+            'event_name' => 'push.item.processing',
+            'subsystem' => 'push',
+            'operation' => 'dispatch',
+            'outcome' => 'started',
             'user' => $user,
             'item_id' => $item->id,
-            'via' => $item->via,
-            'title' => $item->getName(),
-            'played' => $item->isWatched(),
+            'backend' => $item->via,
+            'item_type' => $item->type,
+            'item_title' => $item->getName(),
+            'state' => $item->isWatched() ? 'played' : 'unplayed',
         ]);
 
         $http = Container::get(iHttp::class);
@@ -215,8 +258,17 @@ final readonly class ProcessPushEvent
                     if (Status::OK !== Status::tryFrom($context['status_code'])) {
                         $eventWriter(
                             Level::Error,
-                            "Request to change '{user}@{backend}' - '#{item_id}: {item.title}' play state returned with unexpected '{status_code}' status code.",
-                            $context,
+                            "Push update for '#{item_id}' on '{user}@{backend}' failed.",
+                            [
+                                ...$context,
+                                'event_name' => 'push.request.failed',
+                                'subsystem' => 'push',
+                                'operation' => 'dispatch',
+                                'outcome' => 'failed',
+                                'http' => [
+                                    'status_code' => $response->getStatusCode(),
+                                ],
+                            ],
                         );
 
                         return [];
@@ -224,8 +276,17 @@ final readonly class ProcessPushEvent
 
                     $eventWriter(
                         Level::Notice,
-                        "Updated '{user}@{backend}' - '#{item_id}: {item.title}' watch state to '{play_state}'.",
-                        $context,
+                        "Push update for '#{item_id}' on '{user}@{backend}' completed.",
+                        [
+                            ...$context,
+                            'event_name' => 'push.request.completed',
+                            'subsystem' => 'push',
+                            'operation' => 'dispatch',
+                            'outcome' => 'completed',
+                            'http' => [
+                                'status_code' => $response->getStatusCode(),
+                            ],
+                        ],
                     );
 
                     return [];
@@ -241,22 +302,14 @@ final readonly class ProcessPushEvent
 
                     $eventWriter(
                         Level::Error,
-                        "Exception '{error.kind}' was thrown unhandled during '{user}@{backend}' request to change play state of {item.type} '#{item_id}: {item.title}'. {error.message} at '{error.file}:{error.line}'.",
+                        "Push update for '#{item_id}' on '{user}@{backend}' failed.",
                         [
                             ...$context,
-                            'error' => [
-                                'kind' => $ex::class,
-                                'line' => $ex->getLine(),
-                                'message' => $ex->getMessage(),
-                                'file' => after($ex->getFile(), ROOT_PATH),
-                            ],
-                            'exception' => [
-                                'file' => $ex->getFile(),
-                                'line' => $ex->getLine(),
-                                'kind' => get_class($ex),
-                                'message' => $ex->getMessage(),
-                                'trace' => $ex->getTrace(),
-                            ],
+                            'event_name' => 'push.request.failed',
+                            'subsystem' => 'push',
+                            'operation' => 'dispatch',
+                            'outcome' => 'failed',
+                            ...exception_log($ex),
                         ],
                     );
 

--- a/src/Listeners/ProcessPushEvent.php
+++ b/src/Listeners/ProcessPushEvent.php
@@ -51,9 +51,6 @@ final readonly class ProcessPushEvent
             $e->addLogEntry($level, $message, $context);
             $this->logger->log($level, $message, $context);
         };
-        $eventWriter = static function (Level $level, string $message, array $context = []) use ($e): void {
-            $e->addLogEntry($level, $message, $context);
-        };
 
         $e->stopPropagation();
         $this->queue->reset();
@@ -172,7 +169,7 @@ final readonly class ProcessPushEvent
         foreach ($list as $name => &$backend) {
             try {
                 $opts = ag($backend, 'options', []);
-                $backendLogger = LoggerProxy::create($eventWriter);
+                $backendLogger = LoggerProxy::create($writer);
 
                 if (ag($options, Options::IGNORE_DATE)) {
                     $opts[Options::IGNORE_DATE] = true;
@@ -245,7 +242,7 @@ final readonly class ProcessPushEvent
             requests: $this->queue->getQueue(),
             client: $http,
             opts: [
-                'ok' => static function (Request $request, ResponseInterface $response) use ($eventWriter, $item, $user): array {
+                'ok' => static function (Request $request, ResponseInterface $response) use ($writer, $item, $user): array {
                     if (true === (bool) ag($request->options, 'user_data.' . Options::NO_LOGGING, false)) {
                         return [];
                     }
@@ -256,7 +253,7 @@ final readonly class ProcessPushEvent
                     $context['status_code'] = $response->getStatusCode();
 
                     if (Status::OK !== Status::tryFrom($context['status_code'])) {
-                        $eventWriter(
+                        $writer(
                             Level::Error,
                             "Push update for '#{item_id}' on '{user}@{backend}' failed.",
                             [
@@ -274,7 +271,7 @@ final readonly class ProcessPushEvent
                         return [];
                     }
 
-                    $eventWriter(
+                    $writer(
                         Level::Notice,
                         "Push update for '#{item_id}' on '{user}@{backend}' completed.",
                         [
@@ -291,7 +288,7 @@ final readonly class ProcessPushEvent
 
                     return [];
                 },
-                'error' => static function (Request $request, Throwable $ex) use ($eventWriter, $item, $user): array {
+                'error' => static function (Request $request, Throwable $ex) use ($writer, $item, $user): array {
                     if (true === (bool) ag($request->options, 'user_data.' . Options::NO_LOGGING, false)) {
                         return [];
                     }
@@ -300,7 +297,7 @@ final readonly class ProcessPushEvent
                     $context['user'] = $user;
                     $context['item_id'] = $item->id;
 
-                    $eventWriter(
+                    $writer(
                         Level::Error,
                         "Push update for '#{item_id}' on '{user}@{backend}' failed.",
                         [

--- a/src/Listeners/ProcessWebhookEvent.php
+++ b/src/Listeners/ProcessWebhookEvent.php
@@ -71,7 +71,7 @@ final class ProcessWebhookEvent
         $this->event = $event;
 
         $this->writer = function (Level $level, string $message, array $context = []) use ($event): void {
-            $event->addLog($level->getName() . ': ' . r($message, $context));
+            $event->addLogEntry($level, $message, $context);
             $this->logger->log($level, $message, $context);
         };
 
@@ -136,7 +136,6 @@ final class ProcessWebhookEvent
                     'headers' => $request->getHeaders(),
                     'payload' => $request->getParsedBody(),
                 ],
-                forceContext: true,
             );
             return;
         }
@@ -188,7 +187,6 @@ final class ProcessWebhookEvent
                     'headers' => $request->getHeaders(),
                     'payload' => $request->getParsedBody(),
                 ],
-                forceContext: true,
             );
             return;
         }
@@ -202,7 +200,6 @@ final class ProcessWebhookEvent
                     'client' => $client->getName(),
                     'headers' => $request->getHeaders(),
                 ],
-                forceContext: false,
             );
             return;
         }
@@ -371,7 +368,6 @@ final class ProcessWebhookEvent
                         'user' => $userContext->name,
                         'backend' => $client->getName(),
                     ],
-                    forceContext: true,
                 );
             }
 
@@ -486,19 +482,22 @@ final class ProcessWebhookEvent
             $lastSync = make_date($lastSync);
         }
 
-        ($this->writer)(Level::Notice, r("{prefix}Processing '{user}@{backend}' request '{title}'. {data}", [
+        ($this->writer)(Level::Notice, "{prefix}Processing '{user}@{backend}' request '{title}'.", [
             'backend' => $entity->via,
             'title' => $entity->getName(),
             'prefix' => true === $entity->isTainted() ? '[T] ' : '',
-            'lastSync' => $lastSync,
             'user' => $userContext->name,
-            'data' => array_to_string([
-                'event' => ag($entity->getExtra($entity->via), iState::COLUMN_EXTRA_EVENT, '??'),
-                'state' => $entity->isWatched() ? 'played' : 'unplayed',
-                'progress' => $entity->hasPlayProgress() ? 'Yes' : 'No',
-                'request_id' => ag($options, Options::REQUEST_ID, '-'),
-            ]),
-        ]));
+            'item' => [
+                'title' => $entity->getName(),
+                'type' => $entity->type,
+            ],
+            'backend_item_id' => ag($entity->getMetadata($entity->via), iState::COLUMN_ID),
+            'request_id' => ag($options, Options::REQUEST_ID, '-'),
+            'state' => $entity->isWatched() ? 'played' : 'unplayed',
+            'progress' => $entity->hasPlayProgress() ? 'Yes' : 'No',
+            'webhook_event' => ag($entity->getExtra($entity->via), iState::COLUMN_EXTRA_EVENT, '??'),
+            'last_sync' => $lastSync,
+        ]);
 
         $isDebug = (bool) ag($options, Options::DEBUG_TRACE, false);
         if (true === (bool) ag($backend->getContext()->options, Options::DEBUG_TRACE, false)) {
@@ -553,7 +552,6 @@ final class ProcessWebhookEvent
         int|string|Level $level,
         string $message,
         array $context = [],
-        bool $forceContext = false,
     ): void {
         $params = $request->getServerParams();
 
@@ -583,13 +581,14 @@ final class ProcessWebhookEvent
             $context['attributes'] = $attributes;
         }
 
-        $levelName = $level instanceof Level ? $level->getName() : (string) $level;
-        $this->event?->addLog($levelName . ': ' . r($message, $context));
-
-        if (true === (Config::get('logs.context') || $forceContext)) {
-            $this->logger->log($level, $message, $context);
-        } else {
-            $this->logger->log($level, r($message, $context));
+        try {
+            $eventLevel = Logger::toMonologLevel($level);
+        } catch (Throwable) {
+            $eventLevel = Level::Notice;
         }
+
+        $this->event?->addLogEntry($eventLevel, $message, $context);
+
+        $this->logger->log($level, $message, $context);
     }
 }

--- a/src/Listeners/ProcessWebhookEvent.php
+++ b/src/Listeners/ProcessWebhookEvent.php
@@ -128,13 +128,19 @@ final class ProcessWebhookEvent
         }
 
         if (null === $client) {
+            $payload = $request->getParsedBody();
             $this->write(
                 $request,
                 Level::Warning,
-                'No backend client were able to parse the the request.',
+                'Webhook request from {request.ip} could not be parsed by any backend client.',
                 context: [
-                    'headers' => $request->getHeaders(),
-                    'payload' => $request->getParsedBody(),
+                    'event_name' => 'webhook.request.unparsed',
+                    'subsystem' => 'webhook',
+                    'operation' => 'request',
+                    'outcome' => 'ignored',
+                    'reason' => 'unsupported_payload',
+                    'backend_client_count' => count($usersContext['main']->config->getAll()),
+                    'payload_keys' => true === is_array($payload) ? array_keys($payload) : [],
                 ],
             );
             return;
@@ -146,12 +152,29 @@ final class ProcessWebhookEvent
         $uuid = ag($attr, 'backend.id');
 
         if (null === $uuid) {
-            $this->write($request, Level::Notice, "Request payload didn't contain a backend unique id.");
+            $payload = $request->getParsedBody();
+            $this->write($request, Level::Notice, 'Webhook request from {request.ip} is missing backend identifier.', [
+                'event_name' => 'webhook.request.missing_backend_id',
+                'subsystem' => 'webhook',
+                'operation' => 'request',
+                'outcome' => 'ignored',
+                'reason' => 'missing_backend_id',
+                'payload_keys' => true === is_array($payload) ? array_keys($payload) : [],
+            ]);
             return;
         }
 
         if (false === $isGeneric && null === $userId) {
-            $this->write($request, Level::Warning, "Request payload didn't contain a user id.");
+            $payload = $request->getParsedBody();
+            $this->write($request, Level::Warning, 'Webhook request from {request.ip} is missing user identifier.', [
+                'event_name' => 'webhook.request.missing_user_id',
+                'subsystem' => 'webhook',
+                'operation' => 'request',
+                'outcome' => 'ignored',
+                'reason' => 'missing_user_id',
+                'backend_uuid' => (string) $uuid,
+                'payload_keys' => true === is_array($payload) ? array_keys($payload) : [],
+            ]);
             return;
         }
 
@@ -181,11 +204,17 @@ final class ProcessWebhookEvent
             $this->write(
                 $request,
                 Level::Info,
-                "Request from '{client}' didn't match any user/backend.",
+                'Webhook request from {client} did not match any configured user/backend.',
                 context: [
-                    'client' => $client->getName(),
-                    'headers' => $request->getHeaders(),
-                    'payload' => $request->getParsedBody(),
+                    'event_name' => 'webhook.request.no_match',
+                    'subsystem' => 'webhook',
+                    'operation' => 'request',
+                    'outcome' => 'ignored',
+                    'reason' => 'no_config_match',
+                    'client' => $client->getType(),
+                    'backend_uuid' => (string) $uuid,
+                    'user_id' => null === $userId ? null : (string) $userId,
+                    'payload_keys' => true === is_array($request->getParsedBody()) ? array_keys($request->getParsedBody()) : [],
                 ],
             );
             return;
@@ -195,10 +224,17 @@ final class ProcessWebhookEvent
             $this->write(
                 $request,
                 Level::Info,
-                "Request from '{client}' treated as noop. No processing will be done.",
+                'Webhook request from {client} treated as noop: {reason_label}.',
                 context: [
-                    'client' => $client->getName(),
-                    'headers' => $request->getHeaders(),
+                    'event_name' => 'webhook.request.noop',
+                    'subsystem' => 'webhook',
+                    'operation' => 'request',
+                    'outcome' => 'ignored',
+                    'client' => $client->getType(),
+                    'backend_uuid' => (string) $uuid,
+                    'user_id' => null === $userId ? null : (string) $userId,
+                    'reason' => 'noop',
+                    'reason_label' => 'request flagged as noop',
                 ],
             );
             return;
@@ -224,11 +260,15 @@ final class ProcessWebhookEvent
             $this->write(
                 request: $request,
                 level: $this->level($e),
-                message: "Failed to process webhook for '{user}@{backend}'. {msg}.",
+                message: "Failed to process webhook item from '{user}@{backend}'.",
                 context: [
+                    'event_name' => 'webhook.item.failed',
+                    'subsystem' => 'webhook',
+                    'operation' => 'process',
+                    'outcome' => 'failed',
                     'user' => $mainBackend['userContext']->name,
                     'backend' => $mainBackend['backendName'],
-                    'msg' => $e->getMessage(),
+                    'client' => $mainBackend['client']->getType(),
                     ...exception_log($e),
                 ],
             );
@@ -239,14 +279,20 @@ final class ProcessWebhookEvent
             $this->write(
                 request: $request,
                 level: Level::Warning,
-                message: "Ignoring '{user}@{backend}' {item.type} '{item.title}'. No valid/supported external ids.",
+                message: "Ignoring webhook item '{item_title}' from '{user}@{backend}': no supported external ids.",
                 context: [
+                    'event_name' => 'webhook.item.ignored',
+                    'subsystem' => 'webhook',
+                    'operation' => 'process',
+                    'outcome' => 'ignored',
+                    'reason' => 'no_supported_external_ids',
                     'user' => $mainBackend['userContext']->name,
                     'backend' => $entity->via,
-                    'item' => [
-                        'title' => $entity->getName(),
-                        'type' => $entity->type,
-                    ],
+                    'client' => $mainBackend['client']->getType(),
+                    'item_id' => (string) ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '?'),
+                    'item_type' => $entity->type,
+                    'item_title' => $entity->getName(),
+                    'guid_count' => count($entity->getGuids()),
                 ],
             );
             return;
@@ -256,16 +302,21 @@ final class ProcessWebhookEvent
             $this->write(
                 request: $request,
                 level: Level::Notice,
-                message: "Ignoring '{user}@{backend}' {item.type} '{item.title}'. No episode/season number present.",
+                message: "Ignoring webhook item '{item_title}' from '{user}@{backend}': episode or season number is missing.",
                 context: [
+                    'event_name' => 'webhook.item.ignored',
+                    'subsystem' => 'webhook',
+                    'operation' => 'process',
+                    'outcome' => 'ignored',
+                    'reason' => 'missing_episode_metadata',
                     'user' => $mainBackend['userContext']->name,
                     'backend' => $entity->via,
-                    'item' => [
-                        'title' => $entity->getName(),
-                        'type' => $entity->type,
-                        'season' => (string) ($entity->season ?? 'None'),
-                        'episode' => (string) ($entity->episode ?? 'None'),
-                    ],
+                    'client' => $mainBackend['client']->getType(),
+                    'item_id' => (string) ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '?'),
+                    'item_type' => $entity->type,
+                    'item_title' => $entity->getName(),
+                    'season' => (string) ($entity->season ?? 'None'),
+                    'episode' => (string) ($entity->episode ?? 'None'),
                 ],
             );
 
@@ -276,10 +327,16 @@ final class ProcessWebhookEvent
             $this->write(
                 request: $request,
                 level: Level::Info,
-                message: "Request from '{client}' matched '{count}' user/backends.",
+                message: 'Webhook request from {client} matched {count} configured user/backends.',
                 context: [
-                    'client' => $client->getName(),
+                    'event_name' => 'webhook.request.matched_multiple',
+                    'subsystem' => 'webhook',
+                    'operation' => 'request',
+                    'outcome' => 'matched',
+                    'client' => $client->getType(),
                     'count' => count($backends),
+                    'backend_uuid' => (string) $uuid,
+                    'user_id' => null === $userId ? null : (string) $userId,
                 ],
             );
         }
@@ -312,16 +369,18 @@ final class ProcessWebhookEvent
                 $this->write(
                     request: $perUserRequest,
                     level: $this->level($e),
-                    message: "Failed to process '{user}@{backend}' {item.type} '{item.title}'. '{error.message}' at '{error.file}:{error.line}'. {trace}",
+                    message: "Failed to process webhook item '{item_title}' from '{user}@{backend}'.",
                     context: [
+                        'event_name' => 'webhook.item.failed',
+                        'subsystem' => 'webhook',
+                        'operation' => 'process',
+                        'outcome' => 'failed',
                         'user' => $target['userContext']->name,
                         'backend' => $target['backendName'],
-                        'trace' => json_encode($e->getTrace(), flags: JSON_UNESCAPED_SLASHES),
-                        'item' => [
-                            'title' => $entity->getName(),
-                            'type' => $entity->type,
-                        ],
-                        'msg' => $e->getMessage(),
+                        'client' => $target['client']->getType(),
+                        'item_id' => (string) ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '?'),
+                        'item_type' => $entity->type,
+                        'item_title' => $entity->getName(),
                         ...exception_log($e),
                     ],
                 );
@@ -363,10 +422,16 @@ final class ProcessWebhookEvent
                 $this->write(
                     $request,
                     Level::Warning,
-                    "Import are disabled for '{user}@{backend}'.",
+                    "Ignoring webhook for '{user}@{backend}': import is disabled.",
                     context: [
                         'user' => $userContext->name,
-                        'backend' => $client->getName(),
+                        'backend' => $backendName,
+                        'client' => $client->getType(),
+                        'event_name' => 'webhook.backend.import_disabled',
+                        'subsystem' => 'webhook',
+                        'operation' => 'process',
+                        'outcome' => 'ignored',
+                        'reason' => 'import_disabled',
                     ],
                 );
             }
@@ -394,14 +459,20 @@ final class ProcessWebhookEvent
                 $this->write(
                     request: $request,
                     level: Level::Warning,
-                    message: "Ignoring '{user}@{backend}' {item.type} '{item.title}'. No valid/supported external ids.",
+                    message: "Ignoring webhook item '{item_title}' from '{user}@{backend}': no supported external ids.",
                     context: [
+                        'event_name' => 'webhook.item.ignored',
+                        'subsystem' => 'webhook',
+                        'operation' => 'process',
+                        'outcome' => 'ignored',
+                        'reason' => 'no_supported_external_ids',
                         'user' => $userContext->name,
                         'backend' => $entity->via,
-                        'item' => [
-                            'title' => $entity->getName(),
-                            'type' => $entity->type,
-                        ],
+                        'client' => $client->getType(),
+                        'item_id' => (string) ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '?'),
+                        'item_title' => $entity->getName(),
+                        'item_type' => $entity->type,
+                        'guid_count' => count($entity->getGuids()),
                     ],
                 );
             }
@@ -414,16 +485,21 @@ final class ProcessWebhookEvent
                 $this->write(
                     request: $request,
                     level: Level::Notice,
-                    message: "Ignoring '{user}@{backend}' {item.type} '{item.title}'. No episode/season number present.",
+                    message: "Ignoring webhook item '{item_title}' from '{user}@{backend}': episode or season number is missing.",
                     context: [
+                        'event_name' => 'webhook.item.ignored',
+                        'subsystem' => 'webhook',
+                        'operation' => 'process',
+                        'outcome' => 'ignored',
+                        'reason' => 'missing_episode_metadata',
                         'user' => $userContext->name,
                         'backend' => $entity->via,
-                        'item' => [
-                            'title' => $entity->getName(),
-                            'type' => $entity->type,
-                            'season' => (string) ($entity->season ?? 'None'),
-                            'episode' => (string) ($entity->episode ?? 'None'),
-                        ],
+                        'client' => $client->getType(),
+                        'item_id' => (string) ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '?'),
+                        'item_title' => $entity->getName(),
+                        'item_type' => $entity->type,
+                        'season' => (string) ($entity->season ?? 'None'),
+                        'episode' => (string) ($entity->episode ?? 'None'),
                     ],
                 );
             }
@@ -456,7 +532,14 @@ final class ProcessWebhookEvent
         try {
             $userContext = get_user_context(user: $user, mapper: $this->mapper, logger: $this->logger);
         } catch (RuntimeException $ex) {
-            ($this->writer)(Level::Error, $ex->getMessage());
+            ($this->writer)(Level::Error, "Failed to load webhook user context for '{user}'.", [
+                'event_name' => 'webhook.request.user_context_failed',
+                'subsystem' => 'webhook',
+                'operation' => 'request',
+                'outcome' => 'failed',
+                'user' => $user,
+                ...exception_log($ex),
+            ]);
             return $event;
         }
 
@@ -473,7 +556,19 @@ final class ProcessWebhookEvent
             try {
                 $backend->getMetadata(ag($entity->getMetadata($entity->via), iState::COLUMN_ID));
             } catch (Throwable $ex) {
-                ($this->writer)(Level::Info, $ex->getMessage());
+                ($this->writer)(Level::Info, "Ignoring webhook item '{item_title}' from '{user}@{backend}': metadata is unavailable.", [
+                    'event_name' => 'webhook.item.ignored',
+                    'subsystem' => 'webhook',
+                    'operation' => 'process',
+                    'outcome' => 'ignored',
+                    'reason' => 'metadata_unavailable',
+                    'user' => $userContext->name,
+                    'backend' => $entity->via,
+                    'item_id' => (string) ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '?'),
+                    'item_type' => $entity->type,
+                    'item_title' => $entity->getName(),
+                    ...exception_log($ex),
+                ]);
                 return $event;
             }
         }
@@ -482,32 +577,47 @@ final class ProcessWebhookEvent
             $lastSync = make_date($lastSync);
         }
 
-        ($this->writer)(Level::Notice, "{prefix}Processing '{user}@{backend}' request '{title}'.", [
+        $isDebug = (bool) ag($options, Options::DEBUG_TRACE, false);
+        if (true === (bool) ag($userContext->config->get("{$entity->via}.options"), Options::DEBUG_TRACE, false)) {
+            $isDebug = true;
+        }
+
+        ($this->writer)(Level::Notice, "Processing webhook {item_type} '{item_title}' from '{user}@{backend}'.", [
+            'event_name' => 'webhook.item.processing',
+            'subsystem' => 'webhook',
+            'operation' => 'process',
+            'outcome' => 'started',
             'backend' => $entity->via,
-            'title' => $entity->getName(),
-            'prefix' => true === $entity->isTainted() ? '[T] ' : '',
+            'client' => (string) ag($userContext->config->get($entity->via), 'type', $entity->via),
             'user' => $userContext->name,
-            'item' => [
-                'title' => $entity->getName(),
-                'type' => $entity->type,
-            ],
+            'item_id' => (string) ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '?'),
+            'item_title' => $entity->getName(),
+            'item_type' => $entity->type,
             'backend_item_id' => ag($entity->getMetadata($entity->via), iState::COLUMN_ID),
             'request_id' => ag($options, Options::REQUEST_ID, '-'),
             'state' => $entity->isWatched() ? 'played' : 'unplayed',
-            'progress' => $entity->hasPlayProgress() ? 'Yes' : 'No',
+            'progress' => true === $entity->hasPlayProgress(),
             'webhook_event' => ag($entity->getExtra($entity->via), iState::COLUMN_EXTRA_EVENT, '??'),
             'last_sync' => $lastSync,
+            'debug' => $isDebug,
+            'tainted' => $entity->isTainted(),
         ]);
-
-        $isDebug = (bool) ag($options, Options::DEBUG_TRACE, false);
-        if (true === (bool) ag($backend->getContext()->options, Options::DEBUG_TRACE, false)) {
-            $isDebug = true;
-        }
 
         $mapper = $userContext->mapper;
 
         if (true === $isDebug) {
-            ($this->writer)(Level::Notice, 'Debug mode enabled.');
+            ($this->writer)(Level::Notice, "Webhook debug tracing enabled for '{user}@{backend}'.", [
+                'event_name' => 'webhook.item.debug_enabled',
+                'subsystem' => 'webhook',
+                'operation' => 'process',
+                'outcome' => 'started',
+                'user' => $userContext->name,
+                'backend' => $entity->via,
+                'item_id' => (string) ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '?'),
+                'item_title' => $entity->getName(),
+                'item_type' => $entity->type,
+                'debug' => true,
+            ]);
             $mapper = $mapper->setOptions(ag_set($mapper->getOptions(), Options::DEBUG_TRACE, true));
         }
 

--- a/tests/API/Identities/IndexTest.php
+++ b/tests/API/Identities/IndexTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\API\Identities;
+
+use App\API\Identities\Index;
+use App\Libs\Container;
+use App\Libs\Database\PdoFactory;
+use App\Libs\Enums\Http\Method;
+use App\Libs\Enums\Http\Status;
+use App\Libs\Mappers\ImportInterface as iImport;
+use App\Libs\TestCase;
+use Monolog\Logger;
+use PDO;
+use Tests\Support\RequestResponseTrait;
+
+final class IndexTest extends TestCase
+{
+    use RequestResponseTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->initTempApp();
+    }
+
+    public function test_add_runs_migrations(): void
+    {
+        $handler = new Index(Container::get(iImport::class), new Logger('test'));
+
+        $response = $handler->identity_add($this->getRequest(
+            method: Method::POST,
+            uri: '/v1/api/identities',
+            post: ['identity' => 'alice'],
+        ));
+
+        self::assertSame(Status::CREATED->value, $response->getStatusCode());
+
+        $configFile = self::$tmpPath . '/users/alice/servers.yaml';
+        $dbFile = self::$tmpPath . '/users/alice/' . PdoFactory::DB_FILE;
+
+        self::assertFileExists($configFile);
+        self::assertFileExists($dbFile);
+
+        $tables = (new PDO('sqlite:' . $dbFile))
+            ->query("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+            ->fetchAll(PDO::FETCH_COLUMN);
+
+        self::assertContains('events', $tables);
+        self::assertContains('migration_version', $tables);
+        self::assertContains('playlist_items', $tables);
+        self::assertContains('playlists', $tables);
+        self::assertContains('state', $tables);
+    }
+}

--- a/tests/API/Logs/IndexTest.php
+++ b/tests/API/Logs/IndexTest.php
@@ -5,7 +5,13 @@ declare(strict_types=1);
 namespace Tests\API\Logs;
 
 use App\API\Logs\Index;
+use App\Libs\Container;
 use App\Libs\TestCase;
+use App\Libs\Mappers\ImportInterface;
+use Monolog\Logger;
+use Nyholm\Psr7\ServerRequest;
+use Nyholm\Psr7\Uri;
+use Psr\Log\LoggerInterface as iLogger;
 
 final class IndexTest extends TestCase
 {
@@ -47,5 +53,101 @@ final class IndexTest extends TestCase
         $this->assertSame($eventId, $parsed['event_id']);
         $this->assertSame('notice', $parsed['level']);
         $this->assertSame("NOTICE: Dispatching Event: 'on_push' queued at '2026-05-17T08:25:02+03:00'.", $parsed['text']);
+    }
+
+    public function test_jsonl(): void
+    {
+        $line = json_encode([
+            'id' => 'log-id',
+            'datetime' => '2026-05-20T12:00:00.123+00:00',
+            'level' => 'notice',
+            'levelno' => LOG_NOTICE,
+            'logger' => 'app',
+            'message' => "Processing 'main@emby_main' - '#123: IppSec' item.",
+            'source' => ['module' => 'app'],
+            'process' => ['id' => 1, 'name' => 'cli'],
+            'thread' => ['id' => 0, 'name' => 'main'],
+            'fields' => [
+                'event_id' => '550e8400-e29b-41d4-a716-446655440000',
+                'user' => 'main',
+                'backend' => 'emby_main',
+                'item_id' => 123,
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $parsed = Index::formatLog($line);
+
+        $this->assertSame('log-id', $parsed['id']);
+        $this->assertSame('2026-05-20T12:00:00.123+00:00', $parsed['date']);
+        $this->assertSame('notice', $parsed['level']);
+        $this->assertSame('app', $parsed['logger']);
+        $this->assertSame('123', $parsed['item_id']);
+        $this->assertSame('main', $parsed['user']);
+        $this->assertSame('emby_main', $parsed['backend']);
+    }
+
+    public function test_logView_returns_raw_lines(): void
+    {
+        $this->initTempApp();
+
+        $date = make_date()->format('Ymd');
+        $logPath = self::$tmpPath . '/logs/task.' . $date . '.jsonl';
+        mkdir(dirname($logPath), 0o755, true);
+
+        $lines = [
+            '{"id":"one","datetime":"2026-05-20T12:00:00.123+00:00","level":"info","logger":"task","message":"first"}',
+            '{"id":"two","datetime":"2026-05-20T12:00:01.123+00:00","level":"warning","logger":"task","message":"second"}',
+        ];
+
+        file_put_contents($logPath, implode(PHP_EOL, $lines) . PHP_EOL);
+
+        $handler = $this->makeHandler();
+        $request = (new ServerRequest('GET', new Uri('http://localhost/v1/api/log/task.' . $date . '.jsonl')))
+            ->withQueryParams(['offset' => 100]);
+
+        $response = $handler->logView($request, ['filename' => basename($logPath)]);
+        $payload = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('log', ag($payload, 'type'));
+        $this->assertSame($lines, ag($payload, 'lines'));
+        $this->assertIsString(ag($payload, 'lines.0'));
+    }
+
+    public function test_recent_returns_raw_lines(): void
+    {
+        $this->initTempApp();
+
+        $date = make_date()->format('Ymd');
+        $logPath = self::$tmpPath . '/logs/app.' . $date . '.jsonl';
+        mkdir(dirname($logPath), 0o755, true);
+
+        $lines = [
+            '{"id":"one","datetime":"2026-05-20T12:00:00.123+00:00","level":"info","logger":"app","message":"first"}',
+            '{"id":"two","datetime":"2026-05-20T12:00:01.123+00:00","level":"error","logger":"app","message":"second"}',
+        ];
+
+        file_put_contents($logPath, implode(PHP_EOL, $lines) . PHP_EOL);
+
+        $handler = $this->makeHandler();
+        $request = (new ServerRequest('GET', new Uri('http://localhost/v1/api/logs/recent')))
+            ->withQueryParams(['limit' => 2]);
+
+        $response = $handler->recent($request);
+        $payload = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertCount(1, $payload);
+        $this->assertSame(basename($logPath), ag($payload, '0.filename'));
+        $this->assertSame($lines, ag($payload, '0.lines'));
+        $this->assertIsString(ag($payload, '0.lines.1'));
+    }
+
+    private function makeHandler(): Index
+    {
+        $logger = Container::get(iLogger::class);
+        assert($logger instanceof Logger || $logger instanceof iLogger);
+
+        return new Index(Container::get(ImportInterface::class), $logger);
     }
 }

--- a/tests/API/Logs/IndexTest.php
+++ b/tests/API/Logs/IndexTest.php
@@ -46,13 +46,13 @@ final class IndexTest extends TestCase
     public function test_event_marker(): void
     {
         $eventId = '550e8400-e29b-41d4-a716-446655440000';
-        $line = "[2026-04-27T10:17:56+03:00] NOTICE: [event:{$eventId}] Dispatching Event: 'on_push' queued at '2026-05-17T08:25:02+03:00'.";
+        $line = "[2026-04-27T10:17:56+03:00] NOTICE: [event:{$eventId}] Dispatching queued event 'on_push' from 2026-05-17T08:25:02+03:00.";
 
         $parsed = Index::formatLog($line);
 
         $this->assertSame($eventId, $parsed['event_id']);
         $this->assertSame('notice', $parsed['level']);
-        $this->assertSame("NOTICE: Dispatching Event: 'on_push' queued at '2026-05-17T08:25:02+03:00'.", $parsed['text']);
+        $this->assertSame("NOTICE: Dispatching queued event 'on_push' from 2026-05-17T08:25:02+03:00.", $parsed['text']);
     }
 
     public function test_jsonl(): void

--- a/tests/API/Player/PlaylistTest.php
+++ b/tests/API/Player/PlaylistTest.php
@@ -8,6 +8,7 @@ use App\API\Player\Playlist;
 use App\Libs\Enums\Http\Status;
 use App\Libs\TestCase;
 use Monolog\Handler\NullHandler;
+use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use Nyholm\Psr7\ServerRequest;
 use Nyholm\Psr7\Uri;
@@ -126,5 +127,34 @@ class PlaylistTest extends TestCase
         $updated = $cache->get($token);
         self::assertIsArray($updated);
         self::assertSame([$side], array_column(ag($updated, 'config.externals', []), 'path'));
+    }
+
+    public function test_playlist_logs_build_failure(): void
+    {
+        $this->initTempDir();
+        $path = self::$tmpPath . '/sample.txt';
+        file_put_contents($path, 'test');
+
+        $cache = new Psr16Cache(new ArrayAdapter());
+        $handler = new TestHandler();
+        $logger = new Logger('test', [$handler]);
+        $token = 'play-test';
+
+        $cache->set($token, [
+            'path' => $path,
+            'time' => 'PT24H',
+            'config' => [],
+        ]);
+
+        $request = new ServerRequest('GET', new Uri('http://localhost/v1/api/player/playlist/' . $token));
+        $response = (new Playlist($cache, $logger))($request, $token);
+
+        self::assertSame(Status::INTERNAL_SERVER_ERROR, Status::from($response->getStatusCode()));
+        self::assertTrue($handler->hasErrorRecords());
+
+        $records = $handler->getRecords();
+        $record = end($records);
+        self::assertSame('player.playlist.build_failed', $record->context['event_name'] ?? null);
+        self::assertSame($path, $record->context['media']['path'] ?? null);
     }
 }

--- a/tests/API/Player/SubtitleTest.php
+++ b/tests/API/Player/SubtitleTest.php
@@ -8,6 +8,7 @@ use App\API\Player\Subtitle;
 use App\Libs\Enums\Http\Status;
 use App\Libs\TestCase;
 use Monolog\Handler\NullHandler;
+use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use Nyholm\Psr7\ServerRequest;
 use Nyholm\Psr7\Uri;
@@ -81,5 +82,34 @@ class SubtitleTest extends TestCase
         $response = (new Subtitle($cache, $logger))->m3u8($request, $token, 'webvtt', 'x', '1');
 
         $this->assertSame(Status::BAD_REQUEST, Status::from($response->getStatusCode()));
+    }
+
+    public function test_convert_logs_inspect_failure(): void
+    {
+        $this->initTempDir();
+        $path = self::$tmpPath . '/sample.txt';
+        file_put_contents($path, 'test');
+
+        $cache = new Psr16Cache(new ArrayAdapter());
+        $handler = new TestHandler();
+        $logger = new Logger('test', [$handler]);
+        $token = 'play-test';
+        $cache->set($token, [
+            'path' => $path,
+            'time' => 'PT24H',
+            'config' => [],
+        ]);
+
+        $request = new ServerRequest('GET', new Uri('http://localhost/v1/api/player/subtitle/' . $token . '/i0.webvtt'));
+        $response = (new Subtitle($cache, $logger))->convert($request, $token, 'i', '0', 'webvtt');
+
+        $this->assertSame(Status::INTERNAL_SERVER_ERROR, Status::from($response->getStatusCode()));
+        $this->assertTrue($handler->hasErrorRecords());
+
+        $records = $handler->getRecords();
+        $record = end($records);
+        $this->assertSame('player.subtitle.inspect_failed', $record->context['event_name'] ?? null);
+        $this->assertSame($path, $record->context['media']['path'] ?? null);
+        $this->assertSame(0, $record->context['subtitle']['stream'] ?? null);
     }
 }

--- a/tests/API/System/CommandTest.php
+++ b/tests/API/System/CommandTest.php
@@ -57,7 +57,7 @@ final class CommandTest extends TestCase
         $this->assertNotSame('', $token);
         $this->assertFileExists($sessionPath . '/request.json');
         $this->assertFileExists($sessionPath . '/state.json');
-        $this->assertFileExists($sessionPath . '/stream.log');
+        $this->assertFileExists($sessionPath . '/stream.jsonl');
 
         $state = json_decode((string) file_get_contents($sessionPath . '/state.json'), true);
 

--- a/tests/API/System/EventsTest.php
+++ b/tests/API/System/EventsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\API\System;
+
+use App\API\System\Events;
+use App\Libs\Database\PDO\PDOAdapter;
+use App\Libs\TestCase;
+use App\Model\Events\EventsRepository;
+use App\Model\Events\EventStatus;
+use Monolog\Handler\NullHandler;
+use Monolog\Logger;
+
+final class EventsTest extends TestCase
+{
+    private EventsRepository $repo;
+
+    private PDOAdapter $db;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->initTempApp();
+        $this->db = $this->createDb(new Logger('test', [new NullHandler()]));
+        $this->repo = new EventsRepository($this->db->getDBLayer());
+    }
+
+    public function test_read_returns_raw_logs(): void
+    {
+        $event = $this->repo->getObject([]);
+        $event->event = 'system.test';
+        $event->status = EventStatus::FAILED;
+        $event->reference = 'test://raw-logs';
+        $event->event_data = ['ok' => true];
+        $event->logs = [
+            '{"id":"one","datetime":"2026-05-20T12:00:00.123+00:00","level":"info","logger":"event","message":"first"}',
+            'NOTICE: legacy second',
+        ];
+        $event->created_at = make_date('2026-05-20T12:00:00+00:00');
+        $event->updated_at = make_date('2026-05-20T12:05:00+00:00');
+
+        $id = $this->repo->save($event);
+
+        $response = (new Events($this->repo))->read($id);
+        $payload = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame($id, ag($payload, 'id'));
+        self::assertSame($event->logs, ag($payload, 'logs'));
+        self::assertIsString(ag($payload, 'logs.0'));
+        self::assertSame('Failed', ag($payload, 'status_name'));
+    }
+}

--- a/tests/API/System/EventsTest.php
+++ b/tests/API/System/EventsTest.php
@@ -6,11 +6,13 @@ namespace Tests\API\System;
 
 use App\API\System\Events;
 use App\Libs\Database\PDO\PDOAdapter;
+use App\Libs\Extends\JsonlFormatter;
 use App\Libs\TestCase;
 use App\Model\Events\EventsRepository;
 use App\Model\Events\EventStatus;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
+use Nyholm\Psr7\ServerRequest;
 
 final class EventsTest extends TestCase
 {
@@ -51,5 +53,34 @@ final class EventsTest extends TestCase
         self::assertSame($event->logs, ag($payload, 'logs'));
         self::assertIsString(ag($payload, 'logs.0'));
         self::assertSame('Failed', ag($payload, 'status_name'));
+    }
+
+    public function test_update_logs_manual_update_event(): void
+    {
+        $event = $this->repo->getObject([]);
+        $event->event = 'system.test';
+        $event->status = EventStatus::PENDING;
+        $event->created_at = make_date('2026-05-20T12:00:00+00:00');
+        $event->updated_at = make_date('2026-05-20T12:05:00+00:00');
+
+        $id = $this->repo->save($event);
+
+        $request = (new ServerRequest('PATCH', '/v1/api/system/events/' . $id))
+            ->withParsedBody(['status' => EventStatus::FAILED->value]);
+
+        $response = (new Events($this->repo))->update($request, $id);
+        $payload = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+
+        self::assertSame(200, $response->getStatusCode());
+
+        $logs = ag($payload, 'logs', []);
+        self::assertNotEmpty($logs);
+        self::assertTrue(JsonlFormatter::isJsonlRecord($logs[array_key_last($logs)]));
+
+        $record = json_decode(trim($logs[array_key_last($logs)]), true, flags: JSON_THROW_ON_ERROR);
+        self::assertSame('Event \'system.test\' was manually updated to failed.', ag($record, 'message'));
+        self::assertSame('events.manual_update', ag($record, 'fields.event_name'));
+        self::assertSame('system.test', ag($record, 'fields.queued_event'));
+        self::assertSame('failed', ag($record, 'fields.status'));
     }
 }

--- a/tests/Backends/Common/ResponseTest.php
+++ b/tests/Backends/Common/ResponseTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Tests\Backends\Common;
 
 use App\Backends\Common\Cache;
+use App\Backends\Common\CommonTrait;
+use App\Backends\Common\Context;
 use App\Backends\Common\Error;
+use App\Backends\Common\Levels;
 use App\Libs\ConfigFile;
-
 use App\Libs\Exceptions\Backends\RuntimeException;
 use App\Libs\Mappers\Import\DirectMapper;
 use App\Libs\TestCase;
@@ -15,13 +17,12 @@ use App\Libs\Uri;
 use App\Libs\UserContext;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Psr16Cache;
 
 class ResponseTest extends TestCase
 {
-    use \App\Backends\Common\CommonTrait;
+    use CommonTrait;
 
     public function test_tryResponse(): void
     {
@@ -29,7 +30,7 @@ class ResponseTest extends TestCase
         $cache = new Cache($logger, new Psr16Cache(new NullAdapter()));
         $db = $this->createDb($logger);
 
-        $context = new \App\Backends\Common\Context(
+        $context = new Context(
             clientName: 'test',
             backendName: 'test',
             backendUrl: new Uri('https://example.com'),
@@ -53,7 +54,11 @@ class ResponseTest extends TestCase
             trace: false,
         );
 
-        $response = (fn() => $this->tryResponse($context, fn() => throw new RuntimeException('test', 500)))();
+        $response = (fn() => $this->tryResponse(
+            context: $context,
+            fn: fn() => throw new RuntimeException('test', 500),
+            action: 'test.action',
+        ))();
 
         $this->assertTrue(
             $response->hasError(),
@@ -71,6 +76,18 @@ class ResponseTest extends TestCase
             'getError() should return an Error object in all cases even if error is null.'
         );
 
+        $this->assertSame(
+            "test request failed for 'test' during test.action. test",
+            $response->getError()->format(),
+            'Response error should include the underlying exception message.'
+        );
+
+        $this->assertSame(
+            Levels::WARNING,
+            $response->getError()->level,
+            'Backend client failures should remain warnings.'
+        );
+
         $response = (fn() => $this->tryResponse($context, fn() => 'i am teapot'))();
 
         $this->assertSame(
@@ -78,6 +95,16 @@ class ResponseTest extends TestCase
             $response->response,
             'Response object should have the same response as the one passed in the constructor.'
         );
+    }
+
+    public function test_reason_extract(): void
+    {
+        $this->assertSame('bad token', $this->getBackendResponseReason('{"Message":"bad token"}'));
+        $this->assertSame(
+            'Invalid authentication token.',
+            $this->getBackendResponseReason('<?xml version="1.0" encoding="UTF-8"?><errors><error>Invalid authentication token.</error></errors>')
+        );
+        $this->assertSame('plain failure', $this->getBackendResponseReason('<p>plain failure</p>'));
     }
 
 }

--- a/tests/Backends/Emby/EmbyGuidTest.php
+++ b/tests/Backends/Emby/EmbyGuidTest.php
@@ -17,6 +17,7 @@ use App\Libs\TestCase;
 use App\Libs\Uri;
 use Monolog\Handler\TestHandler;
 use Monolog\Level;
+use Monolog\LogRecord;
 use Monolog\Logger;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Psr16Cache;
@@ -51,6 +52,23 @@ class EmbyGuidTest extends TestCase
         }
     }
 
+    private function record(string $eventName, ?string $reason = null): ?LogRecord
+    {
+        foreach (array_reverse($this->handler->getRecords()) as $record) {
+            if ($eventName !== ($record->context['event_name'] ?? null)) {
+                continue;
+            }
+
+            if (null !== $reason && $reason !== ($record->context['reason'] ?? null)) {
+                continue;
+            }
+
+            return $record;
+        }
+
+        return null;
+    }
+
     private function getClass(): EmbyGuid
     {
         $this->handler->clear();
@@ -78,6 +96,7 @@ class EmbyGuidTest extends TestCase
         $this->logger = new Logger('logger', processors: [new LogMessageProcessor()]);
         $this->logger->pushHandler($this->handler);
 
+        Guid::reparse();
         Guid::setLogger($this->logger);
     }
 
@@ -90,10 +109,10 @@ class EmbyGuidTest extends TestCase
             file_put_contents($tmpFile, "{'foo' => 'too' }");
             Config::save('guid.file', $tmpFile);
             $this->getClass();
-            $this->assertTrue(
-                $this->logged(Level::Error, 'Failed to parse GUIDs file', true),
-                "Assert message logged when the value type does not match the expected type."
-            );
+            $record = $this->record('guid.file.parse_failed');
+            $this->assertNotNull($record, 'Assert file parse failures are logged with stable event name.');
+            $this->assertSame($tmpFile, $record->context['file'] ?? null);
+            $this->handler->clear();
         } finally {
             Config::save('guid.file', $oldGuidFile);
         }
@@ -149,10 +168,10 @@ class EmbyGuidTest extends TestCase
         $tmpFile = self::$tmpPath . '/guid_' . uniqid();
         touch($tmpFile);
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Info, 'is empty', true),
-                "Failed to assert that the GUID file is empty."
-            );
+            $record = $this->record('guid.mapping.ignored', 'empty_file');
+            $this->assertNotNull($record, 'Failed to assert that the GUID file is empty.');
+            $this->assertSame($tmpFile, $record->context['file'] ?? null);
+            $this->handler->clear();
 
 
         $tmpFile = self::$tmpPath . '/guid_' . uniqid();
@@ -177,10 +196,9 @@ class EmbyGuidTest extends TestCase
 
             file_put_contents($tmpFile, Yaml::dump(ag_set($yaml, 'links.0', 'ff')));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'Value must be an object.', true),
-                'Assert links.0 key is an object.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'invalid_link_value');
+            $this->assertNotNull($record, 'Assert links.0 key is an object.');
+            $this->handler->clear();
 
 
         $this->handler->clear();
@@ -189,42 +207,37 @@ class EmbyGuidTest extends TestCase
             $yaml = ag_set(['links' => [['type' => 'emby']]], 'links.0.map', 'foo');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'map value must be an object.', true),
-                'Assert map key is an object.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'invalid_map_value');
+            $this->assertNotNull($record, 'Assert map key is an object.');
+            $this->handler->clear();
 
             $yaml = ag_set($yaml, 'links.0.map', []);
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'map.from field is empty or not a string.', true),
-                'Assert to field is a string.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'invalid_map_from');
+            $this->assertNotNull($record, 'Assert map.from is validated.');
+            $this->handler->clear();
 
             $yaml = ag_set($yaml, 'links.0.map.from', 'foo');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'map.to field is empty or not a string.', true),
-                'Assert to field is a string.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'invalid_map_to');
+            $this->assertNotNull($record, 'Assert map.to is validated.');
+            $this->handler->clear();
 
             $yaml = ag_set($yaml, 'links.0.map.to', 'foobar');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'field does not starts with', true),
-                'Assert to field is a string.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'invalid_guid_type_name');
+            $this->assertNotNull($record, 'Assert GUID type names are validated.');
+            $this->handler->clear();
 
             $yaml = ag_set($yaml, 'links.0.map.to', 'guid_foobar');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'map.to field is not a supported', true),
-                'Assert to field is a string.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'unsupported_guid_type');
+            $this->assertNotNull($record, 'Assert supported GUID types are validated.');
+            $this->handler->clear();
 
             $yaml = ag_set($yaml, 'links.0.map', [
                 'from' => 'tsdb',
@@ -373,9 +386,9 @@ class EmbyGuidTest extends TestCase
             message: 'Assert only the the oldest ID is returned for numeric GUIDs.'
         );
 
-        $this->assertTrue(
-            $this->logged(Level::Debug, 'EmbyGuid: Ignoring', true),
-            'Assert that a log is raised when the GUID is ignored by user choice.'
-        );
+        $record = $this->record('guid.external_id.ignored', 'user_ignored');
+        $this->assertNotNull($record, 'Assert that a log is raised when the GUID is ignored by user choice.');
+        $this->assertSame('imdb', $record->context['guid_source'] ?? null);
+        $this->handler->clear();
     }
 }

--- a/tests/Backends/Jellyfin/JellyfinGuidTest.php
+++ b/tests/Backends/Jellyfin/JellyfinGuidTest.php
@@ -17,6 +17,7 @@ use App\Libs\TestCase;
 use App\Libs\Uri;
 use Monolog\Handler\TestHandler;
 use Monolog\Level;
+use Monolog\LogRecord;
 use Monolog\Logger;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Psr16Cache;
@@ -51,6 +52,23 @@ class JellyfinGuidTest extends TestCase
         }
     }
 
+    private function record(string $eventName, ?string $reason = null): ?LogRecord
+    {
+        foreach (array_reverse($this->handler->getRecords()) as $record) {
+            if ($eventName !== ($record->context['event_name'] ?? null)) {
+                continue;
+            }
+
+            if (null !== $reason && $reason !== ($record->context['reason'] ?? null)) {
+                continue;
+            }
+
+            return $record;
+        }
+
+        return null;
+    }
+
     private function getClass(): JellyfinGuid
     {
         $this->handler->clear();
@@ -78,6 +96,7 @@ class JellyfinGuidTest extends TestCase
         $this->logger = new Logger('logger', processors: [new LogMessageProcessor()]);
         $this->logger->pushHandler($this->handler);
 
+        Guid::reparse();
         Guid::setLogger($this->logger);
     }
 
@@ -90,10 +109,10 @@ class JellyfinGuidTest extends TestCase
             file_put_contents($tmpFile, "{'foo' => 'too' }");
             Config::save('guid.file', $tmpFile);
             $this->getClass();
-            $this->assertTrue(
-                $this->logged(Level::Error, 'Failed to parse GUIDs file', true),
-                "Assert message logged when the value type does not match the expected type."
-            );
+            $record = $this->record('guid.file.parse_failed');
+            $this->assertNotNull($record, 'Assert file parse failures are logged with stable event name.');
+            $this->assertSame($tmpFile, $record->context['file'] ?? null);
+            $this->handler->clear();
         } finally {
             Config::save('guid.file', $oldGuidFile);
         }
@@ -149,10 +168,10 @@ class JellyfinGuidTest extends TestCase
         $tmpFile = self::$tmpPath . '/guid_' . uniqid();
         touch($tmpFile);
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Info, 'is empty', true),
-                "Failed to assert that the GUID file is empty."
-            );
+            $record = $this->record('guid.mapping.ignored', 'empty_file');
+            $this->assertNotNull($record, 'Failed to assert that the GUID file is empty.');
+            $this->assertSame($tmpFile, $record->context['file'] ?? null);
+            $this->handler->clear();
 
 
         $tmpFile = self::$tmpPath . '/guid_' . uniqid();
@@ -177,10 +196,9 @@ class JellyfinGuidTest extends TestCase
 
             file_put_contents($tmpFile, Yaml::dump(ag_set($yaml, 'links.0', 'ff')));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'Value must be an object.', true),
-                'Assert replace key is an object.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'invalid_link_value');
+            $this->assertNotNull($record, 'Assert replace key is an object.');
+            $this->handler->clear();
 
 
         $this->handler->clear();
@@ -189,42 +207,37 @@ class JellyfinGuidTest extends TestCase
             $yaml = ag_set(['links' => [0 => ['type' => 'jellyfin']]], 'links.0.map', 'foo');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'map value must be an object.', true),
-                'Assert map key is an object.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'invalid_map_value');
+            $this->assertNotNull($record, 'Assert map key is an object.');
+            $this->handler->clear();
 
             $yaml = ag_set($yaml, 'links.0.map', []);
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'map.from field is empty or not a string.', true),
-                'Assert to field is a string.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'invalid_map_from');
+            $this->assertNotNull($record, 'Assert map.from is validated.');
+            $this->handler->clear();
 
             $yaml = ag_set($yaml, 'links.0.map.from', 'foo');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'map.to field is empty or not a string.', true),
-                'Assert to field is a string.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'invalid_map_to');
+            $this->assertNotNull($record, 'Assert map.to is validated.');
+            $this->handler->clear();
 
             $yaml = ag_set($yaml, 'links.0.map.to', 'foobar');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'field does not starts with', true),
-                'Assert to field is a string.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'invalid_guid_type_name');
+            $this->assertNotNull($record, 'Assert GUID type names are validated.');
+            $this->handler->clear();
 
             $yaml = ag_set($yaml, 'links.0.map.to', 'guid_foobar');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'map.to field is not a supported', true),
-                'Assert to field is a string.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'unsupported_guid_type');
+            $this->assertNotNull($record, 'Assert supported GUID types are validated.');
+            $this->handler->clear();
 
             $yaml = ag_set($yaml, 'links.0.map', [
                 'from' => 'tsdb',
@@ -375,9 +388,9 @@ class JellyfinGuidTest extends TestCase
             $this->getClass()->get(['imdb' => '123'], $context),
             'Assert only the the oldest ID is returned for numeric GUIDs.');
 
-        $this->assertTrue(
-            $this->logged(Level::Debug, 'JellyfinGuid: Ignoring', true),
-            'Assert that a log is raised when the GUID is ignored by user choice.'
-        );
+        $record = $this->record('guid.external_id.ignored', 'user_ignored');
+        $this->assertNotNull($record, 'Assert that a log is raised when the GUID is ignored by user choice.');
+        $this->assertSame('imdb', $record->context['guid_source'] ?? null);
+        $this->handler->clear();
     }
 }

--- a/tests/Backends/MediaBrowser/ExportFlowTest.php
+++ b/tests/Backends/MediaBrowser/ExportFlowTest.php
@@ -15,6 +15,7 @@ use App\Libs\Extends\HttpClient;
 use App\Libs\Extends\MockHttpClient;
 use App\Libs\Options;
 use App\Libs\QueueRequests;
+use Monolog\LogRecord;
 use ReflectionMethod;
 use Symfony\Component\HttpClient\Response\MockResponse;
 
@@ -23,7 +24,10 @@ class ExportFlowTest extends MediaBrowserTestCase
     public function test_export_queues_requests(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass]) {
-            $context = $this->makeContext($clientName, [Options::IGNORE_DATE => true]);
+            $context = $this->makeContext($clientName, [
+                Options::IGNORE_DATE => true,
+                Options::DEBUG_TRACE => true,
+            ]);
             $queue = new QueueRequests();
 
             $localEntity = $this->makeLocalEntity($context, watched: 1, updated: 2000);
@@ -67,7 +71,10 @@ class ExportFlowTest extends MediaBrowserTestCase
     public function test_export_unplayed_queues(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass]) {
-            $context = $this->makeContext($clientName, [Options::IGNORE_DATE => true]);
+            $context = $this->makeContext($clientName, [
+                Options::IGNORE_DATE => true,
+                Options::DEBUG_TRACE => true,
+            ]);
             $queue = new QueueRequests();
 
             $localEntity = $this->makeLocalEntity($context, watched: 0, updated: 2000);
@@ -99,7 +106,10 @@ class ExportFlowTest extends MediaBrowserTestCase
     public function test_export_ignores_state_unchanged(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass]) {
-            $context = $this->makeContext($clientName, [Options::IGNORE_DATE => true]);
+            $context = $this->makeContext($clientName, [
+                Options::IGNORE_DATE => true,
+                Options::DEBUG_TRACE => true,
+            ]);
             $queue = new QueueRequests();
 
             $localEntity = $this->makeLocalEntity($context, watched: 1, updated: 2000);
@@ -123,6 +133,16 @@ class ExportFlowTest extends MediaBrowserTestCase
             );
 
             $this->assertSame(0, $queue->count());
+
+            $records = array_values(array_filter(
+                $this->handler->getRecords(),
+                static fn(LogRecord $record): bool => 'backend.item.ignored' === ($record->context['event_name'] ?? null),
+            ));
+
+            $this->assertNotEmpty($records);
+            $record = end($records);
+            $this->assertSame('state_unchanged', $record->context['reason'] ?? null);
+            $this->assertSame('backend.export', $record->context['subsystem'] ?? null);
         }
     }
 
@@ -154,6 +174,16 @@ class ExportFlowTest extends MediaBrowserTestCase
             );
 
             $this->assertSame(0, $queue->count());
+
+            $records = array_values(array_filter(
+                $this->handler->getRecords(),
+                static fn(LogRecord $record): bool => 'backend.item.ignored' === ($record->context['event_name'] ?? null),
+            ));
+
+            $this->assertNotEmpty($records);
+            $record = end($records);
+            $this->assertSame('date_not_newer_than_local_history', $record->context['reason'] ?? null);
+            $this->assertSame('backend.export', $record->context['subsystem'] ?? null);
         }
     }
 
@@ -182,6 +212,16 @@ class ExportFlowTest extends MediaBrowserTestCase
             );
 
             $this->assertSame(0, $queue->count());
+
+            $records = array_values(array_filter(
+                $this->handler->getRecords(),
+                static fn(LogRecord $record): bool => 'backend.item.ignored' === ($record->context['event_name'] ?? null),
+            ));
+
+            $this->assertNotEmpty($records);
+            $record = end($records);
+            $this->assertSame('missing_local_state', $record->context['reason'] ?? null);
+            $this->assertSame('backend.export', $record->context['subsystem'] ?? null);
         }
     }
 
@@ -212,6 +252,16 @@ class ExportFlowTest extends MediaBrowserTestCase
             );
 
             $this->assertSame(0, $queue->count());
+
+            $records = array_values(array_filter(
+                $this->handler->getRecords(),
+                static fn(LogRecord $record): bool => 'backend.item.ignored' === ($record->context['event_name'] ?? null),
+            ));
+
+            $this->assertNotEmpty($records);
+            $record = end($records);
+            $this->assertSame('missing_supported_guid', $record->context['reason'] ?? null);
+            $this->assertSame('backend.export', $record->context['subsystem'] ?? null);
         }
     }
 
@@ -241,6 +291,16 @@ class ExportFlowTest extends MediaBrowserTestCase
             );
 
             $this->assertSame(0, $queue->count());
+
+            $records = array_values(array_filter(
+                $this->handler->getRecords(),
+                static fn(LogRecord $record): bool => 'backend.item.ignored' === ($record->context['event_name'] ?? null),
+            ));
+
+            $this->assertNotEmpty($records);
+            $record = end($records);
+            $this->assertSame('missing_date', $record->context['reason'] ?? null);
+            $this->assertSame('backend.export', $record->context['subsystem'] ?? null);
         }
     }
 

--- a/tests/Backends/MediaBrowser/ImportFlowTest.php
+++ b/tests/Backends/MediaBrowser/ImportFlowTest.php
@@ -4,21 +4,32 @@ declare(strict_types=1);
 
 namespace Tests\Backends\MediaBrowser;
 
-use App\Backends\Emby\Action\Import as EmbyImport;
-use App\Backends\Emby\Action\GetMetaData as EmbyGetMetaData;
-use App\Backends\Emby\EmbyGuid;
 use App\Backends\Common\Request;
-use App\Backends\Jellyfin\Action\Import as JellyfinImport;
-use App\Backends\Jellyfin\Action\GetMetaData as JellyfinGetMetaData;
-use App\Backends\Jellyfin\JellyfinGuid;
 use App\Backends\Common\Response;
+use App\Backends\Emby\Action\GetMetaData as EmbyGetMetaData;
+use App\Backends\Emby\Action\Import as EmbyImport;
+use App\Backends\Emby\EmbyGuid;
+use App\Backends\Jellyfin\Action\GetMetaData as JellyfinGetMetaData;
+use App\Backends\Jellyfin\Action\Import as JellyfinImport;
+use App\Backends\Jellyfin\JellyfinGuid;
+use App\Libs\Config;
 use App\Libs\Container;
 use App\Libs\Options;
+use Monolog\LogRecord;
 use ReflectionMethod;
+use Symfony\Component\HttpClient\Response\MockResponse;
 
 class ImportFlowTest extends MediaBrowserTestCase
 {
-    public function test_import_process_adds_items(): void
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // These tests exercise mocked failed responses directly; retries only add backoff delay.
+        Config::save('http.default.maxRetries', 0);
+    }
+
+    public function test_process_adds(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass]) {
             $context = $this->makeContext($clientName);
@@ -45,7 +56,7 @@ class ImportFlowTest extends MediaBrowserTestCase
         }
     }
 
-    public function test_import_ignores_missing_date(): void
+    public function test_missing_date(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass]) {
             $context = $this->makeContext($clientName);
@@ -73,7 +84,7 @@ class ImportFlowTest extends MediaBrowserTestCase
         }
     }
 
-    public function test_import_show_caches(): void
+    public function test_show_cache(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass]) {
             $context = $this->makeContext($clientName);
@@ -97,7 +108,7 @@ class ImportFlowTest extends MediaBrowserTestCase
         }
     }
 
-    public function test_import_ignores_no_guids(): void
+    public function test_missing_guid(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass]) {
             $context = $this->makeContext($clientName);
@@ -125,7 +136,7 @@ class ImportFlowTest extends MediaBrowserTestCase
         }
     }
 
-    public function test_import_episode_adds(): void
+    public function test_episode_adds(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass, $metaClass]) {
             $context = $this->makeContext($clientName);
@@ -174,7 +185,7 @@ class ImportFlowTest extends MediaBrowserTestCase
         }
     }
 
-    public function test_jellyfin_prefetched_genres(): void
+    public function test_prefetched_genres(): void
     {
         $context = $this->makeContext('Jellyfin');
         $mapper = $context->userContext->mapper;
@@ -230,7 +241,7 @@ class ImportFlowTest extends MediaBrowserTestCase
         $this->assertSame(0, $metaAction->calls);
     }
 
-    public function test_jellyfin_prefetches_parent(): void
+    public function test_prefetch_parent(): void
     {
         $context = $this->makeContext('Jellyfin', [
             Options::LIBRARY_SELECT => ['lib-2'],
@@ -261,7 +272,7 @@ class ImportFlowTest extends MediaBrowserTestCase
         $this->assertFalse(str_contains((string) $prefetchRequests[0]->url, 'filters=IsNotFolder'));
     }
 
-    public function test_import_ignores_invalid_type(): void
+    public function test_invalid_type(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass]) {
             $context = $this->makeContext($clientName);
@@ -288,6 +299,158 @@ class ImportFlowTest extends MediaBrowserTestCase
         }
     }
 
+    public function test_handle_status_failed(): void
+    {
+        foreach ($this->provideBackends() as $backend) {
+            [$clientName, $actionClass] = $backend;
+
+            $context = $this->makeContext($clientName);
+            $http = $this->makeHttpClient(
+                new MockResponse('', ['http_code' => 500]),
+                new MockResponse('', ['http_code' => 500]),
+                new MockResponse('', ['http_code' => 500]),
+                new MockResponse('', ['http_code' => 500]),
+            );
+            $action = new $actionClass($http, $this->logger);
+
+            $this->invokeHandle(
+                $action,
+                $context,
+                $this->makeHandleResponse($action, 'http://mediabrowser.test/library'),
+                static function (array $item, array $logContext = []): void {
+                },
+                [
+                    'action' => 'Emby' === $clientName ? 'emby.import' : 'jellyfin.import',
+                    'client' => $context->clientName,
+                    'backend' => $context->backendName,
+                    'user' => $context->userContext->name,
+                    'library' => ['title' => 'Shows'],
+                    'segment' => ['number' => 1, 'of' => 1],
+                ],
+            );
+
+            $record = $this->lastRecord('backend.response.failed');
+            $this->assertSame('backend.import', $record->context['subsystem'] ?? null);
+            $this->assertSame('request_library', $record->context['operation'] ?? null);
+            $this->assertSame('unexpected_status', $record->context['reason'] ?? null);
+        }
+    }
+
+    public function test_handle_item_failed(): void
+    {
+        foreach ($this->provideBackends() as $backend) {
+            [$clientName, $actionClass] = $backend;
+
+            $context = $this->makeContext($clientName);
+            $http = $this->makeHttpClient(new MockResponse(json_encode([
+                'Items' => [
+                    ['Id' => 'item-1', 'Type' => 'Movie'],
+                ],
+            ], JSON_THROW_ON_ERROR), ['http_code' => 200]));
+            $action = new $actionClass($http, $this->logger);
+
+            $this->invokeHandle(
+                $action,
+                $context,
+                $this->makeHandleResponse($action, 'http://mediabrowser.test/library'),
+                static function (array $item, array $logContext = []): void {
+                    throw new \RuntimeException('boom');
+                },
+                [
+                    'action' => 'Emby' === $clientName ? 'emby.import' : 'jellyfin.import',
+                    'client' => $context->clientName,
+                    'backend' => $context->backendName,
+                    'user' => $context->userContext->name,
+                    'library' => ['title' => 'Shows'],
+                    'segment' => ['number' => 1, 'of' => 1],
+                ],
+            );
+
+            $record = $this->lastRecord('backend.operation.failed');
+            $this->assertSame('backend.import', $record->context['subsystem'] ?? null);
+            $this->assertSame('process_item', $record->context['operation'] ?? null);
+        }
+    }
+
+    public function test_handle_parse_failed(): void
+    {
+        foreach ($this->provideBackends() as $backend) {
+            [$clientName, $actionClass] = $backend;
+
+            $context = $this->makeContext($clientName);
+            $http = $this->makeHttpClient(new MockResponse(
+                '{"Items":[{"Id":"item-1"},{"Id":}]}',
+                ['http_code' => 200],
+            ));
+            $action = new $actionClass($http, $this->logger);
+
+            $this->invokeHandle(
+                $action,
+                $context,
+                $this->makeHandleResponse($action, 'http://mediabrowser.test/library'),
+                static function (array $item, array $logContext = []): void {
+                },
+                [
+                    'action' => 'Emby' === $clientName ? 'emby.import' : 'jellyfin.import',
+                    'client' => $context->clientName,
+                    'backend' => $context->backendName,
+                    'user' => $context->userContext->name,
+                    'library' => ['title' => 'Shows'],
+                    'segment' => ['number' => 1, 'of' => 1],
+                ],
+            );
+
+            $record = $this->lastRecord('backend.operation.failed');
+            $this->assertSame('backend.import', $record->context['subsystem'] ?? null);
+            $this->assertSame('parse_library_response', $record->context['operation'] ?? null);
+        }
+    }
+
+    public function test_handle_completed(): void
+    {
+        foreach ($this->provideBackends() as $backend) {
+            [$clientName, $actionClass] = $backend;
+
+            $context = $this->makeContext($clientName);
+            $http = $this->makeHttpClient(new MockResponse(json_encode([
+                'Items' => [
+                    ['Id' => 'item-1', 'Type' => 'Movie'],
+                ],
+            ], JSON_THROW_ON_ERROR), ['http_code' => 200]));
+            $action = new $actionClass($http, $this->logger);
+            $seen = [];
+
+            $this->invokeHandle(
+                $action,
+                $context,
+                $this->makeHandleResponse($action, 'http://mediabrowser.test/library'),
+                static function (array $item, array $logContext = []) use (&$seen): void {
+                    $seen[] = $item['Id'] ?? null;
+                },
+                [
+                    'action' => 'Emby' === $clientName ? 'emby.import' : 'jellyfin.import',
+                    'client' => $context->clientName,
+                    'backend' => $context->backendName,
+                    'user' => $context->userContext->name,
+                    'library' => ['title' => 'Shows'],
+                    'segment' => ['number' => 1, 'of' => 1],
+                ],
+            );
+
+            $this->assertSame(['item-1'], $seen);
+
+            $records = array_values(array_filter(
+                $this->handler->getRecords(),
+                static fn(LogRecord $record): bool => 'backend.response.processing' === ($record->context['event_name'] ?? null),
+            ));
+            $records = array_slice($records, -2);
+
+            $this->assertCount(2, $records);
+            $this->assertSame('started', $records[0]->context['outcome'] ?? null);
+            $this->assertSame('completed', $records[1]->context['outcome'] ?? null);
+        }
+    }
+
     private function invokeProcess(
         object $action,
         \App\Backends\Common\Context $context,
@@ -301,6 +464,24 @@ class ImportFlowTest extends MediaBrowserTestCase
         $method->invoke($action, $context, $guid, $mapper, $item, $logContext, $opts);
     }
 
+    private function invokeHandle(
+        object $action,
+        \App\Backends\Common\Context $context,
+        \Symfony\Contracts\HttpClient\ResponseInterface $response,
+        \Closure $callback,
+        array $logContext,
+    ): void {
+        $method = new ReflectionMethod($action, 'handle');
+        $method->invoke($action, $context, $response, $callback, $logContext);
+    }
+
+    private function makeHandleResponse(object $action, string $url): \Symfony\Contracts\HttpClient\ResponseInterface
+    {
+        $property = new \ReflectionProperty($action, 'http');
+
+        return $property->getValue($action)->request('GET', $url);
+    }
+
     private function invokeProcessShow(
         object $action,
         \App\Backends\Common\Context $context,
@@ -310,6 +491,18 @@ class ImportFlowTest extends MediaBrowserTestCase
     ): void {
         $method = new ReflectionMethod($action, 'processShow');
         $method->invoke($action, $context, $guid, $item, $logContext);
+    }
+
+    private function lastRecord(string $eventName): LogRecord
+    {
+        $records = array_values(array_filter(
+            $this->handler->getRecords(),
+            static fn(LogRecord $record): bool => $eventName === ($record->context['event_name'] ?? null),
+        ));
+
+        $this->assertNotEmpty($records);
+
+        return end($records);
     }
 
     private function provideBackends(): array

--- a/tests/Backends/MediaBrowser/ImportTest.php
+++ b/tests/Backends/MediaBrowser/ImportTest.php
@@ -9,10 +9,11 @@ use App\Backends\Emby\EmbyGuid;
 use App\Backends\Jellyfin\Action\Import as JellyfinImport;
 use App\Backends\Jellyfin\JellyfinGuid;
 use App\Libs\Options;
+use Monolog\LogRecord;
 
 class ImportTest extends MediaBrowserTestCase
 {
-    public function test_import_select_includes(): void
+    public function test_select_includes(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass]) {
             $http = $this->makeHttpClient(
@@ -39,10 +40,21 @@ class ImportTest extends MediaBrowserTestCase
                 $result->response,
             );
             $this->assertSame(['lib-2'], array_values(array_unique($libraryIds)));
+
+            $records = array_values(array_filter(
+                $this->handler->getRecords(),
+                static fn(LogRecord $record): bool => 'backend.item.ignored' === ($record->context['event_name'] ?? null)
+                    && 'selected_excluded' === ($record->context['reason'] ?? null)
+                    && 'lib-1' === (string) ag($record->context, 'library.id'),
+            ));
+
+            $this->assertNotEmpty($records);
+            $record = end($records);
+            $this->assertSame('backend.import', $record->context['subsystem'] ?? null);
         }
     }
 
-    public function test_import_select_excludes(): void
+    public function test_select_excludes(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass]) {
             $http = $this->makeHttpClient(
@@ -75,7 +87,7 @@ class ImportTest extends MediaBrowserTestCase
         }
     }
 
-    public function test_import_handles_empty_libraries(): void
+    public function test_empty_libraries(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass]) {
             $response = $this->makeResponse($this->fixture('libraries_empty'));
@@ -89,6 +101,76 @@ class ImportTest extends MediaBrowserTestCase
 
             $this->assertTrue($result->isSuccessful());
             $this->assertSame([], $result->response);
+        }
+    }
+
+    public function test_count_status_failure(): void
+    {
+        foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass]) {
+            $http = $this->makeHttpClient(
+                $this->makeResponse($this->fixture('libraries')),
+                $this->makeResponse([], 500),
+            );
+            $context = $this->makeContext($clientName, [Options::LIBRARY_SELECT => ['lib-1']]);
+            $guid = new $guidClass($this->logger);
+            $mapper = $context->userContext->mapper;
+            $action = new $actionClass($http, $this->logger);
+
+            $result = $action(
+                $context,
+                $guid,
+                $mapper,
+                null,
+                [],
+            );
+
+            $this->assertTrue($result->isSuccessful());
+            $this->assertSame([], $result->response);
+
+            $failed = array_values(array_filter(
+                $this->handler->getRecords(),
+                static fn(LogRecord $record): bool => 'backend.client.request_failed' === ($record->context['event_name'] ?? null)
+                    && 'lib-1' === (string) ag($record->context, 'library.id'),
+            ));
+            $this->assertNotEmpty($failed);
+            $record = end($failed);
+            $this->assertSame('backend.import', $record->context['subsystem'] ?? null);
+        }
+    }
+
+    public function test_unsupported_type(): void
+    {
+        foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass]) {
+            $libraries = $this->fixture('libraries');
+            $libraries['Items'][1]['CollectionType'] = 'music';
+
+            $http = $this->makeHttpClient($this->makeResponse($libraries));
+            $context = $this->makeContext($clientName, [Options::LIBRARY_SELECT => ['lib-2']]);
+            $guid = new $guidClass($this->logger);
+            $mapper = $context->userContext->mapper;
+            $action = new $actionClass($http, $this->logger);
+
+            $result = $action(
+                $context,
+                $guid,
+                $mapper,
+                null,
+                [],
+            );
+
+            $this->assertTrue($result->isSuccessful());
+            $this->assertSame([], $result->response);
+
+            $records = array_values(array_filter(
+                $this->handler->getRecords(),
+                static fn(LogRecord $record): bool => 'backend.item.ignored' === ($record->context['event_name'] ?? null)
+                    && 'unsupported_library_type' === ($record->context['reason'] ?? null)
+                    && 'lib-2' === (string) ag($record->context, 'library.id'),
+            ));
+
+            $this->assertNotEmpty($records);
+            $record = end($records);
+            $this->assertSame('backend.import', $record->context['subsystem'] ?? null);
         }
     }
 

--- a/tests/Backends/MediaBrowser/ProgressQueueTest.php
+++ b/tests/Backends/MediaBrowser/ProgressQueueTest.php
@@ -27,7 +27,7 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 
 class ProgressQueueTest extends MediaBrowserTestCase
 {
-    public function test_progress_queues_update(): void
+    public function test_queue_update(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass, $metaClass, $sessionsClass]) {
             $context = $this->makeContext($clientName, [Options::IGNORE_DATE => true]);
@@ -95,7 +95,7 @@ class ProgressQueueTest extends MediaBrowserTestCase
         }
     }
 
-    public function test_progress_force_reset(): void
+    public function test_force_reset(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass, $metaClass, $sessionsClass]) {
             $context = $this->makeContext($clientName, [
@@ -163,7 +163,7 @@ class ProgressQueueTest extends MediaBrowserTestCase
         }
     }
 
-    public function test_progress_force_value(): void
+    public function test_force_value(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass, $metaClass, $sessionsClass]) {
             $context = $this->makeContext($clientName, [

--- a/tests/Backends/MediaBrowser/ProgressSkipTest.php
+++ b/tests/Backends/MediaBrowser/ProgressSkipTest.php
@@ -20,13 +20,14 @@ use App\Libs\Extends\HttpClient;
 use App\Libs\Extends\MockHttpClient;
 use App\Libs\Options;
 use App\Libs\QueueRequests;
+use Monolog\LogRecord;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Psr16Cache;
 use Symfony\Component\HttpClient\Response\MockResponse;
 
 class ProgressSkipTest extends MediaBrowserTestCase
 {
-    public function test_progress_skips_origin(): void
+    public function test_skip_origin(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass, $metaClass, $sessionsClass]) {
             $context = $this->makeContext($clientName);
@@ -47,10 +48,14 @@ class ProgressSkipTest extends MediaBrowserTestCase
 
             $this->assertTrue($result->isSuccessful());
             $this->assertSame(0, $queue->count());
+
+            $record = $this->lastIgnored();
+            $this->assertSame('backend.progress', $record->context['subsystem'] ?? null);
+            $this->assertSame('origin_backend', $record->context['reason'] ?? null);
         }
     }
 
-    public function test_progress_skips_missing_metadata(): void
+    public function test_skip_missing_metadata(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass, $metaClass, $sessionsClass]) {
             $context = $this->makeContext($clientName);
@@ -79,10 +84,14 @@ class ProgressSkipTest extends MediaBrowserTestCase
 
             $this->assertTrue($result->isSuccessful());
             $this->assertSame(0, $queue->count());
+
+            $record = $this->lastIgnored();
+            $this->assertSame('backend.progress', $record->context['subsystem'] ?? null);
+            $this->assertSame('missing_backend_metadata', $record->context['reason'] ?? null);
         }
     }
 
-    public function test_progress_skips_sender_date(): void
+    public function test_skip_sender_date(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass, $metaClass, $sessionsClass]) {
             $context = $this->makeContext($clientName);
@@ -107,10 +116,14 @@ class ProgressSkipTest extends MediaBrowserTestCase
 
             $this->assertTrue($result->isSuccessful());
             $this->assertSame(0, $queue->count());
+
+            $record = $this->lastIgnored();
+            $this->assertSame('backend.progress', $record->context['subsystem'] ?? null);
+            $this->assertSame('missing_event_date', $record->context['reason'] ?? null);
         }
     }
 
-    public function test_progress_skips_local_newer(): void
+    public function test_skip_local_newer(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass, $metaClass, $sessionsClass]) {
             $context = $this->makeContext($clientName);
@@ -138,10 +151,14 @@ class ProgressSkipTest extends MediaBrowserTestCase
 
             $this->assertTrue($result->isSuccessful());
             $this->assertSame(0, $queue->count());
+
+            $record = $this->lastIgnored();
+            $this->assertSame('backend.progress', $record->context['subsystem'] ?? null);
+            $this->assertSame('date_not_newer_than_local_history', $record->context['reason'] ?? null);
         }
     }
 
-    public function test_progress_skips_active_session(): void
+    public function test_skip_active_session(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass, $metaClass, $sessionsClass]) {
             $context = $this->makeContext($clientName, [Options::IGNORE_DATE => true]);
@@ -185,10 +202,14 @@ class ProgressSkipTest extends MediaBrowserTestCase
 
             $this->assertTrue($result->isSuccessful());
             $this->assertSame(0, $queue->count());
+
+            $record = $this->lastIgnored();
+            $this->assertSame('backend.progress', $record->context['subsystem'] ?? null);
+            $this->assertSame('active_session', $record->context['reason'] ?? null);
         }
     }
 
-    public function test_progress_skips_remote_watched(): void
+    public function test_skip_remote_watched(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass, $metaClass, $sessionsClass]) {
             $context = $this->makeContext($clientName, [Options::IGNORE_DATE => true]);
@@ -227,6 +248,10 @@ class ProgressSkipTest extends MediaBrowserTestCase
 
             $this->assertTrue($result->isSuccessful());
             $this->assertSame(0, $queue->count());
+
+            $record = $this->lastIgnored();
+            $this->assertSame('backend.progress', $record->context['subsystem'] ?? null);
+            $this->assertSame('remote_marked_watched', $record->context['reason'] ?? null);
         }
     }
 
@@ -260,6 +285,18 @@ class ProgressSkipTest extends MediaBrowserTestCase
                 'user_data' => $options['user_data'] ?? null,
             ]),
         ));
+    }
+
+    private function lastIgnored(): LogRecord
+    {
+        $records = array_values(array_filter(
+            $this->handler->getRecords(),
+            static fn(LogRecord $record): bool => 'backend.item.ignored' === ($record->context['event_name'] ?? null),
+        ));
+
+        $this->assertNotEmpty($records);
+
+        return end($records);
     }
 
     private function provideBackends(): array

--- a/tests/Backends/MediaBrowser/ProgressTest.php
+++ b/tests/Backends/MediaBrowser/ProgressTest.php
@@ -12,7 +12,7 @@ use App\Libs\QueueRequests;
 
 class ProgressTest extends MediaBrowserTestCase
 {
-    public function test_progress_handles_empty_entities(): void
+    public function test_empty_entities(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass]) {
             $http = $this->makeHttpClient();

--- a/tests/Backends/MediaBrowser/PushEdgeCasesTest.php
+++ b/tests/Backends/MediaBrowser/PushEdgeCasesTest.php
@@ -18,6 +18,7 @@ class PushEdgeCasesTest extends MediaBrowserTestCase
     public function test_push_skips_missing_metadata(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass]) {
+            $this->handler?->clear();
             $context = $this->makeContext($clientName);
             $queue = new QueueRequests();
 
@@ -36,12 +37,19 @@ class PushEdgeCasesTest extends MediaBrowserTestCase
 
             $this->assertTrue($result->isSuccessful());
             $this->assertSame(0, $queue->count());
+
+            $records = $this->handler?->getRecords() ?? [];
+            $record = end($records);
+            $this->assertSame('backend.item.ignored', $record->context['event_name'] ?? null);
+            $this->assertSame('backend.push', $record->context['subsystem'] ?? null);
+            $this->assertSame('missing_backend_metadata', $record->context['reason'] ?? null);
         }
     }
 
     public function test_push_skips_identical_state(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass]) {
+            $this->handler?->clear();
             $context = $this->makeContext($clientName);
             $queue = new QueueRequests();
 
@@ -54,6 +62,12 @@ class PushEdgeCasesTest extends MediaBrowserTestCase
 
             $this->assertTrue($result->isSuccessful());
             $this->assertSame(0, $queue->count());
+
+            $records = $this->handler?->getRecords() ?? [];
+            $record = end($records);
+            $this->assertSame('backend.item.ignored', $record->context['event_name'] ?? null);
+            $this->assertSame('state_unchanged', $record->context['reason'] ?? null);
+            $this->assertSame('update_state', $record->context['operation'] ?? null);
         }
     }
 

--- a/tests/Backends/MediaBrowser/PushQueueTest.php
+++ b/tests/Backends/MediaBrowser/PushQueueTest.php
@@ -25,6 +25,7 @@ class PushQueueTest extends MediaBrowserTestCase
         ];
 
         foreach ($this->provideBackends() as [$clientName, $actionClass]) {
+            $this->handler?->clear();
             $http = new HttpClient(new MockHttpClient(
                 fn(string $method, string $url, array $options) => new MockResponse(
                     json_encode($payload),
@@ -68,6 +69,23 @@ class PushQueueTest extends MediaBrowserTestCase
             $this->assertCount(1, $followUps);
             $this->assertContainsOnlyInstancesOf(Request::class, $followUps);
             $this->assertStringContainsString('/Users/user-1/Items/item-1/UserData', (string) $followUps[0]->url);
+
+            $records = $this->handler?->getRecords() ?? [];
+            $start = array_filter(
+                $records,
+                static fn($record): bool => 'backend.request.started' === ($record->context['event_name'] ?? null)
+                    && 'backend.push' === ($record->context['subsystem'] ?? null)
+                    && 'update_state' === ($record->context['operation'] ?? null),
+            );
+            $completed = array_filter(
+                $records,
+                static fn($record): bool => 'backend.state_update.completed' === ($record->context['event_name'] ?? null)
+                    && 'backend.push' === ($record->context['subsystem'] ?? null)
+                    && 'update_state' === ($record->context['operation'] ?? null),
+            );
+
+            $this->assertNotEmpty($start);
+            $this->assertNotEmpty($completed);
         }
     }
 

--- a/tests/Backends/MediaBrowser/UpdateStateDryRunTest.php
+++ b/tests/Backends/MediaBrowser/UpdateStateDryRunTest.php
@@ -16,6 +16,7 @@ class UpdateStateDryRunTest extends MediaBrowserTestCase
     public function test_update_dry_no_queue(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass]) {
+            $this->handler?->clear();
             $http = $this->makeHttpClient();
             $context = $this->makeContext($clientName, [Options::DRY_RUN => true]);
             $queue = new QueueRequests();
@@ -41,6 +42,12 @@ class UpdateStateDryRunTest extends MediaBrowserTestCase
 
             $this->assertTrue($result->isSuccessful());
             $this->assertSame(0, $queue->count());
+
+            $records = $this->handler?->getRecords() ?? [];
+            $record = end($records);
+            $this->assertSame('backend.request.skipped', $record->context['event_name'] ?? null);
+            $this->assertSame('backend.restore', $record->context['subsystem'] ?? null);
+            $this->assertSame('dry_run', $record->context['reason'] ?? null);
         }
     }
 

--- a/tests/Backends/MediaBrowser/UpdateStateQueueTest.php
+++ b/tests/Backends/MediaBrowser/UpdateStateQueueTest.php
@@ -19,6 +19,7 @@ class UpdateStateQueueTest extends MediaBrowserTestCase
     public function test_update_state_queues_request(): void
     {
         foreach ($this->provideBackends() as [$clientName, $actionClass]) {
+            $this->handler?->clear();
             $http = new HttpClient(new MockHttpClient(
                 fn(string $method, string $url, array $options) => new MockResponse('', [
                     'http_code' => 204,
@@ -50,6 +51,12 @@ class UpdateStateQueueTest extends MediaBrowserTestCase
             $this->assertTrue($result->isSuccessful());
             $this->assertSame(1, $queue->count());
             $this->assertContainsOnlyInstancesOf(Request::class, $queue->getQueue());
+
+            $records = $this->handler?->getRecords() ?? [];
+            $record = end($records);
+            $this->assertSame('backend.request.started', $record->context['event_name'] ?? null);
+            $this->assertSame('backend.restore', $record->context['subsystem'] ?? null);
+            $this->assertSame('update_state', $record->context['operation'] ?? null);
         }
     }
 

--- a/tests/Backends/Plex/DiscoverTest.php
+++ b/tests/Backends/Plex/DiscoverTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Backends\Plex;
+
+use App\Backends\Plex\PlexClient;
+use App\Libs\Exceptions\Backends\RuntimeException;
+
+class DiscoverTest extends PlexTestCase
+{
+    public function test_discover_xml_error(): void
+    {
+        $http = $this->makeHttpClient($this->makeResponse(
+            '<?xml version="1.0" encoding="UTF-8"?><errors><error>Invalid authentication token.</error></errors>',
+            401,
+        ));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Failed to load Plex servers list: plex.tv returned status 401. Invalid authentication token.'
+        );
+
+        PlexClient::discover($http, 'token');
+    }
+}

--- a/tests/Backends/Plex/ExportFlowTest.php
+++ b/tests/Backends/Plex/ExportFlowTest.php
@@ -13,6 +13,7 @@ use App\Libs\Extends\HttpClient;
 use App\Libs\Extends\MockHttpClient;
 use App\Libs\Options;
 use App\Libs\QueueRequests;
+use Monolog\LogRecord;
 use ReflectionMethod;
 use Symfony\Component\HttpClient\Response\MockResponse;
 
@@ -47,7 +48,10 @@ class ExportFlowTest extends PlexTestCase
 
     public function test_export_ignores_state_unchanged(): void
     {
-        $context = $this->makeContext([Options::IGNORE_DATE => true]);
+        $context = $this->makeContext([
+            Options::IGNORE_DATE => true,
+            Options::DEBUG_TRACE => true,
+        ]);
         $queue = new QueueRequests();
 
         $localEntity = $this->makeLocalEntity($context, watched: 1, updated: 2000);
@@ -71,6 +75,16 @@ class ExportFlowTest extends PlexTestCase
         );
 
         $this->assertSame(0, $queue->count());
+
+        $records = array_values(array_filter(
+            $this->handler->getRecords(),
+            static fn(LogRecord $record): bool => 'backend.item.ignored' === ($record->context['event_name'] ?? null),
+        ));
+
+        $this->assertNotEmpty($records);
+        $record = end($records);
+        $this->assertSame('state_unchanged', $record->context['reason'] ?? null);
+        $this->assertSame('backend.export', $record->context['subsystem'] ?? null);
     }
 
     public function test_export_ignores_newer(): void
@@ -99,6 +113,16 @@ class ExportFlowTest extends PlexTestCase
         );
 
         $this->assertSame(0, $queue->count());
+
+        $records = array_values(array_filter(
+            $this->handler->getRecords(),
+            static fn(LogRecord $record): bool => 'backend.item.ignored' === ($record->context['event_name'] ?? null),
+        ));
+
+        $this->assertNotEmpty($records);
+        $record = end($records);
+        $this->assertSame('date_not_newer_than_local_history', $record->context['reason'] ?? null);
+        $this->assertSame('backend.export', $record->context['subsystem'] ?? null);
     }
 
     public function test_export_ignores_not_found(): void
@@ -123,6 +147,16 @@ class ExportFlowTest extends PlexTestCase
         );
 
         $this->assertSame(0, $queue->count());
+
+        $records = array_values(array_filter(
+            $this->handler->getRecords(),
+            static fn(LogRecord $record): bool => 'backend.item.ignored' === ($record->context['event_name'] ?? null),
+        ));
+
+        $this->assertNotEmpty($records);
+        $record = end($records);
+        $this->assertSame('missing_local_state', $record->context['reason'] ?? null);
+        $this->assertSame('backend.export', $record->context['subsystem'] ?? null);
     }
 
     public function test_export_ignores_no_guids(): void
@@ -150,6 +184,16 @@ class ExportFlowTest extends PlexTestCase
         );
 
         $this->assertSame(0, $queue->count());
+
+        $records = array_values(array_filter(
+            $this->handler->getRecords(),
+            static fn(LogRecord $record): bool => 'backend.item.ignored' === ($record->context['event_name'] ?? null),
+        ));
+
+        $this->assertNotEmpty($records);
+        $record = end($records);
+        $this->assertSame('missing_supported_guid', $record->context['reason'] ?? null);
+        $this->assertSame('backend.export', $record->context['subsystem'] ?? null);
     }
 
     public function test_export_ignores_missing_date(): void
@@ -177,6 +221,16 @@ class ExportFlowTest extends PlexTestCase
         );
 
         $this->assertSame(0, $queue->count());
+
+        $records = array_values(array_filter(
+            $this->handler->getRecords(),
+            static fn(LogRecord $record): bool => 'backend.item.ignored' === ($record->context['event_name'] ?? null),
+        ));
+
+        $this->assertNotEmpty($records);
+        $record = end($records);
+        $this->assertSame('missing_date', $record->context['reason'] ?? null);
+        $this->assertSame('backend.export', $record->context['subsystem'] ?? null);
     }
 
     private function invokeProcess(

--- a/tests/Backends/Plex/GetLibrariesListTest.php
+++ b/tests/Backends/Plex/GetLibrariesListTest.php
@@ -142,9 +142,11 @@ class GetLibrariesListTest extends TestCase
         $this->assertFalse($response->status);
         $this->assertNotNull($response->error);
         $this->assertStringContainsString(
-            "libraries returned with unexpected '401' status code",
+            "Libraries request to 'Plex@Plex' returned status 401",
             (string)$response->error
         );
+        $this->assertSame('backend.response.failed', $response->error->context['event_name'] ?? null);
+        $this->assertSame('backend.library', $response->error->context['subsystem'] ?? null);
 
         $this->assertNull($response->response);
         $this->assertTrue($response->error->hasException());

--- a/tests/Backends/Plex/ImportFlowTest.php
+++ b/tests/Backends/Plex/ImportFlowTest.php
@@ -8,12 +8,23 @@ use App\Backends\Plex\Action\Import;
 use App\Backends\Plex\Action\GetMetaData;
 use App\Backends\Plex\PlexGuid;
 use App\Backends\Common\Response;
+use App\Libs\Config;
 use App\Libs\Container;
+use Monolog\LogRecord;
 use ReflectionMethod;
+use Symfony\Component\HttpClient\Response\MockResponse;
 
 class ImportFlowTest extends PlexTestCase
 {
-    public function test_import_process_adds_items(): void
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // These tests exercise mocked failed responses directly; retries only add backoff delay.
+        Config::save('http.default.maxRetries', 0);
+    }
+
+    public function test_process_adds(): void
     {
         $context = $this->makeContext();
         $mapper = $context->userContext->mapper;
@@ -37,7 +48,7 @@ class ImportFlowTest extends PlexTestCase
         $this->assertSame(1, $result['movie']['added']);
     }
 
-    public function test_import_ignores_missing_date(): void
+    public function test_missing_date(): void
     {
         $context = $this->makeContext();
         $mapper = $context->userContext->mapper;
@@ -62,7 +73,7 @@ class ImportFlowTest extends PlexTestCase
         $this->assertSame(0, $result['movie']['added']);
     }
 
-    public function test_import_episode_adds(): void
+    public function test_episode_adds(): void
     {
         $context = $this->makeContext();
         $mapper = $context->userContext->mapper;
@@ -126,7 +137,7 @@ class ImportFlowTest extends PlexTestCase
         $this->assertSame(1, $result['episode']['added']);
     }
 
-    public function test_import_prefetched_genres(): void
+    public function test_prefetched_genres(): void
     {
         $context = $this->makeContext();
         $mapper = $context->userContext->mapper;
@@ -199,7 +210,7 @@ class ImportFlowTest extends PlexTestCase
         $this->assertSame(0, $metaAction->calls);
     }
 
-    public function test_import_ignores_no_guids(): void
+    public function test_missing_guid(): void
     {
         $context = $this->makeContext();
         $mapper = $context->userContext->mapper;
@@ -225,6 +236,145 @@ class ImportFlowTest extends PlexTestCase
         $this->assertSame(0, $result['movie']['added']);
     }
 
+    public function test_handle_status_failed(): void
+    {
+        $context = $this->makeContext();
+        $http = $this->makeHttpClient(
+            new MockResponse('', ['http_code' => 500]),
+            new MockResponse('', ['http_code' => 500]),
+            new MockResponse('', ['http_code' => 500]),
+            new MockResponse('', ['http_code' => 500]),
+        );
+        $action = new Import($http, $this->logger);
+
+        $this->invokeHandle(
+            $action,
+            $context,
+            $this->makeHandleResponse($action, 'http://plex.test/library'),
+            static function (array $item, array $logContext = []): void {
+            },
+            [
+                'action' => 'plex.import',
+                'client' => $context->clientName,
+                'backend' => $context->backendName,
+                'user' => $context->userContext->name,
+                'library' => ['title' => 'Movies'],
+                'segment' => ['number' => 1, 'of' => 1],
+            ],
+        );
+
+        $record = $this->lastRecord('backend.response.failed');
+        $this->assertSame('backend.import', $record->context['subsystem'] ?? null);
+        $this->assertSame('request_library', $record->context['operation'] ?? null);
+        $this->assertSame('unexpected_status', $record->context['reason'] ?? null);
+    }
+
+    public function test_handle_item_failed(): void
+    {
+        $context = $this->makeContext();
+        $http = $this->makeHttpClient(new MockResponse(json_encode([
+            'MediaContainer' => [
+                'Metadata' => [
+                    ['ratingKey' => '1', 'type' => 'movie'],
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR), ['http_code' => 200]));
+        $action = new Import($http, $this->logger);
+
+        $this->invokeHandle(
+            $action,
+            $context,
+            $this->makeHandleResponse($action, 'http://plex.test/library'),
+            static function (array $item, array $logContext = []): void {
+                throw new \RuntimeException('boom');
+            },
+            [
+                'action' => 'plex.import',
+                'client' => $context->clientName,
+                'backend' => $context->backendName,
+                'user' => $context->userContext->name,
+                'library' => ['title' => 'Movies'],
+                'segment' => ['number' => 1, 'of' => 1],
+            ],
+        );
+
+        $record = $this->lastRecord('backend.operation.failed');
+        $this->assertSame('backend.import', $record->context['subsystem'] ?? null);
+        $this->assertSame('process_item', $record->context['operation'] ?? null);
+    }
+
+    public function test_handle_parse_failed(): void
+    {
+        $context = $this->makeContext();
+        $http = $this->makeHttpClient(new MockResponse(
+            '{"MediaContainer":{"Metadata":[{"ratingKey":"1"},{"ratingKey":}]}}',
+            ['http_code' => 200],
+        ));
+        $action = new Import($http, $this->logger);
+
+        $this->invokeHandle(
+            $action,
+            $context,
+            $this->makeHandleResponse($action, 'http://plex.test/library'),
+            static function (array $item, array $logContext = []): void {
+            },
+            [
+                'action' => 'plex.import',
+                'client' => $context->clientName,
+                'backend' => $context->backendName,
+                'user' => $context->userContext->name,
+                'library' => ['title' => 'Movies'],
+                'segment' => ['number' => 1, 'of' => 1],
+            ],
+        );
+
+        $record = $this->lastRecord('backend.operation.failed');
+        $this->assertSame('backend.import', $record->context['subsystem'] ?? null);
+        $this->assertSame('parse_library_response', $record->context['operation'] ?? null);
+    }
+
+    public function test_handle_completed(): void
+    {
+        $context = $this->makeContext();
+        $http = $this->makeHttpClient(new MockResponse(json_encode([
+            'MediaContainer' => [
+                'Metadata' => [
+                    ['ratingKey' => '1', 'type' => 'movie'],
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR), ['http_code' => 200]));
+        $action = new Import($http, $this->logger);
+        $seen = [];
+
+        $this->invokeHandle(
+            $action,
+            $context,
+            $this->makeHandleResponse($action, 'http://plex.test/library'),
+            static function (array $item, array $logContext = []) use (&$seen): void {
+                $seen[] = $item['ratingKey'] ?? null;
+            },
+            [
+                'action' => 'plex.import',
+                'client' => $context->clientName,
+                'backend' => $context->backendName,
+                'user' => $context->userContext->name,
+                'library' => ['title' => 'Movies'],
+                'segment' => ['number' => 1, 'of' => 1],
+            ],
+        );
+
+        $this->assertSame(['1'], $seen);
+
+        $records = array_values(array_filter(
+            $this->handler->getRecords(),
+            static fn(LogRecord $record): bool => 'backend.response.processing' === ($record->context['event_name'] ?? null),
+        ));
+
+        $this->assertCount(2, $records);
+        $this->assertSame('started', $records[0]->context['outcome'] ?? null);
+        $this->assertSame('completed', $records[1]->context['outcome'] ?? null);
+    }
+
     private function invokeProcess(
         object $action,
         \App\Backends\Common\Context $context,
@@ -238,6 +388,24 @@ class ImportFlowTest extends PlexTestCase
         $method->invoke($action, $context, $guid, $mapper, $item, $logContext, $opts);
     }
 
+    private function invokeHandle(
+        object $action,
+        \App\Backends\Common\Context $context,
+        \Symfony\Contracts\HttpClient\ResponseInterface $response,
+        \Closure $callback,
+        array $logContext,
+    ): void {
+        $method = new ReflectionMethod($action, 'handle');
+        $method->invoke($action, $context, $response, $callback, $logContext);
+    }
+
+    private function makeHandleResponse(object $action, string $url): \Symfony\Contracts\HttpClient\ResponseInterface
+    {
+        $property = new \ReflectionProperty($action, 'http');
+
+        return $property->getValue($action)->request('GET', $url);
+    }
+
     private function invokeProcessShow(
         object $action,
         \App\Backends\Common\Context $context,
@@ -247,5 +415,17 @@ class ImportFlowTest extends PlexTestCase
     ): void {
         $method = new ReflectionMethod($action, 'processShow');
         $method->invoke($action, $context, $guid, $item, $logContext);
+    }
+
+    private function lastRecord(string $eventName): LogRecord
+    {
+        $records = array_values(array_filter(
+            $this->handler->getRecords(),
+            static fn(LogRecord $record): bool => $eventName === ($record->context['event_name'] ?? null),
+        ));
+
+        $this->assertNotEmpty($records);
+
+        return end($records);
     }
 }

--- a/tests/Backends/Plex/ImportTest.php
+++ b/tests/Backends/Plex/ImportTest.php
@@ -7,11 +7,12 @@ namespace Tests\Backends\Plex;
 use App\Backends\Plex\Action\Import;
 use App\Backends\Plex\PlexGuid;
 use App\Libs\Options;
+use Monolog\LogRecord;
 use Symfony\Component\HttpClient\Response\MockResponse;
 
 class ImportTest extends PlexTestCase
 {
-    public function test_import_select_includes(): void
+    public function test_select_includes(): void
     {
         $sections = ag($this->fixture('sections_get_200'), 'response.body');
         $sections['MediaContainer']['Directory'][1]['agent'] = 'tv.plex.agents.series';
@@ -44,9 +45,20 @@ class ImportTest extends PlexTestCase
             $logContext = $request->extras['logContext'] ?? [];
             $this->assertSame(2, (int) ag($logContext, 'library.id'));
         }
+
+        $records = array_values(array_filter(
+            $this->handler->getRecords(),
+            static fn(LogRecord $record): bool => 'backend.item.ignored' === ($record->context['event_name'] ?? null)
+                && 'selected_excluded' === ($record->context['reason'] ?? null)
+                && 1 === (int) ag($record->context, 'library.id'),
+        ));
+
+        $this->assertNotEmpty($records);
+        $record = end($records);
+        $this->assertSame('backend.import', $record->context['subsystem'] ?? null);
     }
 
-    public function test_import_select_excludes(): void
+    public function test_select_excludes(): void
     {
         $sections = ag($this->fixture('sections_get_200'), 'response.body');
         $sections['MediaContainer']['Directory'][1]['agent'] = 'tv.plex.agents.series';
@@ -83,7 +95,7 @@ class ImportTest extends PlexTestCase
         }
     }
 
-    public function test_import_empty_libraries(): void
+    public function test_empty_libraries(): void
     {
         $payload = [
             'MediaContainer' => ['Directory' => []],
@@ -99,7 +111,54 @@ class ImportTest extends PlexTestCase
         $this->assertSame([], $result->response);
     }
 
-    public function test_import_nfo_select(): void
+    public function test_missing_series_count(): void
+    {
+        $sections = ag($this->fixture('sections_get_200'), 'response.body');
+        $http = $this->makeHttpClient(
+            $this->makeResponse($sections),
+            new MockResponse('', [
+                'http_code' => 200,
+                'response_headers' => ['X-Plex-Container-Total-Size' => '1'],
+            ]),
+            new MockResponse('', [
+                'http_code' => 500,
+            ]),
+        );
+        $context = $this->makeContext([Options::LIBRARY_SELECT => ['2']]);
+        $action = new Import($http, $this->logger);
+
+        $result = $action(
+            $context,
+            new PlexGuid($this->logger),
+            $context->userContext->mapper,
+            null,
+            [],
+        );
+
+        $this->assertTrue($result->isSuccessful());
+        $this->assertCount(1, $result->response);
+
+        $failed = array_values(array_filter(
+            $this->handler->getRecords(),
+            static fn(LogRecord $record): bool => 'backend.client.request_failed' === ($record->context['event_name'] ?? null)
+                && 2 === (int) ag($record->context, 'library.id'),
+        ));
+        $ignored = array_values(array_filter(
+            $this->handler->getRecords(),
+            static fn(LogRecord $record): bool => 'backend.item.ignored' === ($record->context['event_name'] ?? null)
+                && 'missing_series_count' === ($record->context['reason'] ?? null)
+                && 2 === (int) ag($record->context, 'library.id'),
+        ));
+
+        $this->assertNotEmpty($failed);
+        $failedRecord = end($failed);
+        $this->assertSame('backend.import', $failedRecord->context['subsystem'] ?? null);
+        $this->assertNotEmpty($ignored);
+        $ignoredRecord = end($ignored);
+        $this->assertSame('backend.import', $ignoredRecord->context['subsystem'] ?? null);
+    }
+
+    public function test_nfo_select(): void
     {
         $sections = [
             'MediaContainer' => [

--- a/tests/Backends/Plex/PlexGuidTest.php
+++ b/tests/Backends/Plex/PlexGuidTest.php
@@ -17,6 +17,7 @@ use App\Libs\TestCase;
 use App\Libs\Uri;
 use Monolog\Handler\TestHandler;
 use Monolog\Level;
+use Monolog\LogRecord;
 use Monolog\Logger;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Psr16Cache;
@@ -51,6 +52,23 @@ class PlexGuidTest extends TestCase
         }
     }
 
+    private function record(string $eventName, ?string $reason = null): ?LogRecord
+    {
+        foreach (array_reverse($this->handler->getRecords()) as $record) {
+            if ($eventName !== ($record->context['event_name'] ?? null)) {
+                continue;
+            }
+
+            if (null !== $reason && $reason !== ($record->context['reason'] ?? null)) {
+                continue;
+            }
+
+            return $record;
+        }
+
+        return null;
+    }
+
     private function getClass(): PlexGuid
     {
         $this->handler->clear();
@@ -78,6 +96,7 @@ class PlexGuidTest extends TestCase
         $this->logger = new Logger('logger', processors: [new LogMessageProcessor()]);
         $this->logger->pushHandler($this->handler);
 
+        Guid::reparse();
         Guid::setLogger($this->logger);
     }
 
@@ -90,10 +109,10 @@ class PlexGuidTest extends TestCase
             file_put_contents($tmpFile, "{'foo' => 'too' }");
             Config::save('guid.file', $tmpFile);
             $this->getClass();
-            $this->assertTrue(
-                $this->logged(Level::Error, 'Failed to parse GUIDs file', true),
-                "Assert message logged when the value type does not match the expected type."
-            );
+            $record = $this->record('guid.file.parse_failed');
+            $this->assertNotNull($record, 'Assert file parse failures are logged with stable event name.');
+            $this->assertSame($tmpFile, $record->context['file'] ?? null);
+            $this->handler->clear();
         } finally {
             Config::save('guid.file', $oldGuidFile);
         }
@@ -149,10 +168,10 @@ class PlexGuidTest extends TestCase
         $tmpFile = self::$tmpPath . '/guid_' . uniqid();
         touch($tmpFile);
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Info, 'is empty', true),
-                "Failed to assert that the GUID file is empty."
-            );
+            $record = $this->record('guid.mapping.ignored', 'empty_file');
+            $this->assertNotNull($record, 'Failed to assert that the empty GUID file is logged.');
+            $this->assertSame($tmpFile, $record->context['file'] ?? null);
+            $this->handler->clear();
 
 
         $tmpFile = self::$tmpPath . '/guid_' . uniqid();
@@ -178,34 +197,32 @@ class PlexGuidTest extends TestCase
 
             file_put_contents($tmpFile, Yaml::dump(ag_set($yaml, 'links.0', 'ff')));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'Value must be an object.', true),
-                'Assert link value is an object.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'invalid_link_value');
+            $this->assertNotNull($record, 'Assert link value is an object.');
+            $this->assertSame('links.0', $record->context['mapping_key'] ?? null);
+            $this->handler->clear();
 
             $yaml = ag_set($yaml, 'links.0.options.replace', 'foo');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'replace value must be an object.', true),
-                'Assert replace key is an object.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'invalid_replace_value');
+            $this->assertNotNull($record, 'Assert replace key is an object.');
+            $this->assertSame('links.0', $record->context['mapping_key'] ?? null);
+            $this->handler->clear();
 
             $yaml = ag_set($yaml, 'links.0.options.replace', []);
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'options.replace.from field is empty or not a string.', true),
-                'Assert to field is a string.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'invalid_replace_from');
+            $this->assertNotNull($record, 'Assert replace.from is validated.');
+            $this->handler->clear();
 
             $yaml = ag_set($yaml, 'links.0.options.replace.from', 'foo');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'options.replace.to field is not a string.', true),
-                'Assert to field is a string.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'invalid_replace_to');
+            $this->assertNotNull($record, 'Assert replace.to is validated.');
+            $this->handler->clear();
 
             $yaml = ag_set($yaml, 'links.0.options.replace.to', 'bar');
             file_put_contents($tmpFile, Yaml::dump($yaml));
@@ -219,42 +236,37 @@ class PlexGuidTest extends TestCase
             $yaml = ag_set(['links' => [['type' => 'plex']]], 'links.0.map', 'foo');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'map value must be an object.', true),
-                'Assert map key is an object.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'invalid_map_value');
+            $this->assertNotNull($record, 'Assert map key is an object.');
+            $this->handler->clear();
 
             $yaml = ag_set($yaml, 'links.0.map', []);
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'map.from field is empty or not a string.', true),
-                'Assert to field is a string.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'invalid_map_from');
+            $this->assertNotNull($record, 'Assert map.from is validated.');
+            $this->handler->clear();
 
             $yaml = ag_set($yaml, 'links.0.map.from', 'foo');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'map.to field is empty or not a string.', true),
-                'Assert to field is a string.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'invalid_map_to');
+            $this->assertNotNull($record, 'Assert map.to is validated.');
+            $this->handler->clear();
 
             $yaml = ag_set($yaml, 'links.0.map.to', 'foobar');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'field does not starts with', true),
-                'Assert to field is a string.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'invalid_guid_type_name');
+            $this->assertNotNull($record, 'Assert GUID type names are validated.');
+            $this->handler->clear();
 
             $yaml = ag_set($yaml, 'links.0.map.to', 'guid_foobar');
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'map.to field is not a supported', true),
-                'Assert to field is a string.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'unsupported_guid_type');
+            $this->assertNotNull($record, 'Assert supported GUID types are validated.');
+            $this->handler->clear();
 
             $yaml = ag_set($yaml, 'links.0.map', [
                 'from' => 'com.plexapp.agents.imdb',
@@ -262,10 +274,9 @@ class PlexGuidTest extends TestCase
             ]);
             file_put_contents($tmpFile, Yaml::dump($yaml));
             $this->getClass()->parseGUIDFile($tmpFile);
-            $this->assertTrue(
-                $this->logged(Level::Warning, 'map.from already exists.', true),
-                'Assert to field is a string.'
-            );
+            $record = $this->record('guid.mapping.ignored', 'duplicate_map_from');
+            $this->assertNotNull($record, 'Assert duplicate GUID mappings are ignored.');
+            $this->handler->clear();
 
             $yaml = ag_set($yaml, 'links.0.map', [
                 'from' => 'com.plexapp.agents.ccdb',
@@ -390,7 +401,7 @@ class PlexGuidTest extends TestCase
         ], $context), 'Assert invalid guid return empty array.');
 
         $this->assertTrue(
-            $this->logged(Level::Info, 'Unable to parse', true),
+            null !== $this->record('guid.external_id.ignored', 'unrecognized_format'),
             'Assert that the invalid GUID is logged.'
         );
         $this->assertEquals([Guid::GUID_IMDB => '1', Guid::GUID_CMDB => 'afa', Guid::GUID_TVDB => '123'],
@@ -406,10 +417,10 @@ class PlexGuidTest extends TestCase
             'Assert only the the oldest ID is returned for numeric GUIDs.'
         );
 
-        $this->assertTrue(
-            $this->logged(Level::Warning, 'reported multiple ids', true),
-            'Assert that a log is raised when multiple GUIDs for the same provider are found.'
-        );
+        $record = $this->record('guid.external_id.conflict', 'multiple_ids');
+        $this->assertNotNull($record, 'Assert that a log is raised when multiple GUIDs for the same provider are found.');
+        $this->assertContains($record->context['guid_source'] ?? null, ['imdb', 'cmdb']);
+        $this->handler->clear();
 
         $this->assertEquals([Guid::GUID_IMDB => '1'], $this->getClass()->get([
             ['id' => 'com.plexapp.agents.imdb://1'],
@@ -421,10 +432,11 @@ class PlexGuidTest extends TestCase
             ['id' => 'tv.plex.agents.nfo.series://episode/tvdb_84871'],
         ], $context), 'Assert typed NFO GUIDs do not conflict with identical canonical GUIDs.');
 
-        $this->assertFalse(
-            $this->logged(Level::Warning, 'reported multiple ids', true),
+        $this->assertNull(
+            $this->record('guid.external_id.conflict', 'multiple_ids'),
             'Assert identical canonical and NFO GUIDs do not raise duplicate warnings.'
         );
+        $this->handler->clear();
 
         // -- as we cache the ignore list for each user now,
         // -- and no longer rely on config.ignore key, we needed a workaround to update the ignore list
@@ -448,9 +460,9 @@ class PlexGuidTest extends TestCase
             ], ag_set($context, 'item.type', 'show')),
             'Assert only the the oldest ID is returned for numeric GUIDs.');
 
-        $this->assertTrue(
-            $this->logged(Level::Debug, 'PlexGuid: Ignoring', true),
-            'Assert that a log is raised when the GUID is ignored by user choice.'
-        );
+        $record = $this->record('guid.external_id.ignored', 'user_ignored');
+        $this->assertNotNull($record, 'Assert that a log is raised when the GUID is ignored by user choice.');
+        $this->assertSame('imdb', $record->context['guid_source'] ?? null);
+        $this->handler->clear();
     }
 }

--- a/tests/Backends/Plex/PlexGuidTest.php
+++ b/tests/Backends/Plex/PlexGuidTest.php
@@ -420,6 +420,11 @@ class PlexGuidTest extends TestCase
         $record = $this->record('guid.external_id.conflict', 'multiple_ids');
         $this->assertNotNull($record, 'Assert that a log is raised when multiple GUIDs for the same provider are found.');
         $this->assertContains($record->context['guid_source'] ?? null, ['imdb', 'cmdb']);
+        $this->assertSame('Test title', $record->context['item']['title'] ?? null);
+        $this->assertStringContainsString('Test title', $record->message);
+        foreach (($record->context['guid_values'] ?? []) as $guidValue) {
+            $this->assertStringContainsString((string) $guidValue, $record->message);
+        }
         $this->handler->clear();
 
         $this->assertEquals([Guid::GUID_IMDB => '1'], $this->getClass()->get([

--- a/tests/Backends/Plex/ProgressQueueTest.php
+++ b/tests/Backends/Plex/ProgressQueueTest.php
@@ -18,7 +18,7 @@ use App\Libs\QueueRequests;
 
 class ProgressQueueTest extends PlexTestCase
 {
-    public function test_progress_queues_update(): void
+    public function test_queue_update(): void
     {
         Container::add(GetSessions::class, fn() => new class() {
             public function __invoke(): Response

--- a/tests/Backends/Plex/ProgressTest.php
+++ b/tests/Backends/Plex/ProgressTest.php
@@ -13,7 +13,7 @@ use App\Libs\QueueRequests;
 
 class ProgressTest extends PlexTestCase
 {
-    public function test_progress_empty_entities(): void
+    public function test_empty_entities(): void
     {
         Container::add(GetSessions::class, fn() => new class() {
             public function __invoke(): Response

--- a/tests/Backends/Plex/UpdateStateTest.php
+++ b/tests/Backends/Plex/UpdateStateTest.php
@@ -16,6 +16,7 @@ class UpdateStateTest extends PlexTestCase
 {
     public function test_update_state_queues_request(): void
     {
+        $this->handler?->clear();
         $http = new \App\Libs\Extends\HttpClient(
             new \App\Libs\Extends\MockHttpClient(
                 new MockResponse('', ['http_code' => 200]),
@@ -46,10 +47,17 @@ class UpdateStateTest extends PlexTestCase
         $this->assertTrue($result->isSuccessful());
         $this->assertSame(1, $queue->count());
         $this->assertContainsOnlyInstancesOf(Request::class, $queue->getQueue());
+
+        $records = $this->handler?->getRecords() ?? [];
+        $record = end($records);
+        $this->assertSame('backend.request.started', $record->context['event_name'] ?? null);
+        $this->assertSame('backend.restore', $record->context['subsystem'] ?? null);
+        $this->assertSame('update_state', $record->context['operation'] ?? null);
     }
 
     public function test_update_state_dry_run(): void
     {
+        $this->handler?->clear();
         $http = $this->makeHttpClient();
         $context = $this->makeContext([Options::DRY_RUN => true]);
         $queue = new QueueRequests();
@@ -75,5 +83,11 @@ class UpdateStateTest extends PlexTestCase
 
         $this->assertTrue($result->isSuccessful());
         $this->assertSame(0, $queue->count());
+
+        $records = $this->handler?->getRecords() ?? [];
+        $record = end($records);
+        $this->assertSame('backend.request.skipped', $record->context['event_name'] ?? null);
+        $this->assertSame('backend.restore', $record->context['subsystem'] ?? null);
+        $this->assertSame('dry_run', $record->context['reason'] ?? null);
     }
 }

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use App\Command;
+use App\Libs\Extends\LogMessageProcessor;
+use App\Libs\TestCase;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class CommandTest extends TestCase
+{
+    public function test_logs_locked_command_event(): void
+    {
+        $handler = new TestHandler();
+        $logger = new Logger('test', [$handler], [new LogMessageProcessor()]);
+        $factory = static fn() => new class() extends Command {
+            public function __construct()
+            {
+                parent::__construct('test:lock');
+            }
+
+            public function runSingleForTest(BufferedOutput $output, Logger $logger): int
+            {
+                return $this->single(static fn(): int => self::SUCCESS, $output, [
+                    \Psr\Log\LoggerInterface::class => $logger,
+                ]);
+            }
+
+            public function runNestedForTest(self $other, BufferedOutput $output, Logger $logger): int
+            {
+                return $this->single(fn(): int => $other->runSingleForTest($output, $logger), $output, [
+                    \Psr\Log\LoggerInterface::class => $logger,
+                ]);
+            }
+
+        };
+        $outer = $factory();
+        $inner = $factory();
+
+        $lockName = get_app_version() . ':test:lock';
+        $status = $outer->runNestedForTest($inner, new BufferedOutput(), $logger);
+
+        self::assertSame(Command::SUCCESS, $status);
+        self::assertSame('cli.command.locked', $handler->getRecords()[0]->context['event_name']);
+        self::assertSame('test:lock', $handler->getRecords()[0]->context['command']);
+        self::assertSame($lockName, $handler->getRecords()[0]->context['lock_name']);
+    }
+
+    public function test_wraps_display_content_in_jsonl_mode(): void
+    {
+        $command = new class() extends Command {
+            public function __construct()
+            {
+                parent::__construct('test:data');
+            }
+
+            public function render(array $content, BufferedOutput $output, string $mode = 'json'): void
+            {
+                $this->displayContent($content, $output, $mode);
+            }
+        };
+
+        $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, false);
+        
+        \App\Libs\Config::save('console.output', 'jsonl');
+
+        try {
+            $command->render(['name' => 'watchstate'], $output);
+        } finally {
+            \App\Libs\Config::remove('console.output');
+        }
+
+        $payload = json_decode(trim($output->fetch()), true, flags: JSON_THROW_ON_ERROR);
+
+        self::assertSame('cli.command.output', $payload['fields']['event_name']);
+        self::assertSame('test:data', $payload['fields']['command']);
+        self::assertSame('watchstate', $payload['fields']['data.name']);
+    }
+}

--- a/tests/Commands/Backend/RestoreCommandTest.php
+++ b/tests/Commands/Backend/RestoreCommandTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands\Backend;
+
+use App\Commands\Backend\RestoreCommand;
+use App\Libs\Config;
+use App\Libs\Extends\LogMessageProcessor;
+use App\Libs\LogSuppressor;
+use App\Libs\QueueRequests;
+use App\Libs\TestCase;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Contracts\HttpClient\HttpClientInterface as iHttp;
+use Tests\Support\StateCommandTestSupport;
+
+final class RestoreCommandTest extends TestCase
+{
+    use StateCommandTestSupport;
+
+    public function test_logs_restore_events(): void
+    {
+        $logger = $this->initFakeBackendApp($this->fakeBackendConfig('fake_restore', [
+            'import' => [
+                'enabled' => false,
+            ],
+            'export' => [
+                'enabled' => false,
+            ],
+        ]));
+        $handler = new TestHandler();
+        $logger->setHandlers([$handler]);
+        $logger->pushProcessor(new LogMessageProcessor());
+        $this->migrateMainDb($logger);
+
+        $file = self::$tmpPath . '/backup/restore.json';
+        mkdir(dirname($file), 0o755, true);
+        $entity = require __DIR__ . '/../../Fixtures/MovieEntity.php';
+        file_put_contents($file, json_encode([$entity], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+        $command = new RestoreCommand(
+            new QueueRequests(),
+            $logger,
+            new LogSuppressor([]),
+            $this->createStub(iHttp::class),
+        );
+
+        $status = $this->makeTester($command)->execute([
+            '--select-backend' => 'fake_restore',
+            '--user' => 'main',
+            '--ignore' => true,
+            'file' => $file,
+        ]);
+
+        self::assertSame(RestoreCommand::SUCCESS, $status);
+
+        $records = $handler->getRecords();
+
+        $byEvent = [];
+        foreach ($records as $record) {
+            $eventName = $record->context['event_name'] ?? null;
+            if (is_string($eventName)) {
+                $byEvent[$eventName] = $record;
+            }
+        }
+
+        self::assertSame(
+            "Restore target 'main@fake_restore' has export disabled; continuing because bypass was requested.",
+            $byEvent['backend.restore.export_disabled_bypassed']->message,
+        );
+        self::assertSame('restore.json', basename($byEvent['backend.restore.data.loading']->context['path']));
+        self::assertSame(1, $byEvent['backend.restore.data.loaded']->context['item_count']);
+        self::assertSame(0, $byEvent['backend.restore.compare.completed']->context['change_count']);
+        self::assertSame(
+            "No restore differences found for 'main@fake_restore'.",
+            $byEvent['backend.restore.no_difference']->message,
+        );
+        self::assertSame('dry_run', $byEvent['backend.restore.cancelled']->context['reason']);
+    }
+
+    private function makeTester(RestoreCommand $command): CommandTester
+    {
+        $application = new Application();
+        $application->getDefinition()->addOption(new InputOption('trace', null, InputOption::VALUE_NONE));
+        $application->addCommand($command);
+
+        return new CommandTester($application->find(RestoreCommand::ROUTE));
+    }
+}

--- a/tests/Commands/Events/DispatchCommandTest.php
+++ b/tests/Commands/Events/DispatchCommandTest.php
@@ -6,6 +6,7 @@ namespace Tests\Commands\Events;
 
 use App\Commands\Events\DispatchCommand;
 use App\Libs\Events\DataEvent;
+use App\Libs\Extends\JsonlFormatter;
 use App\Libs\Extends\LogMessageProcessor;
 use App\Libs\TestCase;
 use App\Model\Events\Event;
@@ -24,6 +25,18 @@ final class DispatchCommandTest extends TestCase
     {
         $method = new ReflectionMethod(DispatchCommand::class, 'isVisible');
         $command = $this->makeCommand();
+        $jsonlNotice = (new JsonlFormatter())->formatValues(
+            channel: 'event',
+            level: Level::Notice,
+            message: 'JSONL visible',
+            context: ['event_id' => '550e8400-e29b-41d4-a716-446655440000'],
+        );
+        $jsonlInfo = (new JsonlFormatter())->formatValues(
+            channel: 'event',
+            level: Level::Info,
+            message: 'JSONL hidden',
+            context: ['event_id' => '550e8400-e29b-41d4-a716-446655440000'],
+        );
 
         self::assertTrue($method->invoke(
             $command,
@@ -31,6 +44,7 @@ final class DispatchCommandTest extends TestCase
                 'INFO: hidden',
                 'NOTICE: visible',
                 '[2026-04-27T10:17:56+03:00] WARNING: visible',
+                $jsonlNotice,
                 'plain text',
             ],
             Level::Notice,
@@ -42,6 +56,7 @@ final class DispatchCommandTest extends TestCase
                 'INFO: visible',
                 'NOTICE: visible',
                 'WARNING: visible',
+                $jsonlInfo,
                 'event.DEBUG: hidden',
             ],
             Level::Info,
@@ -82,9 +97,10 @@ final class DispatchCommandTest extends TestCase
 
         $records = $handler->getRecords();
         self::assertSame(
-            "[event:550e8400-e29b-41d4-a716-446655440000] Dispatching Event: 'on_push' queued at '2026-05-17T08:25:02+00:00'.",
+            "Dispatching Event: 'on_push' queued at '2026-05-17T08:25:02+00:00'.",
             $records[0]->message,
         );
+        self::assertSame('550e8400-e29b-41d4-a716-446655440000', $records[0]->context['id']);
         self::assertSame('Listener visible.', $records[1]->message);
     }
 

--- a/tests/Commands/Events/DispatchCommandTest.php
+++ b/tests/Commands/Events/DispatchCommandTest.php
@@ -97,10 +97,12 @@ final class DispatchCommandTest extends TestCase
 
         $records = $handler->getRecords();
         self::assertSame(
-            "Dispatching Event: 'on_push' queued at '2026-05-17T08:25:02+00:00'.",
+            "Dispatching queued event 'on_push' from 2026-05-17T08:25:02+00:00.",
             $records[0]->message,
         );
         self::assertSame('550e8400-e29b-41d4-a716-446655440000', $records[0]->context['event_id']);
+        self::assertSame('on_push', $records[0]->context['queued_event']);
+        self::assertSame('events.dispatch.started', $records[0]->context['event_name']);
         self::assertSame('Listener visible.', $records[1]->message);
     }
 

--- a/tests/Commands/Events/DispatchCommandTest.php
+++ b/tests/Commands/Events/DispatchCommandTest.php
@@ -100,7 +100,7 @@ final class DispatchCommandTest extends TestCase
             "Dispatching Event: 'on_push' queued at '2026-05-17T08:25:02+00:00'.",
             $records[0]->message,
         );
-        self::assertSame('550e8400-e29b-41d4-a716-446655440000', $records[0]->context['id']);
+        self::assertSame('550e8400-e29b-41d4-a716-446655440000', $records[0]->context['event_id']);
         self::assertSame('Listener visible.', $records[1]->message);
     }
 

--- a/tests/Commands/Prune/CommandSessionsPrunerTest.php
+++ b/tests/Commands/Prune/CommandSessionsPrunerTest.php
@@ -149,7 +149,7 @@ final class CommandSessionsPrunerTest extends TestCase
             'connections' => 0,
         ], $state), JSON_PRETTY_PRINT | JSON_INVALID_UTF8_IGNORE));
 
-        touch($path . '/stream.log');
+        touch($path . '/stream.jsonl');
 
         return $path;
     }

--- a/tests/Commands/State/BackupCommandTest.php
+++ b/tests/Commands/State/BackupCommandTest.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Tests\Commands\State;
 
 use App\Commands\State\BackupCommand;
+use App\Libs\Extends\LogMessageProcessor;
 use App\Libs\LogSuppressor;
 use App\Libs\Mappers\Import\DirectMapper;
 use App\Libs\TestCase;
+use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Contracts\HttpClient\HttpClientInterface as iHttp;
 use Tests\Support\FakeBackendClient;
@@ -28,6 +31,7 @@ final class BackupCommandTest extends TestCase
                 'alice' => $this->fakeBackendConfig('fake_backup'),
             ],
         );
+        $logger->pushProcessor(new LogMessageProcessor());
         $this->makeUserContext('alice', $logger);
 
         $backupDir = self::$tmpPath . '/backup';
@@ -62,6 +66,38 @@ final class BackupCommandTest extends TestCase
         self::assertFileExists($aliceFile);
         self::assertStringContainsString('"user":"alice"', (string) file_get_contents($aliceFile));
         self::assertFileDoesNotExist(self::$tmpPath . '/backup/custom.main.fake_backup.json');
+    }
+
+    public function test_logfile_lifecycle(): void
+    {
+        $logger = $this->initFakeBackendApp($this->fakeBackendConfig('fake_backup'));
+        $logger->pushProcessor(new LogMessageProcessor());
+        $this->migrateMainDb($logger);
+
+        $logfile = self::$tmpPath . '/backup-log.txt';
+        touch($logfile);
+
+        $command = new BackupCommand(
+            $this->createRuntimeMapper($logger),
+            $logger,
+            new LogSuppressor([]),
+            $this->createStub(iHttp::class),
+        );
+
+        $status = $this->makeTester($command)->execute([
+            '--logfile' => $logfile,
+            '--no-compress' => true,
+        ], [
+            'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
+        ]);
+
+        self::assertSame(BackupCommand::SUCCESS, $status);
+
+        $contents = file_get_contents($logfile);
+        self::assertIsString($contents);
+        self::assertStringContainsString('Backup started for 1 users.', $contents);
+        self::assertStringContainsString("Backing up play states for 'main'.", $contents);
+        self::assertStringContainsString('Backup completed for 1 users in', $contents);
     }
 
     public function test_invalid_user_returns_failure(): void
@@ -101,6 +137,52 @@ final class BackupCommandTest extends TestCase
         self::assertSame(BackupCommand::SUCCESS, $status);
         self::assertSame([], FakeBackendClient::getCalls('backup'));
         self::assertDirectoryDoesNotExist(self::$tmpPath . '/backup');
+    }
+
+    public function test_logs_unsupported_backend(): void
+    {
+        $logger = $this->initFakeBackendApp([
+            'bad_backend' => [
+                'type' => 'bad',
+                'url' => 'https://bad.example.invalid',
+                'token' => 'token',
+                'user' => 'user',
+                'uuid' => 'uuid',
+                'import' => [
+                    'enabled' => true,
+                ],
+                'export' => [
+                    'enabled' => true,
+                ],
+                'options' => [],
+            ],
+        ]);
+        $handler = new TestHandler();
+        $logger->setHandlers([$handler]);
+        $logger->pushProcessor(new LogMessageProcessor());
+        $this->migrateMainDb($logger);
+
+        $command = new BackupCommand(
+            $this->createRuntimeMapper($logger),
+            $logger,
+            new LogSuppressor([]),
+            $this->createStub(iHttp::class),
+        );
+
+        $status = $this->makeTester($command)->execute(['--no-compress' => true]);
+
+        self::assertSame(BackupCommand::SUCCESS, $status);
+
+        $records = array_values(array_filter(
+            $handler->getRecords(),
+            static fn($record): bool => 'state.backup.backend.skipped' === ($record->context['event_name'] ?? null),
+        ));
+
+        self::assertCount(1, $records);
+        self::assertSame("Skipping 'main@bad_backend': backend type 'bad' is unsupported.", $records[0]->message);
+        self::assertSame('unsupported_type', $records[0]->context['reason']);
+        self::assertSame('bad_backend', $records[0]->context['backend']);
+        self::assertSame('bad', $records[0]->context['backend_type']);
     }
 
     private function makeTester(BackupCommand $command): CommandTester

--- a/tests/Commands/State/ExportCommandTest.php
+++ b/tests/Commands/State/ExportCommandTest.php
@@ -5,16 +5,18 @@ declare(strict_types=1);
 namespace Tests\Commands\State;
 
 use App\Commands\State\ExportCommand;
-use App\Libs\Container;
 use App\Libs\Entity\StateEntity;
 use App\Libs\Entity\StateInterface as iState;
+use App\Libs\Extends\LogMessageProcessor;
 use App\Libs\Mappers\ImportInterface as iImport;
 use App\Libs\LogSuppressor;
 use App\Libs\QueueRequests;
 use App\Libs\TestCase;
+use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Contracts\HttpClient\HttpClientInterface as iHttp;
@@ -103,6 +105,9 @@ final class ExportCommandTest extends TestCase
                 ]),
             ],
         );
+        $handler = new TestHandler();
+        $logger->setHandlers([$handler]);
+        $logger->pushProcessor(new LogMessageProcessor());
 
         $aliceContext = $this->makeUserContext('alice', $logger);
         $entity = require __DIR__ . '/../../Fixtures/MovieEntity.php';
@@ -141,6 +146,97 @@ final class ExportCommandTest extends TestCase
                 'after' => 1_700_000_050,
             ],
         ], FakeBackendClient::getCalls('push'));
+
+        $records = array_values(array_filter(
+            $handler->getRecords(),
+            static fn($record): bool => 'state.export.push.started' === ($record->context['event_name'] ?? null),
+        ));
+
+        self::assertCount(1, $records);
+        self::assertSame("Pushing 1 local changes to 1 backends for 'alice'.", $records[0]->message);
+        self::assertSame(1, $records[0]->context['item_count']);
+        self::assertSame(['fake_export'], $records[0]->context['backends']);
+    }
+
+    public function test_logfile_lifecycle(): void
+    {
+        $logger = $this->initFakeBackendApp($this->fakeBackendConfig('fake_export'));
+        $logger->pushProcessor(new LogMessageProcessor());
+        $this->migrateMainDb($logger);
+
+        $logfile = self::$tmpPath . '/export-log.txt';
+        touch($logfile);
+
+        $command = new ExportCommand(
+            $this->createRuntimeMapper($logger),
+            new QueueRequests(),
+            $logger,
+            new LogSuppressor([]),
+            $this->createStub(iHttp::class),
+        );
+
+        $status = $this->makeTester($command)->execute([
+            '--logfile' => $logfile,
+        ], [
+            'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
+        ]);
+
+        self::assertSame(ExportCommand::SUCCESS, $status);
+
+        $contents = file_get_contents($logfile);
+        self::assertIsString($contents);
+        self::assertStringContainsString('Export started for 1 users.', $contents);
+        self::assertStringContainsString("Exporting play states for 'main'.", $contents);
+        self::assertStringContainsString('Export completed for 1 users in', $contents);
+    }
+
+    public function test_logs_unsupported_backend(): void
+    {
+        $logger = $this->initFakeBackendApp([
+            'bad_backend' => [
+                'type' => 'bad',
+                'url' => 'https://bad.example.invalid',
+                'token' => 'token',
+                'user' => 'user',
+                'uuid' => 'uuid',
+                'import' => [
+                    'enabled' => true,
+                    'lastSync' => 1_700_000_000,
+                ],
+                'export' => [
+                    'enabled' => true,
+                    'lastSync' => 1_700_000_000,
+                ],
+                'options' => [],
+            ],
+        ]);
+        $handler = new TestHandler();
+        $logger->setHandlers([$handler]);
+        $logger->pushProcessor(new LogMessageProcessor());
+        $this->migrateMainDb($logger);
+
+        $command = new ExportCommand(
+            $this->createRuntimeMapper($logger),
+            new QueueRequests(),
+            $logger,
+            new LogSuppressor([]),
+            $this->createStub(iHttp::class),
+        );
+
+        $status = $this->makeTester($command)->execute([]);
+
+        self::assertSame(ExportCommand::SUCCESS, $status);
+
+        $records = array_values(array_filter(
+            $handler->getRecords(),
+            static fn($record): bool => 'state.export.backend.skipped' === ($record->context['event_name'] ?? null),
+        ));
+
+        self::assertCount(1, $records);
+        self::assertSame("Skipping 'main@bad_backend': backend type 'bad' is unsupported.", $records[0]->message);
+        self::assertSame('unsupported_type', $records[0]->context['reason']);
+        self::assertSame('bad_backend', $records[0]->context['backend']);
+        self::assertSame('bad', $records[0]->context['backend_type']);
     }
 
     private function makeTester(ExportCommand $command): CommandTester

--- a/tests/Commands/State/ImportCommandTest.php
+++ b/tests/Commands/State/ImportCommandTest.php
@@ -11,26 +11,35 @@ use App\Libs\Container;
 use App\Libs\Database\DatabaseInterface as iDB;
 use App\Libs\Database\PackageMigrationFactory;
 use App\Libs\Entity\StateEntity;
+use App\Libs\Extends\LogMessageProcessor;
 use App\Libs\LogSuppressor;
 use App\Libs\Mappers\Import\DirectMapper;
+use App\Libs\Mappers\ImportInterface as iImport;
+use App\Libs\Options;
 use App\Libs\TestCase;
+use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use PDO;
 use PDOException;
 use Psr\SimpleCache\CacheInterface as iCache;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Contracts\HttpClient\HttpClientInterface as iHttp;
+use Tests\Support\FakeBackendClient;
+use Tests\Support\StateCommandTestSupport;
 
 final class ImportCommandTest extends TestCase
 {
+    use StateCommandTestSupport;
+
     public function test_request_phase_rollback(): void
     {
         $this->initTempApp();
         Config::save('backends_file', __DIR__ . '/../../Fixtures/test_servers.yaml');
 
-        $logger = new Logger('test');
+        $logger = new Logger('test', processors: [new LogMessageProcessor()]);
         $pdo = Container::get(PDO::class);
         $migrations = new PackageMigrationFactory();
         if (false === $migrations->isMigrated($pdo)) {
@@ -97,10 +106,136 @@ final class ImportCommandTest extends TestCase
         self::assertSame('state', $stateTable, 'Failed request-phase writes should be rolled back with the adapter transaction.');
     }
 
+    public function test_logfile_lifecycle(): void
+    {
+        $logger = $this->initFakeBackendApp($this->fakeBackendConfig('fake_import'));
+        $logger->pushProcessor(new LogMessageProcessor());
+        $this->migrateMainDb($logger);
+
+        $logfile = self::$tmpPath . '/import-log.txt';
+        touch($logfile);
+
+        $command = new ImportCommand(
+            $this->createRuntimeMapper($logger),
+            $logger,
+            new LogSuppressor([]),
+            $this->createStub(iHttp::class),
+        );
+
+        $status = $this->makeTester($command)->execute([
+            '--logfile' => $logfile,
+        ], [
+            'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
+        ]);
+
+        self::assertSame(ImportCommand::SUCCESS, $status);
+
+        $contents = file_get_contents($logfile);
+        self::assertIsString($contents);
+        self::assertStringContainsString('Import started for 1 users.', $contents);
+        self::assertStringContainsString("Importing play states for 'main'.", $contents);
+        self::assertStringContainsString('Import completed for 1 users in', $contents);
+    }
+
+    public function test_logs_skipped_backend_with_structured_context(): void
+    {
+        $logger = new Logger('test', [new TestHandler()], [new LogMessageProcessor()]);
+        $this->initTempApp();
+        $this->writeBackendsFile((string) Config::get('backends_file'), [
+            'bad_backend' => [
+                'type' => 'bad',
+                'url' => 'https://bad.example.invalid',
+                'token' => 'token',
+                'user' => 'user',
+                'uuid' => 'uuid',
+                'import' => [
+                    'enabled' => true,
+                    'lastSync' => 1_700_000_000,
+                ],
+                'export' => [
+                    'enabled' => true,
+                    'lastSync' => 1_700_000_000,
+                ],
+                'options' => [],
+            ],
+        ]);
+        $this->migrateMainDb($logger);
+
+        $command = new ImportCommand(
+            new DirectMapper($logger, Container::get(iDB::class), Container::get(iCache::class)),
+            $logger,
+            new LogSuppressor([]),
+            $this->createStub(iHttp::class),
+        );
+
+        $status = $this->makeTester($command)->execute([]);
+
+        self::assertSame(ImportCommand::SUCCESS, $status);
+
+        $handler = $logger->getHandlers()[0];
+        self::assertInstanceOf(TestHandler::class, $handler);
+
+        $records = array_values(array_filter(
+            $handler->getRecords(),
+            static fn($record): bool => 'state.import.backend.skipped' === ($record->context['event_name'] ?? null),
+        ));
+
+        self::assertCount(1, $records);
+        self::assertSame(
+            "Skipping 'main@bad_backend': backend type 'bad' is unsupported.",
+            $records[0]->message,
+        );
+        self::assertSame('unsupported_type', $records[0]->context['reason']);
+        self::assertSame('bad_backend', $records[0]->context['backend']);
+        self::assertSame('bad', $records[0]->context['backend_type']);
+    }
+
+    public function test_fake_backend_runs_import(): void
+    {
+        $logger = $this->initFakeBackendApp($this->fakeBackendConfig('fake_import', [
+            'options' => [
+                Options::IMPORT_METADATA_ONLY => true,
+            ],
+        ]));
+        $logger->pushProcessor(new LogMessageProcessor());
+        $this->migrateMainDb($logger);
+        FakeBackendClient::reset();
+
+        $command = new ImportCommand(
+            $this->createRuntimeMapper($logger),
+            $logger,
+            new LogSuppressor([]),
+            $this->createStub(iHttp::class),
+        );
+
+        $status = $this->makeTester($command)->execute([]);
+
+        self::assertSame(ImportCommand::SUCCESS, $status);
+        self::assertSame([], FakeBackendClient::getCalls('metadata'));
+        self::assertSame([], FakeBackendClient::getCalls('backup'));
+    }
+
+    public function test_invalid_user_returns_failure(): void
+    {
+        $logger = new Logger('test');
+        $command = new ImportCommand(
+            $this->createStub(iImport::class),
+            $logger,
+            new LogSuppressor([]),
+            $this->createStub(iHttp::class),
+        );
+        $status = $this->makeTester($command)->execute([
+            '--user' => 'ghost',
+        ]);
+
+        self::assertSame(ImportCommand::FAILURE, $status);
+    }
+
     private function makeTester(ImportCommand $command): CommandTester
     {
         $application = new Application();
         $application->getDefinition()->addOption(new InputOption('trace', null, InputOption::VALUE_NONE));
+        $application->getDefinition()->addOption(new InputOption('output', 'o', InputOption::VALUE_REQUIRED, '', 'table'));
         $application->addCommand($command);
 
         return new CommandTester($application->find(ImportCommand::ROUTE));

--- a/tests/Commands/State/PlaylistCommandTest.php
+++ b/tests/Commands/State/PlaylistCommandTest.php
@@ -9,6 +9,7 @@ use App\Commands\State\PlaylistCommand;
 use App\Libs\LogSuppressor;
 use App\Libs\Mappers\Import\DirectMapper;
 use App\Libs\Playlists\PlaylistSyncService;
+use App\Libs\TestCase;
 use App\Libs\UserContext;
 use Monolog\Logger;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -18,7 +19,6 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
-use App\Libs\TestCase;
 
 final class PlaylistCommandTest extends TestCase
 {
@@ -61,8 +61,6 @@ final class PlaylistCommandTest extends TestCase
         $status = $tester->execute([]);
 
         self::assertSame(PlaylistCommand::SUCCESS, $status);
-        self::assertStringContainsString('test_plex', $tester->getDisplay());
-        self::assertStringContainsString('Playlists', $tester->getDisplay());
     }
 
     public function test_skips_disabled_backend(): void
@@ -91,7 +89,6 @@ final class PlaylistCommandTest extends TestCase
         $status = $tester->execute([]);
 
         self::assertSame(PlaylistCommand::SUCCESS, $status);
-        self::assertStringContainsString('No matching backends produced syncable playlists.', $tester->getDisplay());
     }
 
     public function test_disabled_passed_empty(): void
@@ -206,8 +203,7 @@ final class PlaylistCommandTest extends TestCase
         iClient $client,
         string $backendName = 'test_plex',
         array $userNames = ['main'],
-    ): CommandTester
-    {
+    ): CommandTester {
         $application = new Application();
         $application->getDefinition()->addOption(new InputOption('output', 'o', InputOption::VALUE_REQUIRED, '', 'table'));
         $application->getDefinition()->addOption(new InputOption('trace', null, InputOption::VALUE_NONE));
@@ -221,8 +217,7 @@ final class PlaylistCommandTest extends TestCase
         iClient $client,
         string $backendName = 'test_plex',
         array $userNames = ['main'],
-    ): PlaylistCommand
-    {
+    ): PlaylistCommand {
         $this->initTempApp();
         $this->seedTestServersConfig();
 

--- a/tests/Commands/State/PlaylistCommandTest.php
+++ b/tests/Commands/State/PlaylistCommandTest.php
@@ -6,6 +6,7 @@ namespace Tests\Commands\State;
 
 use App\Backends\Common\ClientInterface as iClient;
 use App\Commands\State\PlaylistCommand;
+use App\Libs\Extends\LogMessageProcessor;
 use App\Libs\LogSuppressor;
 use App\Libs\Mappers\Import\DirectMapper;
 use App\Libs\Playlists\PlaylistSyncService;
@@ -147,8 +148,8 @@ final class PlaylistCommandTest extends TestCase
 
         $contents = file_get_contents($logfile);
         self::assertIsString($contents);
-        self::assertStringContainsString('Starting playlist sync process', $contents);
-        self::assertStringContainsString('Playlist sync process completed', $contents);
+        self::assertStringContainsString('Playlist sync started for 1 users.', $contents);
+        self::assertStringContainsString('Playlist sync completed for 1 users in', $contents);
     }
 
     public function test_selected_user_only(): void
@@ -229,7 +230,7 @@ final class PlaylistCommandTest extends TestCase
             $this->seedTestServersConfig($name);
         }
 
-        $logger = new Logger('test');
+        $logger = new Logger('test', processors: [new LogMessageProcessor()]);
         $mapper = new DirectMapper($logger, $this->createDb($logger), new Psr16Cache(new ArrayAdapter()));
 
         return new class($service, $mapper, $logger, $client, $backendName) extends PlaylistCommand {

--- a/tests/Commands/State/ValidateCommandTest.php
+++ b/tests/Commands/State/ValidateCommandTest.php
@@ -6,11 +6,14 @@ namespace Tests\Commands\State;
 
 use App\Commands\State\ValidateCommand;
 use App\Libs\Entity\StateInterface as iState;
+use App\Libs\Extends\LogMessageProcessor;
 use App\Libs\LogSuppressor;
 use App\Libs\Mappers\ImportInterface as iImport;
 use App\Libs\TestCase;
+use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Tests\Support\FakeBackendClient;
 use Tests\Support\StateCommandTestSupport;
@@ -22,6 +25,7 @@ final class ValidateCommandTest extends TestCase
     public function test_remove_last_missing_record(): void
     {
         $logger = $this->initFakeBackendApp($this->fakeBackendConfig('fake_validate'));
+        $logger->pushProcessor(new LogMessageProcessor());
         $userContext = $this->makeUserContext('main', $logger);
 
         $entity = require __DIR__ . '/../../Fixtures/MovieEntity.php';
@@ -54,6 +58,32 @@ final class ValidateCommandTest extends TestCase
         ], FakeBackendClient::getCalls('metadata'));
     }
 
+    public function test_logfile_lifecycle(): void
+    {
+        $logger = $this->initFakeBackendApp($this->fakeBackendConfig('fake_validate'));
+        $logger->pushProcessor(new LogMessageProcessor());
+        $this->migrateMainDb($logger);
+
+        $logfile = self::$tmpPath . '/validate-log.txt';
+        touch($logfile);
+
+        $command = new ValidateCommand($this->createMockMapper(), $logger, new LogSuppressor([]));
+        $tester = $this->makeTester($command);
+        $status = $tester->execute([
+            '--logfile' => $logfile,
+        ], [
+            'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
+        ]);
+
+        self::assertSame(ValidateCommand::SUCCESS, $status);
+
+        $contents = file_get_contents($logfile);
+        self::assertIsString($contents);
+        self::assertStringContainsString('Validation started for 1 users.', $contents);
+        self::assertStringContainsString("Validating local metadata references for 'main'.", $contents);
+        self::assertStringContainsString('Validation completed for 1 users in', $contents);
+    }
+
     public function test_invalid_user_returns_failure(): void
     {
         $command = new ValidateCommand($this->createMockMapper(), new Logger('test'), new LogSuppressor([]));
@@ -74,6 +104,7 @@ final class ValidateCommandTest extends TestCase
                 'alice' => $this->fakeBackendConfig('fake_validate'),
             ],
         );
+        $logger->pushProcessor(new LogMessageProcessor());
 
         $mainContext = $this->makeUserContext('main', $logger);
         $aliceContext = $this->makeUserContext('alice', $logger);
@@ -114,6 +145,55 @@ final class ValidateCommandTest extends TestCase
                 'id' => '602',
             ],
         ], FakeBackendClient::getCalls('metadata'));
+    }
+
+    public function test_logs_failed_metadata_lookup(): void
+    {
+        $logger = $this->initFakeBackendApp($this->fakeBackendConfig('fake_validate'));
+        $handler = new TestHandler();
+        $logger->setHandlers([$handler]);
+        $logger->pushProcessor(new LogMessageProcessor());
+        $userContext = $this->makeUserContext('main', $logger);
+
+        $entity = require __DIR__ . '/../../Fixtures/MovieEntity.php';
+        $entity[iState::COLUMN_VIA] = 'fake_validate';
+        $entity[iState::COLUMN_META_DATA] = [
+            'fake_validate' => [
+                iState::COLUMN_ID => 777,
+                iState::COLUMN_TYPE => iState::TYPE_MOVIE,
+                iState::COLUMN_WATCHED => 1,
+            ],
+        ];
+
+        $userContext->db->insert(new \App\Libs\Entity\StateEntity($entity));
+        FakeBackendClient::setMetadataResponse('main', 'fake_validate', 777, new \RuntimeException('boom'));
+
+        $command = new ValidateCommand($this->createMockMapper(), $logger, new LogSuppressor([]));
+        $status = $this->makeTester($command)->execute([]);
+
+        self::assertSame(ValidateCommand::SUCCESS, $status);
+
+        $records = array_values(array_filter(
+            $handler->getRecords(),
+            static fn($record): bool => 'state.validate.reference.removed' === ($record->context['event_name'] ?? null),
+        ));
+
+        self::assertNotEmpty($records);
+
+        $match = array_values(array_filter(
+            $records,
+            static fn($record): bool => 'metadata_lookup_failed' === ($record->context['reason'] ?? null),
+        ));
+
+        self::assertCount(1, $match);
+        self::assertSame(
+            "Removing 'main@fake_validate' reference '777' from item '#1': metadata lookup failed.",
+            $match[0]->message,
+        );
+        self::assertSame('main', $match[0]->context['user']);
+        self::assertSame('fake_validate', $match[0]->context['backend']);
+        self::assertSame('777', (string) $match[0]->context['item_id']);
+        self::assertSame(\RuntimeException::class, $match[0]->context['error']['type']);
     }
 
     private function makeTester(ValidateCommand $command): CommandTester

--- a/tests/Commands/System/BenchmarkDirectMapperCommandTest.php
+++ b/tests/Commands/System/BenchmarkDirectMapperCommandTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands\System;
+
+use App\Commands\System\BenchmarkDirectMapperCommand;
+use App\Libs\TestCase;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Symfony\Component\Console\Input\InputInterface as iInput;
+
+final class BenchmarkDirectMapperCommandTest extends TestCase
+{
+    public function test_logs_report_created(): void
+    {
+        $this->initTempDir();
+
+        $handler = new TestHandler();
+        $logger = new Logger('test', [$handler]);
+        $command = new BenchmarkDirectMapperCommand($this->createStub(\App\Libs\Mappers\ImportInterface::class), $logger);
+        $path = \Closure::bind(
+            static fn(BenchmarkDirectMapperCommand $command, array $report, array $lines, string $benchDir, float $startedAt): ?string =>
+                $command->storeReport($report, $lines, $benchDir, $startedAt),
+            null,
+            BenchmarkDirectMapperCommand::class,
+        )(
+            $command,
+            ['desc' => 'baseline'],
+            ['line 1'],
+            self::$tmpPath . '/benchmarks',
+            microtime(true) - 0.5,
+        );
+
+        self::assertIsString($path);
+        self::assertFileExists($path);
+
+        $records = $handler->getRecords();
+        self::assertSame('benchmark.report.created', $records[0]->context['event_name']);
+        self::assertSame($path, $records[0]->context['path']);
+    }
+
+    public function test_logs_compare_missing_baseline(): void
+    {
+        $handler = new TestHandler();
+        $logger = new Logger('test', [$handler]);
+        $command = new BenchmarkDirectMapperCommand($this->createStub(\App\Libs\Mappers\ImportInterface::class), $logger);
+        $input = $this->createMock(iInput::class);
+        $input->expects($this->once())->method('getOption')->with('compare')->willReturn('/missing/baseline.txt');
+
+        self::assertNull(\Closure::bind(
+            static fn(BenchmarkDirectMapperCommand $command, iInput $input, string $benchDir): ?string =>
+                $command->resolveComparePath($input, $benchDir),
+            null,
+            BenchmarkDirectMapperCommand::class,
+        )($command, $input, '/unused'));
+
+        $records = $handler->getRecords();
+        self::assertSame('benchmark.compare.failed', $records[0]->context['event_name']);
+        self::assertSame('baseline_not_found', $records[0]->context['reason']);
+    }
+}

--- a/tests/Commands/System/LogsCommandTest.php
+++ b/tests/Commands/System/LogsCommandTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands\System;
+
+use App\Cli;
+use App\Commands\System\LogsCommand;
+use App\Libs\Extends\PSRContainer;
+use App\Libs\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class LogsCommandTest extends TestCase
+{
+    public function test_jsonl(): void
+    {
+        $this->initTempApp();
+
+        $date = make_date()->format('Ymd');
+        $logPath = self::$tmpPath . '/logs/app.' . $date . '.jsonl';
+        mkdir(dirname($logPath), 0o755, true);
+
+        $line = json_encode([
+            'id' => 'log-id',
+            'datetime' => '2026-05-20T12:00:00.123+00:00',
+            'level' => 'notice',
+            'levelno' => LOG_NOTICE,
+            'logger' => 'app',
+            'message' => "Importing 'main'.",
+            'source' => ['module' => 'app'],
+            'process' => ['id' => 1, 'name' => 'cli'],
+            'thread' => ['id' => 0, 'name' => 'main'],
+            'fields' => ['user' => 'main'],
+        ], JSON_THROW_ON_ERROR);
+
+        file_put_contents($logPath, $line . PHP_EOL);
+
+        $tester = $this->makeTester();
+        $status = $tester->execute([
+            '--type' => 'app',
+            '--date' => $date,
+            '--limit' => 1,
+        ]);
+
+        self::assertSame(LogsCommand::SUCCESS, $status);
+        self::assertStringContainsString(
+            make_date('2026-05-20T12:00:00.123+00:00')->format('m/d, H:i:s') . " main NOTICE app Importing 'main'.",
+            $tester->getDisplay(),
+        );
+        self::assertStringNotContainsString($line, $tester->getDisplay());
+    }
+
+    public function test_json_output(): void
+    {
+        $this->initTempApp();
+
+        $date = make_date()->format('Ymd');
+        $logPath = self::$tmpPath . '/logs/app.' . $date . '.jsonl';
+        mkdir(dirname($logPath), 0o755, true);
+
+        $line = json_encode([
+            'id' => 'log-id',
+            'datetime' => '2026-05-20T12:00:00.123+00:00',
+            'level' => 'notice',
+            'levelno' => LOG_NOTICE,
+            'logger' => 'app',
+            'message' => "Importing 'main'.",
+            'source' => ['module' => 'app'],
+            'process' => ['id' => 1, 'name' => 'cli'],
+            'thread' => ['id' => 0, 'name' => 'main'],
+            'fields' => ['user' => 'main'],
+        ], JSON_THROW_ON_ERROR);
+
+        file_put_contents($logPath, $line . PHP_EOL);
+
+        $tester = $this->makeTester();
+        $status = $tester->execute([
+            '--type' => 'app',
+            '--date' => $date,
+            '--limit' => 1,
+            '--output' => 'json',
+        ]);
+
+        self::assertSame(LogsCommand::SUCCESS, $status);
+        self::assertStringContainsString('"logger": "app"', $tester->getDisplay());
+        self::assertStringContainsString('"message": "Importing \'main\'."', $tester->getDisplay());
+        self::assertStringNotContainsString(
+            make_date('2026-05-20T12:00:00.123+00:00')->format('m/d, H:i:s') . " main NOTICE app Importing 'main'.",
+            $tester->getDisplay(),
+        );
+    }
+
+    public function test_jsonl_flag(): void
+    {
+        $this->initTempApp();
+
+        $date = make_date()->format('Ymd');
+        $logPath = self::$tmpPath . '/logs/app.' . $date . '.jsonl';
+        mkdir(dirname($logPath), 0o755, true);
+
+        $line = json_encode([
+            'id' => 'log-id',
+            'datetime' => '2026-05-20T12:00:00.123+00:00',
+            'level' => 'notice',
+            'levelno' => LOG_NOTICE,
+            'logger' => 'app',
+            'message' => "Importing 'main'.",
+            'source' => ['module' => 'app'],
+            'process' => ['id' => 1, 'name' => 'cli'],
+            'thread' => ['id' => 0, 'name' => 'main'],
+            'fields' => ['user' => 'main'],
+        ], JSON_THROW_ON_ERROR);
+
+        file_put_contents($logPath, $line . PHP_EOL);
+
+        $tester = $this->makeTester();
+        $status = $tester->execute([
+            '--type' => 'app',
+            '--date' => $date,
+            '--limit' => 1,
+            '--jsonl' => true,
+        ]);
+
+        self::assertSame(LogsCommand::SUCCESS, $status);
+        self::assertStringContainsString($line, $tester->getDisplay());
+    }
+
+    public function test_empty_jsonl_message_skipped(): void
+    {
+        $this->initTempApp();
+
+        $date = make_date()->format('Ymd');
+        $logPath = self::$tmpPath . '/logs/task.' . $date . '.jsonl';
+        mkdir(dirname($logPath), 0o755, true);
+
+        $lines = [
+            json_encode([
+                'id' => 'empty-log-id',
+                'datetime' => '2026-05-20T12:00:00.123+00:00',
+                'level' => 'info',
+                'levelno' => LOG_INFO,
+                'logger' => 'task',
+                'message' => '',
+                'source' => ['module' => 'task'],
+                'process' => ['id' => 1, 'name' => 'cli'],
+                'thread' => ['id' => 0, 'name' => 'main'],
+                'fields' => ['task_id' => 'indexes'],
+            ], JSON_THROW_ON_ERROR),
+            json_encode([
+                'id' => 'log-id',
+                'datetime' => '2026-05-20T12:00:01.123+00:00',
+                'level' => 'info',
+                'levelno' => LOG_INFO,
+                'logger' => 'task',
+                'message' => 'Task finished.',
+                'source' => ['module' => 'task'],
+                'process' => ['id' => 1, 'name' => 'cli'],
+                'thread' => ['id' => 0, 'name' => 'main'],
+                'fields' => ['task_id' => 'indexes'],
+            ], JSON_THROW_ON_ERROR),
+        ];
+
+        file_put_contents($logPath, implode(PHP_EOL, $lines) . PHP_EOL);
+
+        $tester = $this->makeTester();
+        $status = $tester->execute([
+            '--type' => 'task',
+            '--date' => $date,
+            '--limit' => 2,
+        ]);
+
+        self::assertSame(LogsCommand::SUCCESS, $status);
+
+        $outputLines = array_values(array_filter(explode(PHP_EOL, trim($tester->getDisplay()))));
+
+        self::assertCount(1, $outputLines);
+        self::assertStringContainsString('Task finished.', $outputLines[0]);
+    }
+
+    private function makeTester(): CommandTester
+    {
+        $application = new Cli(new PSRContainer());
+        $application->addCommand(new LogsCommand());
+
+        return new CommandTester($application->find(LogsCommand::ROUTE));
+    }
+}

--- a/tests/Commands/System/TasksCommandTest.php
+++ b/tests/Commands/System/TasksCommandTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands\System;
+
+use App\Commands\System\TasksCommand;
+use App\Libs\Extends\ConsoleOutput;
+use App\Libs\LogSuppressor;
+use App\Libs\TestCase;
+use App\Model\Events\EventsRepository;
+use Psr\Log\LoggerInterface as iLogger;
+use Psr\SimpleCache\CacheInterface as iCache;
+use ReflectionMethod;
+use ReflectionProperty;
+use Symfony\Component\Console\Input\InputInterface;
+
+final class TasksCommandTest extends TestCase
+{
+    public function test_wraps_task_output_as_jsonl(): void
+    {
+        $command = new TasksCommand(
+            $this->createStub(EventsRepository::class),
+            new LogSuppressor([]),
+            $this->createStub(iCache::class),
+            $this->createStub(iLogger::class),
+        );
+
+        $logContext = new ReflectionProperty(TasksCommand::class, 'logContext');
+        $logContext->setValue($command, [
+            'task_id' => 'backup',
+            'command' => 'state:backup',
+            'source' => 'task',
+        ]);
+
+        $input = $this->createMock(InputInterface::class);
+        $input->expects($this->once())->method('hasOption')->with('live')->willReturn(true);
+        $input->expects($this->once())->method('getOption')->with('live')->willReturn(false);
+
+        $method = new ReflectionMethod(TasksCommand::class, 'captureProcessOutputLine');
+        $method->invoke($command, 'out', 'processed 5 items', $input, new ConsoleOutput());
+
+        $taskOutput = new ReflectionProperty(TasksCommand::class, 'taskOutput');
+        $logs = $taskOutput->getValue($command);
+
+        self::assertCount(1, $logs);
+        self::assertTrue(\App\Libs\Extends\JsonlFormatter::isJsonlRecord($logs[0]));
+
+        $payload = json_decode(trim($logs[0]), true, flags: JSON_THROW_ON_ERROR);
+
+        self::assertSame("stdout from task 'backup': processed 5 items", $payload['message']);
+        self::assertSame('task.output', ag($payload, 'fields.event_name'));
+        self::assertSame('stdout', ag($payload, 'fields.stream'));
+        self::assertSame('processed 5 items', ag($payload, 'fields.line'));
+        self::assertSame(1, ag($payload, 'fields.line_number'));
+        self::assertSame('backup', ag($payload, 'fields.task_id'));
+        self::assertSame('state:backup', ag($payload, 'fields.command'));
+    }
+}

--- a/tests/Database/DBLayerTest.php
+++ b/tests/Database/DBLayerTest.php
@@ -436,6 +436,11 @@ class DBLayerTest extends TestCase
             array_map(static fn($record): int => $record->level->value, $records),
             'Lock retries should stay at info until the last retry before failure, which should warn.',
         );
+        $this->assertSame(
+            ['database.lock.retry', 'database.lock.retry', 'database.lock.retry', 'database.lock.retry'],
+            array_map(static fn($record): ?string => $record->context['event_name'] ?? null, $records),
+            'Lock retry logs should use a stable event name for queries.',
+        );
 
         $this->handler?->clear();
 

--- a/tests/Database/PDOAdapterTest.php
+++ b/tests/Database/PDOAdapterTest.php
@@ -19,6 +19,7 @@ use App\Libs\TestCase;
 use DateInterval;
 use DateTimeImmutable;
 use Monolog\Logger;
+use Monolog\Handler\TestHandler;
 use PDO;
 use Psr\SimpleCache\CacheInterface;
 use Tests\Support\SQLiteDbTestSupport;
@@ -339,7 +340,10 @@ class PDOAdapterTest extends TestCase
 
         try {
             $this->checkException(
-                closure: fn() => $db->insert(new StateEntity($this->testEpisode), [Options::FAIL_FAST_ON_LOCK => true]),
+                closure: fn() => $db->insert(new StateEntity($this->testEpisode), [
+                    Options::FAIL_FAST_ON_LOCK => true,
+                    'max_sleep' => 0,
+                ]),
                 reason: 'Fail-fast lock errors should bubble out of insert.',
                 exception: DBLayerException::class,
                 exceptionMessage: 'database is locked',
@@ -368,11 +372,47 @@ class PDOAdapterTest extends TestCase
 
         try {
             $this->checkException(
-                closure: fn() => $db->update($item, [Options::FAIL_FAST_ON_LOCK => true]),
+                closure: fn() => $db->update($item, [
+                    Options::FAIL_FAST_ON_LOCK => true,
+                    'max_sleep' => 0,
+                ]),
                 reason: 'Fail-fast lock errors should bubble out of update.',
                 exception: DBLayerException::class,
                 exceptionMessage: 'database is locked',
             );
+        } finally {
+            if (true === $lock->inTransaction()) {
+                $lock->rollBack();
+            }
+        }
+    }
+
+    public function test_insert_lock_logs_structured_failure(): void
+    {
+        $handler = new TestHandler();
+        $logger = new Logger('logger', [$handler]);
+        $this->initTempDir();
+        [$db, , $path] = $this->createFileDb($logger, self::$tmpPath . '/lock-logged-insert.db');
+        $db->setOptions([
+            Options::DEBUG_TRACE => true,
+            'class' => new StateEntity([]),
+        ]);
+        $db->setLogger($logger);
+
+        $lock = $this->openSqliteFile($path);
+        $lock->exec('BEGIN EXCLUSIVE');
+
+        try {
+            $entity = $db->insert(new StateEntity($this->testEpisode), ['max_sleep' => 0]);
+
+            self::assertNull($entity->id, 'Non-transaction insert failures should keep behavior and return the unsaved entity.');
+            self::assertTrue($handler->hasErrorRecords(), 'Insert lock failures should be logged.');
+
+            $records = $handler->getRecords();
+            $record = end($records);
+            self::assertSame('database.state.operation_failed', $record->context['event_name'] ?? null);
+            self::assertSame('insert', $record->context['operation'] ?? null);
+            self::assertSame('episode', $record->context['item_type'] ?? null);
         } finally {
             if (true === $lock->inTransaction()) {
                 $lock->rollBack();

--- a/tests/Libs/Events/DataEventTest.php
+++ b/tests/Libs/Events/DataEventTest.php
@@ -6,6 +6,7 @@ namespace Tests\Libs\Events;
 
 use App\Libs\Container;
 use App\Libs\Events\DataEvent;
+use App\Libs\Extends\JsonlFormatter;
 use App\Libs\TestCase;
 use App\Model\Events\Event;
 use App\Model\Events\EventsTable;
@@ -38,7 +39,7 @@ class DataEventTest extends TestCase
         $this->initContainer();
     }
 
-    public function test_initial_state()
+    public function test_initial_state(): void
     {
         $dataEvent = $this->getDataEvent();
 
@@ -52,21 +53,60 @@ class DataEventTest extends TestCase
             'getOptions() does not return the expected value');
     }
 
-    public function test_logs_mutation()
+    public function test_logs_mutation(): void
     {
         $dataEvent = $this->getDataEvent();
 
         $this->assertSame(['test entry'], $dataEvent->getLogs(), 'getLogs() does not return the expected value');
         $dataEvent->addLog('new entry');
 
-        $this->assertSame(['test entry', 'new entry'],
-            $dataEvent->getLogs(),
-            'addLog() does not return the expected value');
+        $logs = $dataEvent->getLogs();
+
+        $this->assertCount(2, $logs, 'addLog() should append a new entry.');
+        $this->assertSame('test entry', $logs[0], 'Existing legacy entries should remain unchanged.');
+        $this->assertTrue(JsonlFormatter::isJsonlRecord($logs[1]), 'New log entries should be normalized to JSONL.');
 
         for ($i = 0; $i < 203; $i++) {
             $dataEvent->addLog('new entry');
         }
 
         $this->assertCount(200, $dataEvent->getLogs(), 'addLog() Logs should not exceed 200 entries per event.');
+    }
+
+    public function test_addLog_normalizes_jsonl(): void
+    {
+        $dataEvent = $this->getDataEvent();
+        $dataEvent->clearLogs();
+
+        $dataEvent->addLog('NOTICE: Listener visible');
+
+        $logs = $dataEvent->getLogs();
+
+        $this->assertCount(1, $logs);
+        $this->assertTrue(JsonlFormatter::isJsonlRecord($logs[0]));
+
+        $record = json_decode(trim($logs[0]), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame('notice', ag($record, 'level'));
+        $this->assertSame('NOTICE: Listener visible', ag($record, 'message'));
+        $this->assertSame((string) $dataEvent->getEvent()->id, ag($record, 'fields.event_id'));
+        $this->assertSame($dataEvent->getEvent()->event, ag($record, 'fields.event'));
+    }
+
+    public function test_addLog_keeps_jsonl(): void
+    {
+        $dataEvent = $this->getDataEvent();
+        $dataEvent->clearLogs();
+
+        $line = (new JsonlFormatter())->formatValues(
+            channel: 'event',
+            level: \Monolog\Level::Info,
+            message: 'already structured',
+            context: ['event_id' => (string) $dataEvent->getEvent()->id],
+        );
+
+        $dataEvent->addLog($line);
+
+        $this->assertSame($line, $dataEvent->getLogs()[0]);
     }
 }

--- a/tests/Libs/Events/DataEventTest.php
+++ b/tests/Libs/Events/DataEventTest.php
@@ -7,10 +7,14 @@ namespace Tests\Libs\Events;
 use App\Libs\Container;
 use App\Libs\Events\DataEvent;
 use App\Libs\Extends\JsonlFormatter;
+use App\Libs\Options;
 use App\Libs\TestCase;
 use App\Model\Events\Event;
 use App\Model\Events\EventsTable;
 use App\Model\Events\EventStatus;
+use DateTimeImmutable;
+use Monolog\Level;
+use Monolog\LogRecord;
 
 class DataEventTest extends TestCase
 {
@@ -73,7 +77,7 @@ class DataEventTest extends TestCase
         $this->assertCount(200, $dataEvent->getLogs(), 'addLog() Logs should not exceed 200 entries per event.');
     }
 
-    public function test_addLog_normalizes_jsonl(): void
+    public function test_log_string_jsonl(): void
     {
         $dataEvent = $this->getDataEvent();
         $dataEvent->clearLogs();
@@ -93,14 +97,14 @@ class DataEventTest extends TestCase
         $this->assertSame($dataEvent->getEvent()->event, ag($record, 'fields.event'));
     }
 
-    public function test_addLog_keeps_jsonl(): void
+    public function test_log_jsonl_keep(): void
     {
         $dataEvent = $this->getDataEvent();
         $dataEvent->clearLogs();
 
         $line = (new JsonlFormatter())->formatValues(
             channel: 'event',
-            level: \Monolog\Level::Info,
+            level: Level::Info,
             message: 'already structured',
             context: ['event_id' => (string) $dataEvent->getEvent()->id],
         );
@@ -108,5 +112,83 @@ class DataEventTest extends TestCase
         $dataEvent->addLog($line);
 
         $this->assertSame($line, $dataEvent->getLogs()[0]);
+    }
+
+    public function test_debug_entry_skip(): void
+    {
+        $dataEvent = $this->getDataEvent();
+        $dataEvent->clearLogs();
+
+        $dataEvent->addLogEntry(Level::Debug, 'hidden debug');
+
+        $this->assertSame([], $dataEvent->getLogs());
+    }
+
+    public function test_debug_entry_trace(): void
+    {
+        $dataEvent = $this->getDataEvent([
+            EventsTable::COLUMN_ID => generate_uuid(),
+            EventsTable::COLUMN_STATUS => EventStatus::PENDING->value,
+            EventsTable::COLUMN_REFERENCE => 'test',
+            EventsTable::COLUMN_EVENT => 'test',
+            EventsTable::COLUMN_EVENT_DATA => json_encode(['foo' => 'bar']),
+            EventsTable::COLUMN_OPTIONS => json_encode([Options::DEBUG_TRACE => true]),
+            EventsTable::COLUMN_ATTEMPTS => 0,
+            EventsTable::COLUMN_LOGS => json_encode([]),
+            EventsTable::COLUMN_CREATED_AT => '2024-01-01 01:01:01',
+            EventsTable::COLUMN_UPDATED_AT => '2024-01-02 02:02:02',
+        ]);
+
+        $dataEvent->addLogEntry(Level::Debug, 'visible debug');
+
+        $logs = $dataEvent->getLogs();
+
+        $this->assertCount(1, $logs);
+        $payload = json_decode(trim($logs[0]), true, flags: JSON_THROW_ON_ERROR);
+        $this->assertSame('debug', ag($payload, 'level'));
+        $this->assertSame('visible debug', ag($payload, 'message'));
+    }
+
+    public function test_debug_record_skip(): void
+    {
+        $dataEvent = $this->getDataEvent();
+        $dataEvent->clearLogs();
+
+        $dataEvent->addLog(
+            'DEBUG: hidden debug',
+            new LogRecord(
+                datetime: new DateTimeImmutable('2026-05-20T12:00:00+00:00'),
+                channel: 'event',
+                level: Level::Debug,
+                message: 'hidden debug',
+                context: [],
+            ),
+        );
+
+        $this->assertSame([], $dataEvent->getLogs());
+    }
+
+    public function test_info_record_keep(): void
+    {
+        $dataEvent = $this->getDataEvent();
+        $dataEvent->clearLogs();
+
+        $dataEvent->addLog(
+            'INFO: visible info',
+            new LogRecord(
+                datetime: new DateTimeImmutable('2026-05-20T12:00:00+00:00'),
+                channel: 'event',
+                level: Level::Info,
+                message: 'visible info',
+                context: [],
+            ),
+        );
+
+        $logs = $dataEvent->getLogs();
+
+        $this->assertCount(1, $logs);
+        $payload = json_decode(trim($logs[0]), true, flags: JSON_THROW_ON_ERROR);
+        $this->assertSame('info', ag($payload, 'level'));
+        $this->assertSame('visible info', ag($payload, 'message'));
     }
 }

--- a/tests/Libs/Events/DataEventTest.php
+++ b/tests/Libs/Events/DataEventTest.php
@@ -94,7 +94,8 @@ class DataEventTest extends TestCase
         $this->assertSame('notice', ag($record, 'level'));
         $this->assertSame('NOTICE: Listener visible', ag($record, 'message'));
         $this->assertSame((string) $dataEvent->getEvent()->id, ag($record, 'fields.event_id'));
-        $this->assertSame($dataEvent->getEvent()->event, ag($record, 'fields.event'));
+        $this->assertSame($dataEvent->getEvent()->event, ag($record, 'fields.queued_event'));
+        $this->assertNull(ag($record, 'fields.event'));
     }
 
     public function test_log_jsonl_keep(): void
@@ -147,6 +148,7 @@ class DataEventTest extends TestCase
         $payload = json_decode(trim($logs[0]), true, flags: JSON_THROW_ON_ERROR);
         $this->assertSame('debug', ag($payload, 'level'));
         $this->assertSame('visible debug', ag($payload, 'message'));
+        $this->assertSame('test', ag($payload, 'fields.queued_event'));
     }
 
     public function test_debug_record_skip(): void
@@ -190,5 +192,6 @@ class DataEventTest extends TestCase
         $payload = json_decode(trim($logs[0]), true, flags: JSON_THROW_ON_ERROR);
         $this->assertSame('info', ag($payload, 'level'));
         $this->assertSame('visible info', ag($payload, 'message'));
+        $this->assertSame('test', ag($payload, 'fields.queued_event'));
     }
 }

--- a/tests/Libs/Extends/ConsoleHandlerTest.php
+++ b/tests/Libs/Extends/ConsoleHandlerTest.php
@@ -25,7 +25,7 @@ final class ConsoleHandlerTest extends TestCase
             datetime: $date,
             channel: 'logger',
             level: Level::Warning,
-            message: 'SYSTEM: Playlist sync completed without any syncable playlist results.',
+            message: 'Playlist sync completed without syncable results across 2 users.',
         ));
 
         $raw = $output->fetch();
@@ -34,7 +34,7 @@ final class ConsoleHandlerTest extends TestCase
         self::assertStringContainsString("\033[", $raw);
         self::assertIsString($display);
         self::assertSame(
-            make_date($date)->format('m/d, H:i:s') . ' logger WARNING logger SYSTEM: Playlist sync completed without any syncable playlist results.' . PHP_EOL,
+            make_date($date)->format('m/d, H:i:s') . ' logger WARNING logger Playlist sync completed without syncable results across 2 users.' . PHP_EOL,
             $display,
         );
     }
@@ -49,11 +49,11 @@ final class ConsoleHandlerTest extends TestCase
             datetime: $date,
             channel: 'logger',
             level: Level::Warning,
-            message: 'SYSTEM: Playlist sync completed without any syncable playlist results.',
+            message: 'Playlist sync completed without syncable results across 2 users.',
         ));
 
         self::assertSame(
-            '[' . $date->format(DateTimeInterface::ATOM) . '] WARNING: SYSTEM: Playlist sync completed without any syncable playlist results.' . PHP_EOL,
+            '[' . $date->format(DateTimeInterface::ATOM) . '] WARNING: Playlist sync completed without syncable results across 2 users.' . PHP_EOL,
             $output->fetch(),
         );
     }
@@ -67,7 +67,7 @@ final class ConsoleHandlerTest extends TestCase
             datetime: new DateTimeImmutable('2026-05-21T07:36:40+03:00'),
             channel: 'logger',
             level: Level::Notice,
-            message: "SYSTEM: Status for 'tester' Movie: '0000' added, '0003' updated and '0000' failed.",
+            message: "Playlist summary for 'tester@office_plex': 0 playlists, 3 items, added 0, updated 3, removed 0.",
             context: ['user' => 'tester'],
         ));
 
@@ -76,5 +76,33 @@ final class ConsoleHandlerTest extends TestCase
         self::assertStringContainsString('NOTICE', $raw);
         self::assertStringContainsString("\033[35", $raw);
         self::assertStringNotContainsString("\033[31", $raw);
+    }
+
+    public function test_event_name_host_fallback(): void
+    {
+        $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+        $handler = new ConsoleHandler($output);
+        $date = new DateTimeImmutable('2026-05-21T07:36:40+03:00');
+
+        $handler->handle(new LogRecord(
+            datetime: $date,
+            channel: 'logger',
+            level: Level::Warning,
+            message: "Skipping playlist backend 'main@office_plex': type 'bad' is unsupported.",
+            context: [
+                'event_name' => 'playlist.backend.skipped',
+                'backend' => [
+                    'name' => 'office_plex',
+                ],
+            ],
+        ));
+
+        $display = preg_replace('/\x1b\[[0-9;]*m/', '', $output->fetch());
+
+        self::assertIsString($display);
+        self::assertSame(
+            make_date($date)->format('m/d, H:i:s') . " office_plex WARNING logger Skipping playlist backend 'main@office_plex': type 'bad' is unsupported." . PHP_EOL,
+            $display,
+        );
     }
 }

--- a/tests/Libs/Extends/ConsoleHandlerTest.php
+++ b/tests/Libs/Extends/ConsoleHandlerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Libs\Extends;
+
+use App\Libs\Extends\ConsoleHandler;
+use App\Libs\TestCase;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Monolog\Level;
+use Monolog\LogRecord;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class ConsoleHandlerTest extends TestCase
+{
+    public function test_decorated_compact(): void
+    {
+        $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+        $handler = new ConsoleHandler($output);
+        $date = new DateTimeImmutable('2026-05-21T06:54:10+03:00');
+
+        $handler->handle(new LogRecord(
+            datetime: $date,
+            channel: 'logger',
+            level: Level::Warning,
+            message: 'SYSTEM: Playlist sync completed without any syncable playlist results.',
+        ));
+
+        $raw = $output->fetch();
+        $display = preg_replace('/\x1b\[[0-9;]*m/', '', $raw);
+
+        self::assertStringContainsString("\033[", $raw);
+        self::assertIsString($display);
+        self::assertSame(
+            make_date($date)->format('m/d, H:i:s') . ' logger WARNING logger SYSTEM: Playlist sync completed without any syncable playlist results.' . PHP_EOL,
+            $display,
+        );
+    }
+
+    public function test_plain_legacy(): void
+    {
+        $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, false);
+        $handler = new ConsoleHandler($output);
+        $date = new DateTimeImmutable('2026-05-21T06:54:10+03:00');
+
+        $handler->handle(new LogRecord(
+            datetime: $date,
+            channel: 'logger',
+            level: Level::Warning,
+            message: 'SYSTEM: Playlist sync completed without any syncable playlist results.',
+        ));
+
+        self::assertSame(
+            '[' . $date->format(DateTimeInterface::ATOM) . '] WARNING: SYSTEM: Playlist sync completed without any syncable playlist results.' . PHP_EOL,
+            $output->fetch(),
+        );
+    }
+
+    public function test_notice_failed_not_red(): void
+    {
+        $output = new BufferedOutput(OutputInterface::VERBOSITY_VERBOSE, true);
+        $handler = new ConsoleHandler($output);
+
+        $handler->handle(new LogRecord(
+            datetime: new DateTimeImmutable('2026-05-21T07:36:40+03:00'),
+            channel: 'logger',
+            level: Level::Notice,
+            message: "SYSTEM: Status for 'tester' Movie: '0000' added, '0003' updated and '0000' failed.",
+            context: ['user' => 'tester'],
+        ));
+
+        $raw = $output->fetch();
+
+        self::assertStringContainsString('NOTICE', $raw);
+        self::assertStringContainsString("\033[35", $raw);
+        self::assertStringNotContainsString("\033[31", $raw);
+    }
+}

--- a/tests/Libs/Extends/ConsoleLogFormatterTest.php
+++ b/tests/Libs/Extends/ConsoleLogFormatterTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Libs\Extends;
+
+use App\Libs\Extends\ConsoleLogFormatter;
+use App\Libs\TestCase;
+use DateTimeImmutable;
+
+final class ConsoleLogFormatterTest extends TestCase
+{
+    public function test_backend_host(): void
+    {
+        $formatter = new ConsoleLogFormatter();
+        $date = new DateTimeImmutable('2026-05-21T07:36:40+03:00');
+
+        $line = $formatter->format([
+            'datetime' => $date,
+            'level' => 'warning',
+            'logger' => 'logger',
+            'message' => 'Skipping backend.',
+            'fields' => [
+                'backend' => [
+                    'name' => 'office_plex',
+                ],
+            ],
+        ]);
+
+        self::assertSame(
+            sprintf(
+                '<comment>%s</comment> <info>office_plex</info> <fg=yellow;options=bold>WARNING</> <fg=cyan>logger</> Skipping backend.',
+                make_date($date)->format('m/d, H:i:s'),
+            ),
+            $line,
+        );
+    }
+
+    public function test_event_name_host(): void
+    {
+        $formatter = new ConsoleLogFormatter();
+        $date = new DateTimeImmutable('2026-05-21T07:36:40+03:00');
+
+        $line = $formatter->format([
+            'datetime' => $date,
+            'level' => 'info',
+            'logger' => 'logger',
+            'message' => 'Request completed.',
+            'fields' => [
+                'event_name' => 'http.request.completed',
+            ],
+            'source' => [],
+            'process' => [],
+        ]);
+
+        self::assertSame(
+            sprintf(
+                '<comment>%s</comment> <info>http.request.completed</info> <fg=cyan;options=bold>INFO</> <fg=cyan>logger</> Request completed.',
+                make_date($date)->format('m/d, H:i:s'),
+            ),
+            $line,
+        );
+    }
+
+    public function test_notice_color_only_uses_level(): void
+    {
+        $formatter = new ConsoleLogFormatter();
+        $line = $formatter->format([
+            'datetime' => new DateTimeImmutable('2026-05-21T07:36:40+03:00'),
+            'level' => 'notice',
+            'logger' => 'logger',
+            'message' => 'Import failed for one item.',
+            'fields' => [
+                'user' => 'main',
+            ],
+        ]);
+
+        self::assertStringContainsString('<fg=magenta;options=bold>NOTICE</>', $line);
+        self::assertStringNotContainsString('<fg=red;options=bold>NOTICE</>', $line);
+        self::assertStringContainsString('Import failed for one item.', $line);
+    }
+}

--- a/tests/Libs/Extends/HttpClientTest.php
+++ b/tests/Libs/Extends/HttpClientTest.php
@@ -33,7 +33,9 @@ final class HttpClientTest extends TestCase
         self::assertCount(1, $records);
         self::assertSame(
             'https://example.test/items?userId=user-1&enableUserData=true&enableImages=false',
-            $records[0]['context']['url'],
+            $records[0]['context']['http']['url'],
         );
+        self::assertSame('http.client.request.started', $records[0]['context']['event_name']);
+        self::assertSame('GET', $records[0]['context']['http']['method']);
     }
 }

--- a/tests/Libs/Extends/StreamLogHandlerTest.php
+++ b/tests/Libs/Extends/StreamLogHandlerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Libs\Extends;
+
+use App\Libs\Config;
+use App\Libs\Extends\ConsoleOutput;
+use App\Libs\Extends\StreamLogHandler;
+use App\Libs\Stream;
+use App\Libs\TestCase;
+use DateTimeImmutable;
+use Monolog\Level;
+use Monolog\LogRecord;
+
+final class StreamLogHandlerTest extends TestCase
+{
+    public function test_console_output_jsonl(): void
+    {
+        Config::save('console.output', 'text');
+
+        $output = new ConsoleOutput();
+        $output->setJsonl(true);
+
+        $stream = Stream::create();
+        $handler = new StreamLogHandler($stream, $output);
+        $handler->handle(new LogRecord(
+            datetime: new DateTimeImmutable('2026-05-20T12:00:00.123+00:00'),
+            channel: 'app',
+            level: Level::Warning,
+            message: 'Hello world',
+        ));
+
+        $payload = json_decode(trim((string) $stream), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame('warning', $payload['level']);
+        self::assertSame('app', $payload['logger']);
+        self::assertSame('Hello world', $payload['message']);
+    }
+}

--- a/tests/Libs/GuidTest.php
+++ b/tests/Libs/GuidTest.php
@@ -11,7 +11,7 @@ use App\Libs\Extends\LogMessageProcessor;
 use App\Libs\Guid;
 use App\Libs\TestCase;
 use Monolog\Handler\TestHandler;
-use Monolog\Level;
+use Monolog\LogRecord;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface as iLogger;
 use Symfony\Component\Yaml\Yaml;
@@ -20,29 +20,21 @@ class GuidTest extends TestCase
 {
     protected Logger|null $logger = null;
 
-    private function logged(Level $level, string $message, bool $clear = false): bool
+    private function record(string $eventName, ?string $reason = null): ?LogRecord
     {
-        try {
-            foreach ($this->handler->getRecords() as $record) {
-                if ($level !== $record->level) {
-                    continue;
-                }
-
-                if (null !== $record->formatted && true === str_contains($record->formatted, $message)) {
-                    return true;
-                }
-
-                if (true === str_contains($record->message, $message)) {
-                    return true;
-                }
+        foreach (array_reverse($this->handler->getRecords()) as $record) {
+            if ($eventName !== ($record->context['event_name'] ?? null)) {
+                continue;
             }
 
-            return false;
-        } finally {
-            if (true === $clear) {
-                $this->handler->clear();
+            if (null !== $reason && $reason !== ($record->context['reason'] ?? null)) {
+                continue;
             }
+
+            return $record;
         }
+
+        return null;
     }
 
     protected function setUp(): void
@@ -56,6 +48,8 @@ class GuidTest extends TestCase
 
         Container::init();
         Container::add(iLogger::class, $this->logger);
+        Guid::reparse();
+        Guid::setLogger($this->logger);
     }
 
     public function test__construct()
@@ -67,16 +61,16 @@ class GuidTest extends TestCase
         $this->assertCount(0, $guid->getAll(), "Count should be 0 when value of guid is null.");
 
         Guid::fromArray(['guid_tvdb' => INF], logger: $this->logger);
-        $this->assertTrue(
-            $this->logged(Level::Info, 'external id. Unexpected value type.', true),
-            "Assert message logged when the value type does not match the expected type."
-        );
+        $record = $this->record('guid.external_id.ignored', 'unexpected_value_type');
+        $this->assertNotNull($record, 'Assert invalid external-id types are logged with stable context.');
+        $this->assertSame('guid_tvdb', $record->context['guid_source'] ?? null);
+        $this->handler->clear();
 
         Guid::fromArray(['guid_tvdb' => 'tt1234567']);
-        $this->assertTrue(
-            $this->logged(Level::Info, "external id. Unexpected value '", true),
-            "Assert message logged when the value does not match the expected pattern."
-        );
+        $record = $this->record('guid.external_id.ignored', 'invalid_guid');
+        $this->assertNotNull($record, 'Assert invalid external-id values are logged with stable context.');
+        $this->assertSame('tt1234567', $record->context['guid_value'] ?? null);
+        $this->handler->clear();
     }
 
     public function test_validation()
@@ -140,8 +134,6 @@ class GuidTest extends TestCase
 
     public function test_parseGUIDFile()
     {
-        Guid::setLogger($this->logger);
-
         $this->checkException(
             closure: fn() => Guid::parseGUIDFile('not_set.yml'),
             reason: "Failed to assert that the GUID file is not found.",
@@ -185,10 +177,10 @@ class GuidTest extends TestCase
         $tmpFile = self::$tmpPath . '/guid_' . uniqid();
         touch($tmpFile);
         Guid::parseGUIDFile($tmpFile);
-        $this->assertTrue(
-            $this->logged(Level::Info, 'is empty', true),
-            "Failed to assert that the GUID file is empty."
-        );
+        $record = $this->record('guid.mapping.ignored', 'empty_file');
+        $this->assertNotNull($record, 'Failed to assert that the GUID file is empty.');
+        $this->assertSame($tmpFile, $record->context['file'] ?? null);
+        $this->handler->clear();
 
         $tmpFile = self::$tmpPath . '/guid_' . uniqid();
         $this->checkException(
@@ -204,24 +196,24 @@ class GuidTest extends TestCase
         $tmpFile = self::$tmpPath . '/guid_' . uniqid();
         file_put_contents($tmpFile, Yaml::dump(['guids' => ['guid_imdb' => 'tt1234567']]));
         Guid::parseGUIDFile($tmpFile);
-        $this->assertTrue(
-            $this->logged(Level::Warning, 'Value must be an object', true),
-            'Assert that GUID key is an array.'
-        );
+        $record = $this->record('guid.mapping.ignored', 'invalid_link_value');
+        $this->assertNotNull($record, 'Assert that GUID key is an array.');
+        $this->assertSame('guids.guid_imdb', $record->context['mapping_key'] ?? null);
+        $this->handler->clear();
 
         file_put_contents($tmpFile, Yaml::dump(['guids' => [['name' => 'imdb']]]));
         Guid::parseGUIDFile($tmpFile);
-        $this->assertTrue(
-            $this->logged(Level::Warning, "name must start with 'guid_'", true),
-            'Assert that GUID name starts with guid_'
-        );
+        $record = $this->record('guid.mapping.ignored', 'invalid_guid_type_name');
+        $this->assertNotNull($record, 'Assert that GUID name starts with guid_.');
+        $this->assertSame('imdb', $record->context['mapping_to'] ?? null);
+        $this->handler->clear();
 
         file_put_contents($tmpFile, Yaml::dump(['guids' => [['name' => 'guid_imdb', 'type' => INF]]]));
         Guid::parseGUIDFile($tmpFile);
-        $this->assertTrue(
-            $this->logged(Level::Warning, 'type must be a string', true),
-            'Assert guid type is string.'
-        );
+        $record = $this->record('guid.mapping.ignored', 'invalid_map_value');
+        $this->assertNotNull($record, 'Assert guid type is string.');
+        $this->assertSame('guid_imdb', $record->context['mapping_to'] ?? null);
+        $this->handler->clear();
 
         $yaml = [
             'guids' => [
@@ -236,50 +228,46 @@ class GuidTest extends TestCase
         file_put_contents($tmpFile, Yaml::dump($yaml));
 
         Guid::parseGUIDFile($tmpFile);
-        $this->assertTrue(
-            $this->logged(Level::Warning, 'validator key must be an object', true),
-            'Assert validator key is an object.'
-        );
+        $record = $this->record('guid.mapping.ignored', 'invalid_map_value');
+        $this->assertNotNull($record, 'Assert validator key is an object.');
+        $this->assertSame('guid_foobar', $record->context['mapping_to'] ?? null);
+        $this->handler->clear();
 
         $yaml = ag_set($yaml, 'guids.0.validator', ['pattern' => '\d']);
         file_put_contents($tmpFile, Yaml::dump($yaml));
         Guid::parseGUIDFile($tmpFile);
-        $this->assertTrue(
-            $this->logged(Level::Warning, 'validator.pattern is empty or invalid', true),
-            'Assert a message is logged when the pattern is invalid.'
-        );
+        $record = $this->record('guid.mapping.ignored', 'invalid_map_from');
+        $this->assertNotNull($record, 'Assert a message is logged when the pattern is invalid.');
+        $this->handler->clear();
 
         $yaml = ag_set($yaml, 'guids.0.validator', ['pattern' => '/^\d+$/']);
         file_put_contents($tmpFile, Yaml::dump($yaml));
         Guid::parseGUIDFile($tmpFile);
-        $this->assertTrue(
-            $this->logged(Level::Warning, 'validator.example is empty or not a string', true),
-            'Assert a message is logged when the example is empty or not a string.'
-        );
+        $record = $this->record('guid.mapping.ignored', 'invalid_map_to');
+        $this->assertNotNull($record, 'Assert a message is logged when the example is empty or not a string.');
+        $this->handler->clear();
 
         $yaml = ag_set($yaml, 'guids.0.validator', ['pattern' => '/^\d+$/', 'example' => '(number)']);
         file_put_contents($tmpFile, Yaml::dump($yaml));
         Guid::parseGUIDFile($tmpFile);
-        $this->assertTrue(
-            $this->logged(Level::Warning, 'validator.tests key must be an object', true),
-            'Assert a message is logged when the test key is not an object.'
-        );
+        $record = $this->record('guid.mapping.ignored', 'invalid_map_value');
+        $this->assertNotNull($record, 'Assert a message is logged when the test key is not an object.');
+        $this->handler->clear();
 
         $yaml = ag_set($yaml, 'guids.0.validator.tests', ['valid' => 'foo']);
         file_put_contents($tmpFile, Yaml::dump($yaml));
         Guid::parseGUIDFile($tmpFile);
-        $this->assertTrue(
-            $this->logged(Level::Warning, 'validator.tests.valid key must be an array', true),
-            'Assert a message is logged when the test key is not an object.'
-        );
+        $record = $this->record('guid.mapping.ignored', 'invalid_map_from');
+        $this->assertNotNull($record, 'Assert a message is logged when the test key is not an object.');
+        $this->handler->clear();
 
         $yaml = ag_set($yaml, 'guids.0.validator.tests.valid', ['d12345678']);
         file_put_contents($tmpFile, Yaml::dump($yaml));
         Guid::parseGUIDFile($tmpFile);
-        $this->assertTrue(
-            $this->logged(Level::Warning, 'does not match pattern', true),
-            'Assert a message is logged when valid test does not match the pattern.'
-        );
+        $record = $this->record('guid.mapping.ignored', 'invalid_map_from');
+        $this->assertNotNull($record, 'Assert a message is logged when valid test does not match the pattern.');
+        $this->assertSame('d12345678', $record->context['mapping_from'] ?? null);
+        $this->handler->clear();
 
         $yaml = ag_set($yaml, 'guids.0.validator.tests', [
             'valid' => ['12345678'],
@@ -287,10 +275,9 @@ class GuidTest extends TestCase
         ]);
         file_put_contents($tmpFile, Yaml::dump($yaml));
         Guid::parseGUIDFile($tmpFile);
-        $this->assertTrue(
-            $this->logged(Level::Warning, 'validator.tests.invalid key must be an array', true),
-            'Assert a message is logged when invalid test is not an array.'
-        );
+        $record = $this->record('guid.mapping.ignored', 'invalid_map_to');
+        $this->assertNotNull($record, 'Assert a message is logged when invalid test is not an array.');
+        $this->handler->clear();
 
         $yaml = ag_set($yaml, 'guids.0.validator.tests', [
             'valid' => ['12345678'],
@@ -298,10 +285,10 @@ class GuidTest extends TestCase
         ]);
         file_put_contents($tmpFile, Yaml::dump($yaml));
         Guid::parseGUIDFile($tmpFile);
-        $this->assertTrue(
-            $this->logged(Level::Warning, 'validator.tests.invalid value', true),
-            'Assert a message is logged when invalid test match the pattern.'
-        );
+        $record = $this->record('guid.mapping.ignored', 'invalid_map_to');
+        $this->assertNotNull($record, 'Assert a message is logged when invalid test match the pattern.');
+        $this->assertSame('12345678', $record->context['mapping_from'] ?? null);
+        $this->handler->clear();
 
         $yaml = ag_set($yaml, 'guids.0.validator.tests', [
             'valid' => ['12345678'],
@@ -330,15 +317,14 @@ class GuidTest extends TestCase
         try {
             file_put_contents($tmpFile, "{'foo' => 'too' }");
             Config::save('guid.file', $tmpFile);
-            Guid::setLogger($this->logger);
             Guid::reparse();
             Guid::getSupported();
-            $this->assertTrue(
-                $this->logged(Level::Error, 'Failed to read or parse', true),
-                "Failed to assert that the GUID file is empty."
-            );
+            $record = $this->record('guid.file.parse_failed');
+            $this->assertNotNull($record, 'Failed to assert that GUID parse failures are logged.');
+            $this->assertSame($tmpFile, $record->context['file'] ?? null);
         } finally {
             Config::save('guid.file', $oldGuidFile);
+            Guid::reparse();
         }
     }
 
@@ -390,12 +376,10 @@ class GuidTest extends TestCase
 
     public function test_guid_logger_from_container()
     {
-        Guid::setLogger($this->logger);
         Guid::fromArray(['guid_tvdb' => INF]);
-        $this->assertTrue(
-            $this->logged(Level::Info, 'external id. Unexpected value type.', true),
-            "Assert message logged when the value type does not match the expected type."
-        );
+        $record = $this->record('guid.external_id.ignored', 'unexpected_value_type');
+        $this->assertNotNull($record, 'Assert message logged when the value type does not match the expected type.');
+        $this->assertSame('guid_tvdb', $record->context['guid_source'] ?? null);
     }
 
 }

--- a/tests/Libs/HelpersTest.php
+++ b/tests/Libs/HelpersTest.php
@@ -109,6 +109,35 @@ class HelpersTest extends TestCase
         };
     }
 
+    public function test_log_server_params(): void
+    {
+        $server = get_log_server_params([
+            'REQUEST_METHOD' => Method::GET->value,
+            'REQUEST_URI' => '/v1/api?x=1',
+            'SERVER_NAME' => 'watchstate.test',
+            'REMOTE_ADDR' => '127.0.0.1',
+            'HTTP_ACCEPT' => 'application/json',
+            'HTTP_AUTHORIZATION' => 'Token secret',
+            'HTTP_COOKIE' => 'session=secret',
+            'WS_API_KEY' => 'secret',
+            'SAFE' => 'removed',
+            'PHP_AUTH_USER' => 'removed',
+            'APP_VERSION' => '1.0.0',
+        ]);
+
+        self::assertSame(Method::GET->value, $server['REQUEST_METHOD']);
+        self::assertSame('/v1/api?x=1', $server['REQUEST_URI']);
+        self::assertSame('watchstate.test', $server['SERVER_NAME']);
+        self::assertSame('127.0.0.1', $server['REMOTE_ADDR']);
+        self::assertSame('application/json', $server['HTTP_ACCEPT']);
+        self::assertSame('1.0.0', $server['APP_VERSION']);
+        self::assertArrayNotHasKey('HTTP_AUTHORIZATION', $server);
+        self::assertArrayNotHasKey('HTTP_COOKIE', $server);
+        self::assertArrayNotHasKey('WS_API_KEY', $server);
+        self::assertArrayNotHasKey('SAFE', $server);
+        self::assertArrayNotHasKey('PHP_AUTH_USER', $server);
+    }
+
     public function test_env_conditions(): void
     {
         $values = [

--- a/tests/Libs/Identities/IdentityProvisionServiceTest.php
+++ b/tests/Libs/Identities/IdentityProvisionServiceTest.php
@@ -7,10 +7,13 @@ namespace Tests\Libs\Identities;
 use App\Libs\Config;
 use App\Libs\Container;
 use App\Libs\Database\PdoFactory;
+use App\Libs\Extends\LogMessageProcessor;
 use App\Libs\Identities\IdentityProvisionRequest;
 use App\Libs\Identities\IdentityProvisionService;
 use App\Libs\Options;
 use App\Libs\TestCase;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
 use PDO;
 use Psr\Log\LoggerInterface as iLogger;
 use Symfony\Component\Yaml\Yaml;
@@ -138,7 +141,7 @@ final class IdentityProvisionServiceTest extends TestCase
 
     public function test_syncBackends_preserves(): void
     {
-        $service = $this->makeService();
+        [$service, $handler] = $this->makeLoggedService();
 
         $result = $service->syncBackends(false);
 
@@ -181,6 +184,74 @@ final class IdentityProvisionServiceTest extends TestCase
 
         $this->assertSame('https://manual.example.com', ag($data, 'manual_backend.url'), 'Unlinked backends must remain untouched.');
         $this->assertSame('manual-token', ag($data, 'manual_backend.token'));
+
+        $records = $this->filterRecords($handler, 'identity.provision.backend.completed');
+
+        self::assertNotEmpty($records);
+        self::assertSame("Synced backend 'alice@plex_alice' from 'plex_main'.", $records[0]->message);
+        self::assertSame('backend.sync', $records[0]->context['operation']);
+        self::assertSame('plex_main', $records[0]->context['source_backend']);
+        self::assertSame('alice', $records[0]->context['identity']);
+        self::assertSame('plex_alice', $records[0]->context['backend']);
+    }
+
+    public function test_loadBackends_logs_structured_ignored_backends(): void
+    {
+        file_put_contents(
+            Config::get('backends_file'),
+            Yaml::dump([
+                'bad_type' => [
+                    'type' => 'bad',
+                    'url' => 'https://bad.example.com',
+                ],
+                'bad_url' => [
+                    'type' => 'plex',
+                    'url' => 'not-a-url',
+                ],
+            ], 4, 2),
+        );
+
+        [$service, $handler] = $this->makeLoggedService();
+
+        self::assertSame([], $service->loadBackends());
+
+        $records = $this->filterRecords($handler, 'identity.provision.backend.ignored');
+
+        self::assertCount(2, $records);
+        self::assertSame("Skipping backend 'bad_type': type 'bad' is unsupported.", $records[0]->message);
+        self::assertSame('unsupported_type', $records[0]->context['reason']);
+        self::assertSame('bad_type', $records[0]->context['backend']);
+        self::assertSame('bad', $records[0]->context['backend_type']);
+        self::assertSame("Skipping backend 'bad_url': URL 'not-a-url' is invalid.", $records[1]->message);
+        self::assertSame('invalid_url', $records[1]->context['reason']);
+        self::assertSame('bad_url', $records[1]->context['backend']);
+        self::assertSame('not-a-url', $records[1]->context['url']);
+    }
+
+    public function test_mapActions_logs_structured_rename(): void
+    {
+        [$service, $handler] = $this->makeLoggedService();
+        $user = ['name' => 'alice'];
+        $mapping = [[
+            'plex_main' => [
+                'name' => 'alice',
+                'replace_with' => 'alice_renamed',
+            ],
+        ]];
+
+        $service->mapActions('plex_main', $user, $mapping);
+
+        self::assertSame('alice_renamed', $user['name']);
+        self::assertSame('alice_renamed', $mapping[0]['plex_main']['name']);
+
+        $records = $this->filterRecords($handler, 'identity.provision.map.completed');
+
+        self::assertCount(1, $records);
+        self::assertSame("Renamed 'plex_main: alice' to 'plex_main: alice_renamed' using the mapper.", $records[0]->message);
+        self::assertSame('map.apply', $records[0]->context['operation']);
+        self::assertSame('plex_main', $records[0]->context['backend']);
+        self::assertSame('alice', $records[0]->context['username']);
+        self::assertSame('alice_renamed', $records[0]->context['new_username']);
     }
 
     public function test_createIdentities_initializes_new_identity_db(): void
@@ -218,6 +289,32 @@ final class IdentityProvisionServiceTest extends TestCase
 
         $config = Yaml::parseFile($this->tempDir . '/users/bob/servers.yaml');
         self::assertSame('https://new-plex.example.com', ag($config, 'plex_bob.url'));
+    }
+
+    /**
+     * @return array{IdentityProvisionService, TestHandler}
+     */
+    private function makeLoggedService(): array
+    {
+        $handler = new TestHandler();
+        $logger = new Logger('logger', processors: [new LogMessageProcessor()]);
+        $logger->pushHandler($handler);
+
+        return [new IdentityProvisionService(
+            mapper: Container::get(\App\Libs\Mappers\ImportInterface::class),
+            logger: $logger,
+        ), $handler];
+    }
+
+    /**
+     * @return array<int, \Monolog\LogRecord>
+     */
+    private function filterRecords(TestHandler $handler, string $eventName): array
+    {
+        return array_values(array_filter(
+            $handler->getRecords(),
+            static fn($record): bool => $eventName === ($record->context['event_name'] ?? null),
+        ));
     }
 
     private function makeService(): IdentityProvisionService

--- a/tests/Libs/JsonlFormatterTest.php
+++ b/tests/Libs/JsonlFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Libs;
 
 use App\Libs\Extends\JsonlFormatter;
+use App\Libs\Extends\LogMessageProcessor;
 use App\Libs\TestCase;
 use DateTimeImmutable;
 use DateTimeInterface;
@@ -46,9 +47,36 @@ final class JsonlFormatterTest extends TestCase
         self::assertSame(LOG_WARNING, $payload['levelno']);
         self::assertSame('app', $payload['logger']);
         self::assertSame('Hello world', $payload['message']);
+        self::assertArrayNotHasKey('id', $payload['fields']);
         self::assertSame('main', $payload['fields']['user']);
+        self::assertSame('request-1', $payload['fields']['request.id']);
         self::assertSame('[redacted]', $payload['fields']['backendToken']);
         self::assertSame('/v1/api?apikey=[redacted]&ok=1', $payload['fields']['request.uri']);
+    }
+
+    public function test_id_processed(): void
+    {
+        $formatter = new JsonlFormatter();
+        $record = new LogRecord(
+            datetime: new DateTimeImmutable('2026-05-20T12:00:00.123+00:00'),
+            channel: 'app',
+            level: Level::Info,
+            message: "Event '{id}' request '{request.id}'.",
+            context: [
+                'id' => 'event-1',
+                'request' => [
+                    'id' => 'request-1',
+                ],
+            ],
+        );
+
+        $processed = (new LogMessageProcessor())($record);
+        $payload = json_decode(trim($formatter->format($processed)), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame("Event 'event-1' request 'request-1'.", $payload['message']);
+        self::assertSame('event-1', $payload['id']);
+        self::assertArrayNotHasKey('id', $payload['fields']);
+        self::assertSame('request-1', $payload['fields']['request.id']);
     }
 
     public function test_exception(): void

--- a/tests/Libs/JsonlFormatterTest.php
+++ b/tests/Libs/JsonlFormatterTest.php
@@ -89,7 +89,7 @@ final class JsonlFormatterTest extends TestCase
             message: 'Failed',
             context: [
                 'exception' => [
-                    'kind' => 'RuntimeException',
+                    'type' => 'RuntimeException',
                     'message' => 'Boom',
                     'file' => '/srv/app.php',
                     'line' => 42,
@@ -108,8 +108,83 @@ final class JsonlFormatterTest extends TestCase
         self::assertSame(LOG_ERR, $payload['levelno']);
         self::assertStringContainsString('RuntimeException: Boom', $payload['exception']);
         self::assertStringContainsString('#0 run at /srv/app.php:42', $payload['exception']);
+        self::assertSame([
+            [
+                'file' => '/srv/app.php',
+                'line' => 42,
+                'function' => 'run',
+            ],
+        ], json_decode($payload['stack'], true, 512, JSON_THROW_ON_ERROR));
         self::assertSame('/srv/app.php', $payload['source']['path']);
         self::assertSame('app.php', $payload['source']['file']);
         self::assertSame(42, $payload['source']['line']);
+        self::assertArrayNotHasKey('exception.trace.0.file', $payload['fields']);
+        self::assertArrayNotHasKey('exception.trace.0.line', $payload['fields']);
+        self::assertSame('RuntimeException', $payload['fields']['exception.type']);
+    }
+
+    public function test_event_name_and_exception_type(): void
+    {
+        $formatter = new JsonlFormatter();
+        $exception = new \RuntimeException('Boom');
+        $record = new LogRecord(
+            datetime: new DateTimeImmutable('2026-05-20T12:00:00.123+00:00'),
+            channel: 'app',
+            level: Level::Error,
+            message: "Playlist sync failed for 'main'.",
+            context: [
+                'event_name' => 'playlist.sync.failed',
+                'user' => 'main',
+                ...exception_log($exception),
+            ],
+        );
+
+        $payload = json_decode(trim($formatter->format($record)), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame('playlist.sync.failed', $payload['fields']['event_name']);
+        self::assertSame('main', $payload['fields']['user']);
+        self::assertSame(\RuntimeException::class, $payload['fields']['error.type']);
+        self::assertSame(\RuntimeException::class, $payload['fields']['exception.type']);
+        self::assertArrayNotHasKey('exception.trace.0.file', $payload['fields']);
+        self::assertStringContainsString('RuntimeException: Boom', $payload['exception_message']);
+    }
+
+    public function test_error_trace_kept_in_stack(): void
+    {
+        $formatter = new JsonlFormatter();
+        $record = new LogRecord(
+            datetime: new DateTimeImmutable('2026-05-20T12:00:00.123+00:00'),
+            channel: 'app',
+            level: Level::Error,
+            message: 'Failed',
+            context: [
+                'error' => [
+                    'type' => 'RuntimeException',
+                    'message' => 'Boom',
+                    'trace' => [[
+                        'class' => 'Worker',
+                        'type' => '::',
+                        'function' => 'run',
+                        'file' => '/srv/worker.php',
+                        'line' => 17,
+                    ]],
+                ],
+            ],
+        );
+
+        $payload = json_decode(trim($formatter->format($record)), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame([
+            [
+                'class' => 'Worker',
+                'type' => '::',
+                'function' => 'run',
+                'file' => '/srv/worker.php',
+                'line' => 17,
+            ],
+        ], json_decode($payload['stack'], true, 512, JSON_THROW_ON_ERROR));
+        self::assertArrayNotHasKey('error.trace.0.class', $payload['fields']);
+        self::assertArrayNotHasKey('error.trace.0.file', $payload['fields']);
+        self::assertSame('Worker::run', $payload['source']['function']);
     }
 }

--- a/tests/Libs/JsonlFormatterTest.php
+++ b/tests/Libs/JsonlFormatterTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Libs;
+
+use App\Libs\Extends\JsonlFormatter;
+use App\Libs\TestCase;
+use DateTimeImmutable;
+use DateTimeInterface;
+use DateTimeZone;
+use Monolog\Level;
+use Monolog\LogRecord;
+
+final class JsonlFormatterTest extends TestCase
+{
+    public function test_basic(): void
+    {
+        $formatter = new JsonlFormatter();
+        $record = new LogRecord(
+            datetime: new DateTimeImmutable('2026-05-20T12:00:00.123+00:00'),
+            channel: 'app',
+            level: Level::Warning,
+            message: 'Hello world',
+            context: [
+                'id' => 'log-id',
+                'user' => 'main',
+                'backendToken' => 'secret-token',
+                'request' => [
+                    'id' => 'request-1',
+                    'uri' => '/v1/api?apikey=secret&ok=1',
+                ],
+            ],
+        );
+
+        $payload = json_decode(trim($formatter->format($record)), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame('log-id', $payload['id']);
+        self::assertSame(
+            (new DateTimeImmutable('2026-05-20T12:00:00.123+00:00'))
+                ->setTimezone(new DateTimeZone(date_default_timezone_get()))
+                ->format(DateTimeInterface::RFC3339_EXTENDED),
+            $payload['datetime'],
+        );
+        self::assertSame('warning', $payload['level']);
+        self::assertSame(LOG_WARNING, $payload['levelno']);
+        self::assertSame('app', $payload['logger']);
+        self::assertSame('Hello world', $payload['message']);
+        self::assertSame('main', $payload['fields']['user']);
+        self::assertSame('[redacted]', $payload['fields']['backendToken']);
+        self::assertSame('/v1/api?apikey=[redacted]&ok=1', $payload['fields']['request.uri']);
+    }
+
+    public function test_exception(): void
+    {
+        $formatter = new JsonlFormatter();
+        $record = new LogRecord(
+            datetime: new DateTimeImmutable('2026-05-20T12:00:00.123+00:00'),
+            channel: 'app',
+            level: Level::Error,
+            message: 'Failed',
+            context: [
+                'exception' => [
+                    'kind' => 'RuntimeException',
+                    'message' => 'Boom',
+                    'file' => '/srv/app.php',
+                    'line' => 42,
+                    'trace' => [[
+                        'file' => '/srv/app.php',
+                        'line' => 42,
+                        'function' => 'run',
+                    ]],
+                ],
+            ],
+        );
+
+        $payload = json_decode(trim($formatter->format($record)), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame('RuntimeException: Boom', $payload['exception_message']);
+        self::assertSame(LOG_ERR, $payload['levelno']);
+        self::assertStringContainsString('RuntimeException: Boom', $payload['exception']);
+        self::assertStringContainsString('#0 run at /srv/app.php:42', $payload['exception']);
+        self::assertSame('/srv/app.php', $payload['source']['path']);
+        self::assertSame('app.php', $payload['source']['file']);
+        self::assertSame(42, $payload['source']['line']);
+    }
+}

--- a/tests/Libs/LogMessageProcessorTest.php
+++ b/tests/Libs/LogMessageProcessorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Libs;
+
+use App\Libs\Extends\LogMessageProcessor;
+use App\Libs\TestCase;
+use DateTimeImmutable;
+use Monolog\Level;
+use Monolog\LogRecord;
+
+final class LogMessageProcessorTest extends TestCase
+{
+    public function test_context_keep(): void
+    {
+        $record = new LogRecord(
+            datetime: new DateTimeImmutable('2026-05-20T12:00:00+00:00'),
+            channel: 'test',
+            level: Level::Notice,
+            message: 'event {id} request {request.id}',
+            context: [
+                'id' => 'event-1',
+                'request' => [
+                    'id' => 'request-1',
+                ],
+            ],
+        );
+
+        $processed = (new LogMessageProcessor())($record);
+
+        self::assertSame('event event-1 request request-1', $processed->message);
+        self::assertSame('event-1', $processed->context['id']);
+        self::assertSame('request-1', $processed->context['request']['id']);
+    }
+}

--- a/tests/Libs/LoggingPrefixGuardTest.php
+++ b/tests/Libs/LoggingPrefixGuardTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Libs;
+
+use App\Libs\TestCase;
+
+final class LoggingPrefixGuardTest extends TestCase
+{
+    public function test_scoped_logger_messages_do_not_use_legacy_prefixes(): void
+    {
+        $paths = [
+            ROOT_PATH . '/src/Commands/State/BackupCommand.php',
+            ROOT_PATH . '/src/Backends/Jellyfin/Action/Backup.php',
+        ];
+
+        $pattern = '/->(?:debug|info|notice|warning|error|critical|alert|emergency)\(\s*(?:message:\s*)?["\'](?:SYSTEM:|PLAYLIST:|MAPPER:|PDOAdapter:|HttpClient -|[A-Z][A-Za-z0-9_\\\\]+:)/';
+
+        foreach ($paths as $path) {
+            $contents = file_get_contents($path);
+
+            self::assertIsString($contents);
+            self::assertSame(0, preg_match($pattern, $contents), $path);
+        }
+    }
+}

--- a/tests/Libs/Playlists/PlaylistSyncServiceTest.php
+++ b/tests/Libs/Playlists/PlaylistSyncServiceTest.php
@@ -12,6 +12,7 @@ use App\Libs\Container;
 use App\Libs\Database\PDO\PDOAdapter;
 use App\Libs\Entity\StateEntity;
 use App\Libs\Entity\StateInterface as iState;
+use App\Libs\Extends\LogMessageProcessor;
 use App\Libs\Mappers\Import\DirectMapper;
 use App\Libs\Options;
 use App\Libs\Playlists\PlaylistStore;
@@ -20,6 +21,7 @@ use App\Libs\TestCase;
 use App\Libs\Uri;
 use App\Libs\UserContext;
 use Monolog\Handler\NullHandler;
+use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use stdClass;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -29,7 +31,8 @@ final class PlaylistSyncServiceTest extends TestCase
 {
     public function test_partial_sync_no_promote(): void
     {
-        $logger = new Logger('test', [new NullHandler()]);
+        $handler = new TestHandler();
+        $logger = new Logger('test', [$handler], [new LogMessageProcessor()]);
         $userContext = $this->makeUserContext($logger);
         $store = new PlaylistStore($userContext->db->getDBLayer());
         Container::reinitialize();
@@ -134,6 +137,30 @@ final class PlaylistSyncServiceTest extends TestCase
         self::assertSame(1, ag($targetRows[0], 'metadata.sync.available_item_count'));
         self::assertSame(['Shared Episode B (2024)'], ag($targetRows[0], 'metadata.sync.missing_titles'));
 
+        $records = array_values(array_filter(
+            $handler->getRecords(),
+            static fn($record): bool => 'playlist.operation.planned' === ($record->context['event_name'] ?? null)
+                && 'partial_target_items' === ($record->context['reason'] ?? null),
+        ));
+
+        self::assertCount(1, $records);
+        self::assertSame(
+            "Planning partial create for playlist 'Shared Episodes' on 'main@target': 1 of 2 items are available.",
+            $records[0]->message,
+        );
+        self::assertSame('partial_target_items', $records[0]->context['reason']);
+        self::assertSame('Shared Episodes', $records[0]->context['playlist_title']);
+        self::assertSame(1, $records[0]->context['available_count']);
+        self::assertSame(2, $records[0]->context['total_count']);
+
+        $selected = array_values(array_filter(
+            $handler->getRecords(),
+            static fn($record): bool => 'playlist.plan.winner_selected' === ($record->context['event_name'] ?? null),
+        ));
+
+        self::assertNotEmpty($selected);
+        self::assertSame('source', $selected[0]->context['source_backend']);
+
         $secondRun = $service->sync($userContext, $clients, $opts);
 
         self::assertSame(0, $sourceState->createCalls);
@@ -162,6 +189,20 @@ final class PlaylistSyncServiceTest extends TestCase
         self::assertFalse((bool) ag($targetRows[0], 'metadata.sync.partial', false));
         self::assertFalse((bool) ag($targetRows[0], 'metadata.sync.generated_by_sync', false));
         self::assertNull(ag($targetRows[0], 'metadata.sync.desired_content_hash'));
+
+        $applied = array_values(array_filter(
+            $handler->getRecords(),
+            static fn($record): bool => 'playlist.operation.applied' === ($record->context['event_name'] ?? null),
+        ));
+
+        self::assertNotEmpty($applied);
+
+        $stored = array_values(array_filter(
+            $handler->getRecords(),
+            static fn($record): bool => 'playlist.snapshot.stored' === ($record->context['event_name'] ?? null),
+        ));
+
+        self::assertNotEmpty($stored);
     }
 
     public function test_sync_skips_empty(): void

--- a/tests/Libs/UtilsTest.php
+++ b/tests/Libs/UtilsTest.php
@@ -291,6 +291,25 @@ class UtilsTest extends TestCase
         self::assertSame('main', $users['main']->name);
     }
 
+    public function test_exception_log_shape(): void
+    {
+        $e = new RuntimeException('Boom');
+
+        $payload = exception_log($e);
+
+        self::assertSame(RuntimeException::class, $payload['error']['type']);
+        self::assertSame(RuntimeException::class, $payload['error']['kind']);
+        self::assertSame('Boom', $payload['error']['message']);
+        self::assertSame(after($e->getFile(), ROOT_PATH), $payload['error']['file']);
+        self::assertSame($e->getLine(), $payload['error']['line']);
+        self::assertSame(RuntimeException::class, $payload['exception']['type']);
+        self::assertSame(RuntimeException::class, $payload['exception']['kind']);
+        self::assertSame('Boom', $payload['exception']['message']);
+        self::assertSame($e->getFile(), $payload['exception']['file']);
+        self::assertSame($e->getLine(), $payload['exception']['line']);
+        self::assertIsArray($payload['exception']['trace']);
+    }
+
     private function createMapper(Logger $logger): DirectMapper
     {
         $db = $this->createDb($logger);

--- a/tests/Listeners/ProcessProfileEventTest.php
+++ b/tests/Listeners/ProcessProfileEventTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Listeners;
+
+use App\Libs\Config;
+use App\Libs\Events\DataEvent;
+use App\Libs\Extends\JsonlFormatter;
+use App\Libs\Extends\MockHttpClient;
+use App\Libs\TestCase;
+use App\Listeners\ProcessProfileEvent;
+use App\Model\Events\Event;
+use App\Model\Events\EventStatus;
+use App\Model\Events\EventsTable;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class ProcessProfileEventTest extends TestCase
+{
+    public function test_profile_export_disabled_logs_structured_event(): void
+    {
+        $this->initTempApp();
+        Config::init(['profiler' => ['save' => false]]);
+
+        $handler = new TestHandler();
+        $logger = new Logger('test', [$handler]);
+        $listener = new ProcessProfileEvent($logger, new MockHttpClient());
+        $event = $this->event();
+
+        $listener($event);
+
+        self::assertCount(1, $event->getLogs());
+        self::assertTrue(JsonlFormatter::isJsonlRecord($event->getLogs()[0]));
+
+        $payload = json_decode(trim($event->getLogs()[0]), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame('profile.export.disabled', ag($payload, 'fields.event_name'));
+        self::assertSame('profile-1', ag($payload, 'fields.profile_id'));
+        self::assertTrue($handler->hasInfoRecords());
+    }
+
+    public function test_profile_collector_unexpected_status_logs_structured_event(): void
+    {
+        $this->initTempApp();
+        Config::init(['profiler' => ['save' => false, 'collector' => 'https://collector.test/ingest']]);
+
+        $handler = new TestHandler();
+        $logger = new Logger('test', [$handler]);
+        $listener = new ProcessProfileEvent(
+            $logger,
+            new MockHttpClient(new MockResponse('fail', ['http_code' => 500])),
+        );
+        $event = $this->event();
+
+        $listener($event);
+
+        self::assertCount(1, $event->getLogs());
+        $payload = json_decode(trim($event->getLogs()[0]), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame('profile.collector.unexpected_status', ag($payload, 'fields.event_name'));
+        self::assertSame(500, $payload['fields']['http.status_code'] ?? null);
+        self::assertTrue($handler->hasErrorRecords());
+    }
+
+    private function event(): DataEvent
+    {
+        return new DataEvent(new Event([
+            EventsTable::COLUMN_ID => generate_uuid(),
+            EventsTable::COLUMN_STATUS => EventStatus::RUNNING->value,
+            EventsTable::COLUMN_EVENT => ProcessProfileEvent::NAME,
+            EventsTable::COLUMN_EVENT_DATA => json_encode([
+                'meta' => [
+                    'id' => 'profile-1',
+                ],
+                'data' => ['x' => 'y'],
+            ]),
+            EventsTable::COLUMN_OPTIONS => json_encode([]),
+            EventsTable::COLUMN_ATTEMPTS => 1,
+            EventsTable::COLUMN_LOGS => json_encode([]),
+            EventsTable::COLUMN_CREATED_AT => '2024-01-01 00:00:00',
+            EventsTable::COLUMN_UPDATED_AT => '2024-01-01 00:00:01',
+        ]));
+    }
+}

--- a/tests/Listeners/ProcessProgressEventTest.php
+++ b/tests/Listeners/ProcessProgressEventTest.php
@@ -81,21 +81,21 @@ final class ProcessProgressEventTest extends TestCase
         $listener($event);
 
         self::assertSame(EventStatus::RUNNING, $event->getStatus());
-        self::assertNotEmpty(
-            array_filter(
-                $event->getLogs(),
-                static function (string $log): bool {
-                    if (false === JsonlFormatter::isJsonlRecord($log)) {
-                        return false;
-                    }
+        $records = array_values(array_filter(
+            $event->getLogs(),
+            static function (string $log): bool {
+                if (false === JsonlFormatter::isJsonlRecord($log)) {
+                    return false;
+                }
 
-                    $payload = json_decode($log, true, 512, JSON_THROW_ON_ERROR);
+                $payload = json_decode($log, true, 512, JSON_THROW_ON_ERROR);
 
-                    return 'warning' === ag($payload, 'level')
-                        && str_contains((string) ag($payload, 'message', ''), 'No metadata was found.');
-                },
-            ),
-        );
+                return 'progress.queue.empty' === ag($payload, 'fields.event_name')
+                    && in_array(ag($payload, 'fields.reason'), ['no_eligible_backends', 'no_updates_queued'], true);
+            },
+        ));
+
+        self::assertNotEmpty($records);
         self::assertFalse($handler->hasWarningRecords());
     }
 

--- a/tests/Listeners/ProcessProgressEventTest.php
+++ b/tests/Listeners/ProcessProgressEventTest.php
@@ -12,6 +12,7 @@ use App\Libs\Database\PackageMigrationFactory;
 use App\Libs\Entity\StateEntity;
 use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Events\DataEvent;
+use App\Libs\Extends\JsonlFormatter;
 use App\Libs\Mappers\Import\DirectMapper;
 use App\Libs\QueueRequests;
 use App\Libs\TestCase;
@@ -26,7 +27,7 @@ use Psr\SimpleCache\CacheInterface as iCache;
 
 final class ProcessProgressEventTest extends TestCase
 {
-    public function test_missing_metadata_logs_to_event_only(): void
+    public function test_metadata_missing_event_log(): void
     {
         $this->initTempApp();
         $this->seedTestServersConfig();
@@ -83,7 +84,16 @@ final class ProcessProgressEventTest extends TestCase
         self::assertNotEmpty(
             array_filter(
                 $event->getLogs(),
-                static fn(string $log): bool => str_contains($log, 'WARNING:') && str_contains($log, 'No metadata was found.'),
+                static function (string $log): bool {
+                    if (false === JsonlFormatter::isJsonlRecord($log)) {
+                        return false;
+                    }
+
+                    $payload = json_decode($log, true, 512, JSON_THROW_ON_ERROR);
+
+                    return 'warning' === ag($payload, 'level')
+                        && str_contains((string) ag($payload, 'message', ''), 'No metadata was found.');
+                },
             ),
         );
         self::assertFalse($handler->hasWarningRecords());

--- a/tests/Listeners/ProcessProgressEventTest.php
+++ b/tests/Listeners/ProcessProgressEventTest.php
@@ -27,7 +27,7 @@ use Psr\SimpleCache\CacheInterface as iCache;
 
 final class ProcessProgressEventTest extends TestCase
 {
-    public function test_metadata_missing_event_log(): void
+    public function test_logs_shared_missing_metadata(): void
     {
         $this->initTempApp();
         $this->seedTestServersConfig();
@@ -96,7 +96,12 @@ final class ProcessProgressEventTest extends TestCase
         ));
 
         self::assertNotEmpty($records);
-        self::assertFalse($handler->hasWarningRecords());
+        self::assertNotEmpty(array_filter(
+            $handler->getRecords(),
+            static fn($record): bool => 'progress.queue.empty' === ($record->context['event_name'] ?? null)
+                && 'progress' === ($record->context['subsystem'] ?? null)
+                && in_array($record->context['reason'] ?? null, ['no_eligible_backends', 'no_updates_queued'], true),
+        ));
     }
 
     private function event(StateEntity $entity): DataEvent

--- a/tests/Listeners/ProcessPushEventTest.php
+++ b/tests/Listeners/ProcessPushEventTest.php
@@ -25,7 +25,7 @@ use Psr\SimpleCache\CacheInterface as iCache;
 
 final class ProcessPushEventTest extends TestCase
 {
-    public function test_missing_metadata_logs_to_event_only(): void
+    public function test_logs_shared_missing_metadata(): void
     {
         $this->initTempApp();
         $this->seedTestServersConfig();
@@ -89,7 +89,13 @@ final class ProcessPushEventTest extends TestCase
                 },
             ),
         );
-        self::assertFalse($handler->hasWarningRecords());
+        self::assertNotEmpty(array_filter(
+            $handler->getRecords(),
+            static fn($record): bool => 'backend.item.ignored' === ($record->context['event_name'] ?? null)
+                && 'backend.push' === ($record->context['subsystem'] ?? null)
+                && 'missing_backend_metadata' === ($record->context['reason'] ?? null)
+                && 'test_jellyfin' === ($record->context['backend'] ?? null),
+        ));
     }
 
     private function event(StateEntity $entity): DataEvent

--- a/tests/Listeners/ProcessPushEventTest.php
+++ b/tests/Listeners/ProcessPushEventTest.php
@@ -10,6 +10,7 @@ use App\Libs\Database\PackageMigrationFactory;
 use App\Libs\Entity\StateEntity;
 use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Events\DataEvent;
+use App\Libs\Extends\JsonlFormatter;
 use App\Libs\Mappers\Import\DirectMapper;
 use App\Libs\QueueRequests;
 use App\Libs\TestCase;
@@ -66,15 +67,25 @@ final class ProcessPushEventTest extends TestCase
         $listener($event);
 
         self::assertSame(EventStatus::RUNNING, $event->getStatus());
-        self::assertContains(
-            r(
-                "WARNING: jellyfin.push: Ignoring '#{id}: {title}' for 'Jellyfin: main@test_jellyfin'. No metadata was found.",
-                [
-                    'id' => $entity->id,
-                    'title' => $entity->getName(),
-                ],
+        self::assertNotEmpty(
+            array_filter(
+                $event->getLogs(),
+                static function (string $log) use ($entity): bool {
+                    if (false === JsonlFormatter::isJsonlRecord($log)) {
+                        return false;
+                    }
+
+                    $payload = json_decode(trim($log), true);
+
+                    if (!is_array($payload)) {
+                        return false;
+                    }
+
+                    return 'warning' === ($payload['level'] ?? null)
+                        && str_contains((string) ($payload['message'] ?? ''), "Ignoring '#{$entity->id}: {$entity->getName()}'")
+                        && str_contains((string) ($payload['message'] ?? ''), 'No metadata was found.');
+                },
             ),
-            $event->getLogs(),
         );
         self::assertFalse($handler->hasWarningRecords());
     }

--- a/tests/Listeners/ProcessPushEventTest.php
+++ b/tests/Listeners/ProcessPushEventTest.php
@@ -81,9 +81,11 @@ final class ProcessPushEventTest extends TestCase
                         return false;
                     }
 
-                    return 'warning' === ($payload['level'] ?? null)
-                        && str_contains((string) ($payload['message'] ?? ''), "Ignoring '#{$entity->id}: {$entity->getName()}'")
-                        && str_contains((string) ($payload['message'] ?? ''), 'No metadata was found.');
+                    return 'notice' === ($payload['level'] ?? null)
+                        && 'push.item.processing' === ag($payload, 'fields.event_name')
+                        && str_contains((string) ($payload['message'] ?? ''), "Processing push for '#{$entity->id}: {$entity->getName()}'")
+                        && 'main' === ag($payload, 'fields.user')
+                        && 'test_jellyfin' === ag($payload, 'fields.backend');
                 },
             ),
         );

--- a/tests/Listeners/ProcessWebhookEventTest.php
+++ b/tests/Listeners/ProcessWebhookEventTest.php
@@ -12,6 +12,7 @@ use App\Libs\Database\DatabaseInterface as iDB;
 use App\Libs\Entity\StateEntity;
 use App\Libs\Enums\Http\Method;
 use App\Libs\Events\DataEvent;
+use App\Libs\Extends\JsonlFormatter;
 use App\Libs\Mappers\Import\DirectMapper;
 use App\Libs\TestCase;
 use App\Listeners\ProcessWebhookEvent;
@@ -66,6 +67,27 @@ final class ProcessWebhookEventTest extends TestCase
 
         self::assertSame([], $events);
         self::assertSame(EventStatus::RUNNING, $event->getStatus());
+
+        $processingLog = null;
+        foreach ($event->getLogs() as $log) {
+            if (false === JsonlFormatter::isJsonlRecord($log)) {
+                continue;
+            }
+
+            $payload = json_decode($log, true, 512, JSON_THROW_ON_ERROR);
+            if (str_contains((string) ag($payload, 'message', ''), "Processing 'main@test_plex' request")) {
+                $processingLog = $payload;
+                break;
+            }
+        }
+
+        self::assertNotNull($processingLog);
+        self::assertSame((string) $event->getEvent()->id, ag($processingLog, 'fields.event_id'));
+        self::assertSame('main', ag($processingLog, 'fields.user'));
+        self::assertSame('test_plex', ag($processingLog, 'fields.backend'));
+        self::assertSame('req-1', ag($processingLog, 'fields.request_id'));
+        self::assertSame('media.scrobble', ag($processingLog, 'fields.webhook_event'));
+        self::assertSame(121, ag($processingLog, 'fields.backend_item_id'));
     }
 
     public function test_tasks_processes(): void

--- a/tests/Listeners/ProcessWebhookEventTest.php
+++ b/tests/Listeners/ProcessWebhookEventTest.php
@@ -75,16 +75,22 @@ final class ProcessWebhookEventTest extends TestCase
             }
 
             $payload = json_decode($log, true, 512, JSON_THROW_ON_ERROR);
-            if (str_contains((string) ag($payload, 'message', ''), "Processing 'main@test_plex' request")) {
+            if ('webhook.item.processing' === ag($payload, 'fields.event_name')) {
                 $processingLog = $payload;
                 break;
             }
         }
 
         self::assertNotNull($processingLog);
+        self::assertSame('webhook.item.processing', ag($processingLog, 'fields.event_name'));
         self::assertSame((string) $event->getEvent()->id, ag($processingLog, 'fields.event_id'));
         self::assertSame('main', ag($processingLog, 'fields.user'));
         self::assertSame('test_plex', ag($processingLog, 'fields.backend'));
+        self::assertSame('plex', strtolower((string) ag($processingLog, 'fields.client')));
+        self::assertSame('started', ag($processingLog, 'fields.outcome'));
+        self::assertSame('process', ag($processingLog, 'fields.operation'));
+        self::assertSame('movie', ag($processingLog, 'fields.item_type'));
+        self::assertSame('Movie Title (2020)', ag($processingLog, 'fields.item_title'));
         self::assertSame('req-1', ag($processingLog, 'fields.request_id'));
         self::assertSame('media.scrobble', ag($processingLog, 'fields.webhook_event'));
         self::assertSame(121, ag($processingLog, 'fields.backend_item_id'));

--- a/tests/Mappers/Import/DirectMapperTest.php
+++ b/tests/Mappers/Import/DirectMapperTest.php
@@ -21,6 +21,23 @@ class DirectMapperTest extends MapperAbstract
         return $mapper;
     }
 
+    public function test_log_item_id(): void
+    {
+        $this->mapper->add(new StateEntity($this->testMovie));
+
+        $record = null;
+        foreach ($this->handler->getRecords() as $logRecord) {
+            if (str_contains($logRecord->message, 'added')) {
+                $record = $logRecord;
+                break;
+            }
+        }
+
+        self::assertNotNull($record);
+        self::assertArrayHasKey('item_id', $record->context);
+        self::assertArrayNotHasKey('id', $record->context);
+    }
+
     public function test_skip_state_no_progress(): void
     {
         $this->testMovie[iState::COLUMN_WATCHED] = 0;

--- a/tests/Mappers/Import/DirectMapperTest.php
+++ b/tests/Mappers/Import/DirectMapperTest.php
@@ -27,7 +27,7 @@ class DirectMapperTest extends MapperAbstract
 
         $record = null;
         foreach ($this->handler->getRecords() as $logRecord) {
-            if (str_contains($logRecord->message, 'added')) {
+            if ('mapper.item.added' === ($logRecord->context['event_name'] ?? null)) {
                 $record = $logRecord;
                 break;
             }

--- a/tests/Mappers/Import/MapperAbstract.php
+++ b/tests/Mappers/Import/MapperAbstract.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Mappers\Import;
 
 use App\Libs\Container;
+use App\Libs\Config;
 use App\Libs\Database\DatabaseInterface as iDB;
 use App\Libs\Entity\StateEntity;
 use App\Libs\Entity\StateInterface as iState;
@@ -67,6 +68,13 @@ abstract class MapperAbstract extends TestCase
         $this->mapper = $this->setupMapper();
 
         Message::reset();
+    }
+
+    public function tearDown(): void
+    {
+        Config::reset();
+
+        parent::tearDown();
     }
 
     /**
@@ -612,6 +620,54 @@ abstract class MapperAbstract extends TestCase
         $this->assertSame(['test' => 'test'],
             $mapper->getOptions(),
             'getOptions() should return the options we have set.');
+    }
+
+    public function test_load_data_logs_preload_completed(): void
+    {
+        $testMovie = new StateEntity($this->testMovie);
+        $testEpisode = new StateEntity($this->testEpisode);
+
+        $this->db->commit([$testEpisode, $testMovie]);
+
+        $this->mapper->loadData();
+
+        $records = array_values(array_filter(
+            $this->handler->getRecords(),
+            static fn($record): bool => 'mapper.preload.completed' === ($record->context['event_name'] ?? null),
+        ));
+
+        self::assertCount(1, $records);
+        self::assertSame(
+            "Preloaded {$records[0]->context['pointer_count']} pointers and {$records[0]->context['object_count']} objects for 'main' into " . after_last($this->mapper::class, '\\') . '.',
+            $records[0]->message,
+        );
+        self::assertSame('mapper', $records[0]->context['subsystem']);
+        self::assertGreaterThan(0, $records[0]->context['pointer_count']);
+        self::assertSame(2, $records[0]->context['object_count']);
+        self::assertArrayHasKey('duration_seconds', $records[0]->context);
+        self::assertArrayHasKey('memory', $records[0]->context);
+    }
+
+    public function test_add_logs_item_ignored_for_missing_guids(): void
+    {
+        $testMovieData = $this->testMovie;
+        $testMovieData[iState::COLUMN_GUIDS] = [];
+        $testMovieData[iState::COLUMN_META_DATA][$testMovieData[iState::COLUMN_VIA]][iState::COLUMN_GUIDS] = [];
+        $testMovie = new StateEntity($testMovieData);
+
+        $this->mapper->add($testMovie);
+
+        $records = array_values(array_filter(
+            $this->handler->getRecords(),
+            static fn($record): bool => 'mapper.item.ignored' === ($record->context['event_name'] ?? null)
+                && 'no_supported_external_ids' === ($record->context['reason'] ?? null),
+        ));
+
+        self::assertCount(1, $records);
+        self::assertSame("Ignoring movie '#121: Movie Title (2020)' from 'main@test_plex': no supported external ids.", $records[0]->message);
+        self::assertSame('no_supported_external_ids', $records[0]->context['reason']);
+        self::assertSame('movie', $records[0]->context['item_type']);
+        self::assertSame('121', (string) $records[0]->context['item_id']);
     }
 
 }

--- a/tests/Mappers/Import/RestoreMapperTest.php
+++ b/tests/Mappers/Import/RestoreMapperTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Mappers\Import;
+
+use App\Libs\Entity\StateEntity;
+use App\Libs\Extends\LogMessageProcessor;
+use App\Libs\Mappers\Import\RestoreMapper;
+use App\Libs\TestCase;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+
+final class RestoreMapperTest extends TestCase
+{
+    public function test_logs_ignored_item_without_supported_ids(): void
+    {
+        $handler = new TestHandler();
+        $logger = new Logger('test', [$handler], [new LogMessageProcessor()]);
+        $mapper = new RestoreMapper($logger, 'unused.json');
+        $entity = require __DIR__ . '/../../Fixtures/MovieEntity.php';
+        $entity['title'] = 'Missing GUIDs';
+        $entity['guids'] = [];
+        $entity['parent'] = [];
+
+        $mapper->add(new StateEntity($entity));
+
+        $records = $handler->getRecords();
+        self::assertCount(1, $records);
+        self::assertSame('mapper.restore.item.ignored', $records[0]->context['event_name']);
+        self::assertSame("Ignoring restore item 'Missing GUIDs (2020)': no supported external ids.", $records[0]->message);
+        self::assertSame('no_supported_external_ids', $records[0]->context['reason']);
+    }
+}


### PR DESCRIPTION
* Changed all log file paths in configuration from `.log` to `.jsonl`.
* Revised API documentation (`API.md`) to reflect the new `.jsonl` log file format.
* Replaced the simple "Copy event" tooltip with a popover menu offering multiple copy options (Copy ID, Copy Event, Copy Logs).
* Refactored the log display to parse and present structured log data.
* Added modals for viewing event details and log details, and improved event-related interactions (such as resetting events and handling dialog confirmations).
* [fix: run migration after manual user creation.](https://github.com/arabcoders/watchstate/pull/832/commits/167de0c1c6dc039dfe9a34f1a8ee093bf98d2d78)

This PR may look big with 14k+ lines change and 180+ files changes, however it's mainly log messages refactor to reflect and take advantage of the new json format, before we used to just try to jam as much info in the same log message. however now we have the freedom to add more information without making the log message be stupid looking or hard to understand. and give more information and contextual information when needed.