### PR TITLE
Feat: add path-derived GUID source for media matching

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # NEWS
 
+### 2026-04-26
+
+Cross-backend sync for playlists is now available as a **beta** feature. This is still early work, so expect some rough edges, 
+backend-specific issues, and possible breaking changes as it matures. 
+
+Because playlist behavior differs across backends, the feature may change over time, and if it proves too unreliable to support consistently, 
+it may be reworked or removed. To enable it, simply go to Tasks and enable the `Playlist` task.
+
 ### 2026-04-23
 
 Plex appears to have backtracked on the API change that broke external `invited users`, so WatchState supports them again for now.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ box, this tool supports `Jellyfin`, `Plex` and `Emby` media servers.
 
 ### 2026-05-25
 
-Path matching is now available. It lets items match using a GUID source derived from the media path, which helps when your backends share the same media files but have unreliable or inconsistent external IDs. See the [path matching guide](/guides/path-match.md) for setup and backfill instructions.
+Path matching is now available in v1.8.5+. It lets items match using a GUID source derived from the media path, which helps when your backends share the same media files but have unreliable or inconsistent external IDs. See the [path matching guide](/guides/path-match.md) for setup and backfill instructions.
 
 ### 2026-04-30
 

--- a/README.md
+++ b/README.md
@@ -10,19 +10,15 @@ box, this tool supports `Jellyfin`, `Plex` and `Emby` media servers.
 
 # Updates
 
+### 2026-05-25
+
+Path matching is now available. It lets items match using a GUID source derived from the media path, which helps when your backends share the same media files but have unreliable or inconsistent external IDs. See the [path matching guide](/guides/path-match.md) for setup and backfill instructions.
+
 ### 2026-04-30
 
 WatchState now uses the new versioned `v02` database schema. On first boot after updating, startup may take a bit longer than usual while legacy databases are imported, migrations are applied, and indexes are rebuilt.
 
 During that upgrade, the old database files are kept as `.migrated` safety copies. Once the first boot finishes and you have confirmed everything looks good, you can delete those `.migrated` files if you want to reclaim the space.
-
-### 2026-04-26
-
-Cross-backend sync for playlists is now available as a **beta** feature. This is still early work, so expect some rough edges, 
-backend-specific issues, and possible breaking changes as it matures. 
-
-Because playlist behavior differs across backends, the feature may change over time, and if it proves too unreliable to support consistently, 
-it may be reworked or removed. To enable it, simply go to Tasks and enable the `Playlist` task.
 
 Please refer to [NEWS](/NEWS.md) for the latest updates and changes.
 
@@ -118,6 +114,8 @@ After starting the container, you can access the WebUI by visiting `http://local
 
 > [!NOTE]
 > Note, For the first time, you will be prompted to create a new system user, this is a one time operation.
+
+If you want WatchState to match items using local media paths, see the [path matching guide](guides/path-match.md).
 
 To add your backends, please click on the help button in the top right corner, and choose which method you
 want [one-way](guides/one-way-sync.md) or [two-way](guides/two-way-sync.md) sync. and follow the instructions.

--- a/config/config.php
+++ b/config/config.php
@@ -129,6 +129,9 @@ return (function () {
         'disable' => [
             'episode' => (bool) env('WS_GUID_DISABLE_EPISODE', false),
         ],
+        'path' => [
+            'enabled' => (bool) env('WS_GUID_PATH_ENABLED', false),
+        ],
     ];
 
     $config['backends_file'] = fix_path(env('WS_BACKENDS_FILE', ag($config, 'path') . '/config/servers.yaml'));

--- a/config/env.spec.php
+++ b/config/env.spec.php
@@ -491,6 +491,12 @@ return (function () {
             'type' => 'bool',
         ],
         [
+            'key' => 'WS_GUID_PATH_ENABLED',
+            'config' => 'guid.path.enabled',
+            'description' => 'Enable generating path-derived local GUIDs for matching.',
+            'type' => 'bool',
+        ],
+        [
             'key' => 'WS_PROGRESS_MINIMUM',
             'config' => 'progress.minimum',
             'description' => 'Time in seconds to consider progress update as valid.',

--- a/container/files/init-container.sh
+++ b/container/files/init-container.sh
@@ -78,7 +78,7 @@ echo "[$(date +"%Y-%m-%dT%H:%M:%S%z")] Migrating legacy database if needed."
 /opt/bin/console db:legacy --execute
 
 echo "[$(date +"%Y-%m-%dT%H:%M:%S%z")] Running database migrations."
-/opt/bin/console db:migrate --execute
+CONTAINER_INIT=1 /opt/bin/console db:migrate --execute
 
 echo "[$(date +"%Y-%m-%dT%H:%M:%S%z")] Running database maintenance tasks."
 /opt/bin/console db:maintenance

--- a/frontend/app/components/BackendAdd.vue
+++ b/frontend/app/components/BackendAdd.vue
@@ -17,6 +17,24 @@
     <UAlert color="warning" variant="soft" icon="i-lucide-info" title="Important">
       <template #description>
         <ul class="list-disc space-y-2 pl-5 text-sm text-default">
+          <li v-if="pathGuidEnvMissing">
+            Path matching is disabled. If this backend shares media files with your existing
+            backends, consider enabling
+            <NuxtLink
+              to="/env?edit=WS_GUID_PATH_ENABLED&value=true"
+              class="inline-flex items-center gap-1 text-primary"
+            >
+              <UIcon name="i-lucide-sliders-horizontal" class="size-4" />
+              <span>WS_GUID_PATH_ENABLED</span>
+            </NuxtLink>
+            before adding it, so future imports can store path GUIDs without a forced reimport. See
+            the
+            <NuxtLink to="/help/path-match" class="inline-flex items-center gap-1 text-primary">
+              <UIcon name="i-lucide-circle-help" class="size-4" />
+              <span>path matching guide</span>
+            </NuxtLink>
+            for details.
+          </li>
           <li>
             If you are adding new backend that is fresh and doesn't have your current watch state,
             you should turn off import and enable only metadata import at the start to prevent
@@ -641,6 +659,7 @@ const error = ref<string | null>(null);
 const backup_data = ref<boolean>(true);
 const force_export = ref<boolean>(false);
 const force_import = ref<boolean>(false);
+const pathGuidEnvMissing = ref<boolean>(false);
 
 type NotificationType = 'info' | 'success' | 'warning' | 'error';
 
@@ -849,6 +868,15 @@ const updateIdentifier = (): void => {
 onMounted(async () => {
   clearError();
   await loadSupported();
+
+  try {
+    const response = await request('/system/env/WS_GUID_PATH_ENABLED');
+    pathGuidEnvMissing.value = 200 !== response.status;
+  } catch (error) {
+    console.error(error);
+    pathGuidEnvMissing.value = false;
+  }
+
   if (supported.value.length > 0 && supported.value[0]) {
     backend.value.type = supported.value[0];
   }

--- a/frontend/app/components/EventView.vue
+++ b/frontend/app/components/EventView.vue
@@ -359,7 +359,7 @@ const timer = ref<ReturnType<typeof setInterval> | null>(null);
 const toggleLogs = useStorage<boolean>('events_toggle_logs', true);
 const toggleData = useStorage<boolean>('events_toggle_data', true);
 const toggleOptions = useStorage<boolean>('events_toggle_options', true);
-const wrapLines = useStorage<boolean>('logs_wrap_lines', false);
+const wrapLines = useStorage<boolean>('events_wrap_lines', false);
 
 const cardUi = {
   header: 'p-4',

--- a/frontend/app/components/Markdown.vue
+++ b/frontend/app/components/Markdown.vue
@@ -235,7 +235,10 @@ const loadContent = async (): Promise<void> => {
     } as MarkedExtension;
 
     marked.use(options);
-    content.value = String(marked.parse(text));
+    const parsed = String(marked.parse(text));
+    content.value = parsed
+      .replace(/<table>/g, '<div class="ws-markdown-table"><table>')
+      .replace(/<\/table>/g, '</table></div>');
     await nextTick();
     addListeners();
   } catch (caughtError) {
@@ -266,9 +269,19 @@ onBeforeUnmount(() => removeListeners());
 .markdown-alert-title {
   display: inline-flex;
   align-items: center;
+  gap: 0.375rem;
   font-weight: 500;
   text-transform: uppercase;
   user-select: none;
+}
+
+.markdown-alert-title svg {
+  width: 1rem;
+  height: 1rem;
+  flex: 0 0 1rem;
+  color: currentColor;
+  fill: currentColor;
+  stroke: currentColor;
 }
 
 .markdown-alert-note {
@@ -437,12 +450,34 @@ onBeforeUnmount(() => removeListeners());
   border-collapse: collapse;
   overflow: hidden;
   border-radius: 0.375rem;
-  border: 1px solid color-mix(in srgb, var(--ui-border) 50%, transparent);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-bg);
+}
+
+.ws-markdown-table {
+  max-width: 100%;
+  margin: 1rem 0;
+  overflow-x: auto;
+  border: 1px solid var(--ui-border);
+  border-radius: 0.375rem;
+}
+
+.ws-markdown .ws-markdown-table table {
+  width: max-content;
+  min-width: 100%;
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+}
+
+.ws-markdown .ws-markdown-table th,
+.ws-markdown .ws-markdown-table td {
+  white-space: nowrap;
 }
 
 .ws-markdown th,
 .ws-markdown td {
-  border: 1px solid color-mix(in srgb, var(--ui-border) 40%, transparent);
+  border: 1px solid var(--ui-border);
   padding: 0.65rem 0.75rem;
   text-align: left;
   vertical-align: top;
@@ -450,7 +485,11 @@ onBeforeUnmount(() => removeListeners());
 
 .ws-markdown th {
   font-weight: 600;
-  background: color-mix(in srgb, var(--ui-border) 18%, transparent);
+  background: var(--ui-bg-elevated);
+}
+
+.ws-markdown tbody tr:nth-child(even) {
+  background: color-mix(in srgb, var(--ui-bg-elevated) 55%, transparent);
 }
 
 .ws-markdown img {

--- a/frontend/app/pages/env.vue
+++ b/frontend/app/pages/env.vue
@@ -257,7 +257,7 @@
                 <p>This environment variable overrides the shown configuration key.</p>
                 <p>
                   <code>{{ form_config }}</code>
-                  <span>:</span>
+                  <span>: </span>
                   <strong v-if="!form_mask">{{ form_config_value }}</strong>
                   <strong v-else class="text-toned italic">Hidden</strong>
                 </p>

--- a/frontend/app/pages/help/index.vue
+++ b/frontend/app/pages/help/index.vue
@@ -119,5 +119,11 @@ const choices: Array<{ number: number; title: string; text: string; url: string 
     text: 'Browse the bundled Plex, Jellyfin, and Emby upstream routes.',
     url: '/help/openapi',
   },
+  {
+    number: 10,
+    title: 'Path matching',
+    text: 'How to enable path-based matching.',
+    url: '/help/path-match',
+  },
 ];
 </script>

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -346,7 +346,7 @@ useHead({ title: 'Index' });
 const route = useRoute();
 const poster_enable = useStorage('poster_enable', true);
 const autoReloadLogs = useStorage<boolean>('auto_reload_logs', true);
-const wrapLines = useStorage('logs_wrap_lines', false);
+const wrapLines = useStorage('index_logs_wrap_lines', false);
 const breakpoints = useBreakpoints({ mobile: 0, desktop: 640 });
 
 const lastHistory = ref<Array<HistoryItem>>([]);

--- a/guides/path-match.md
+++ b/guides/path-match.md
@@ -62,3 +62,61 @@ Once the import is done, you can inspect the run log in **Operations** > <!--i:i
 
 > [!NOTE]
 > Once the backfill is done, future imports and webhook events will store the new GUID.
+
+# FAQ
+
+### What path parts are used?
+
+Path matching does not try to understand your library root, movie folder, show folder, or season folder names. It normalizes the backend-reported file path by replacing backslashes with `/`, collapsing duplicate separators, and lowercasing path segments. It then hashes fixed suffixes.
+
+| Stored field      | Example backend path           | Suffix used for matching   | Rule                                                 |
+| ----------------- | ------------------------------ | -------------------------- | ---------------------------------------------------- |
+| for movies        | `/foo/bar/movies/movie.mkv`    | `/movies/movie.mkv`        | Final 2 path segments                                |
+| for episodes      | `/foo/bar/tv/show/episode.mkv` | `/tv/show/episode.mkv/1/1` | Final 3 path segments plus logical season/episode    |
+| for episodes show | `/foo/bar/tv/show/episode.mkv` | `/tv/show`                 | The 2 directory segments immediately before the file |
+
+The paths do not need to have the same leading root across backends. They only need the relevant trailing suffix to match.
+
+### What happens with badly made libraries?
+
+Path matching is not meant to rescue every possible broken or non-standard library layout.
+
+The important part is whether the suffix WatchState hashes is stable across backends.
+
+| Case                                                                    | Backend A suffix     | Backend B suffix          | Result   |
+| ----------------------------------------------------------------------- | -------------------- | ------------------------- | -------- |
+| Same flat movie parent                                                  | `/movies/movie.mkv`  | `/movies/movie.mkv`       | Match    |
+| Different flat movie parent                                             | `/movies/movie.mkv`  | `/films/movie.mkv`        | No match |
+| Episode without season folder, same final 3 segments                    | `/tv/anime1/ep1.mkv` | `/tv/anime1/ep1.mkv`      | Match    |
+| Episode without season folder, different library folder in final suffix | `/tv/anime1/ep1.mkv` | `/tvshows/anime1/ep1.mkv` | No match |
+| Too few movie segments                                                  | `/movie.mkv`         | N/A                       | Skipped  |
+| Too few episode segments                                                | `/anime1/ep1.mkv`    | N/A                       | Skipped  |
+
+Path GUID generation is skipped when there are not enough path segments to build the required suffix.
+
+This is intentional. Path matching is an extra fallback for reasonably organized libraries, not a full library-repair system.
+
+### Why not strip the library root or support base-path remapping?
+
+WatchState does not support per-backend root stripping, base-path mapping, or manual path replacement for path matching.
+
+That choice is intentional for three reasons:
+
+1. The current implementation already ignores leading path segments by hashing only fixed trailing suffixes.
+2. Adding per-backend root detection or remapping would make the matching path more complex for a feature that is supposed to behave like a normal GUID source.
+3. Path matching is on a hot import path, so avoiding extra backend-specific lookup and rewrite logic keeps it simpler and cheaper to run.
+
+Example:
+
+| Backend  | Full path                       | Movie suffix used |
+| -------- | ------------------------------- | ----------------- |
+| Plex     | `/media/movies/foo/foo.mkv`     | `/foo/foo.mkv`    |
+| Jellyfin | `/a/b/c/d/whatever/foo/foo.mkv` | `/foo/foo.mkv`    |
+
+These already match because WatchState only cares about `/foo/foo.mkv`, not the different leading roots.
+
+### So when would root stripping help but still not be supported?
+
+Root stripping could help libraries where the configured library root appears inside the final suffix and differs between backends. For example, `/mnt/tv/anime1/ep1.mkv` and `\\nas\tvshows\anime1\ep1.mkv` would only match if WatchState knew to strip `/mnt/tv` and `\\nas\tvshows` first.
+
+That tradeoff is acceptable. Path matching is intentionally optimized for the common case, not every uncommon or poorly structured layout. For more info, see [this discussion](https://github.com/arabcoders/watchstate/discussions/829).

--- a/guides/path-match.md
+++ b/guides/path-match.md
@@ -1,0 +1,64 @@
+# Path Matching
+
+Path matching adds a local GUID source named `guid_path`. When enabled, WatchState derives a stable hash from backend-reported media file paths and stores it alongside the normal GUIDs.
+
+# When Path Matching Helps
+
+Path matching is useful when your backends have missing, weak, or inconsistent external IDs, but they still point at the same local media files.
+
+Examples that still match by path:
+
+```text
+/mnt/media/tv/Show Title/Season 01/S01E01.mkv
+Z:\TV\Show Title\Season 01\S01E01.mkv
+```
+
+Examples that do not match by path:
+
+```text
+/mnt/media/tv/Show Title/Season 01/S01E01.mkv
+/mnt/media/tv/Show Title (2024)/Season 1/Episode 01.mkv
+```
+
+# Enable Path Matching
+
+To enable path matching:
+
+1. Go to **Configuration** > <!--i:i-lucide-sliders-horizontal--> **Environment**.
+2. Click the <!--i:i-lucide-plus--> **Add** button.
+3. Select `WS_GUID_PATH_ENABLED`.
+4. Toggle the switch to enable.
+5. Save the change.
+
+# Updating Existing Data
+
+Enabling path matching only affects entities created or refreshed after the setting is turned on. Existing rows keep their current data until they are imported again. Existing rows without `guid_path` continue to work, but they cannot match by path until refreshed.
+
+If all of your backends point to the same media files, it is usually enough to refresh just one backend. That one import seeds the local database with `guid_path`, and the other backends can continue operating in metadata-only mode while still matching against the stored path GUIDs.
+
+For example:
+
+1. Go to **Operations** > <!--i:i-lucide-terminal--> **Console**.
+2. Run a full import for one backend that has the shared library:
+
+```bash
+state:import --user main --select-backend plex --force-full
+```
+
+If your backends do not all share the same media, run a full refresh across all imported backends instead:
+
+```bash
+state:import -v --force-full
+```
+
+Once the import is done, you can inspect the run log in **Operations** > <!--i:i-lucide-scroll-text--> **Logs**.
+
+# Notes
+
+> [!IMPORTANT]
+> Do not use `--metadata-only` for this refresh. metadata-only mode does not rewrite GUIDs for existing rows.
+> 
+> Backends with `Import` disabled are treated as metadata-only during `state:import`. That is usually fine when all backends share the same media, because one imported backend is enough to seed `guid_path` for the shared items. Only temporarily enable `Import` from the <!--i:i-lucide-server--> **Backends** page if that backend has items or media paths that are not covered by the backend you refreshed.
+
+> [!NOTE]
+> Once the backfill is done, future imports and webhook events will store the new GUID.

--- a/guides/path-match.md
+++ b/guides/path-match.md
@@ -2,6 +2,8 @@
 
 Path matching adds a local GUID source named `guid_path`. When enabled, WatchState derives a stable hash from backend-reported media file paths and stores it alongside the normal GUIDs.
 
+This feature becomes available in v1.8.5+ and is disabled by default for now.
+
 # When Path Matching Helps
 
 Path matching is useful when your backends have missing, weak, or inconsistent external IDs, but they still point at the same local media files.

--- a/src/API/System/Events.php
+++ b/src/API/System/Events.php
@@ -18,6 +18,7 @@ use App\Model\Events\EventsRepository;
 use App\Model\Events\EventsTable as EntityTable;
 use App\Model\Events\EventStatus;
 use InvalidArgumentException;
+use Monolog\Level;
 use Psr\Http\Message\ResponseInterface as iResponse;
 use Psr\Http\Message\ServerRequestInterface as iRequest;
 
@@ -291,14 +292,14 @@ final readonly class Events
         }
 
         if (true === (bool) $params->get('reset_logs', false)) {
-            $entity->logs = [];
+            $entity->clearLogs();
         }
 
         $changed = !empty($entity->diff());
 
         if ($changed) {
             $entity->updated_at = (string) make_date();
-            $entity->logs[] = 'Event was manually updated';
+            $entity->addLog(Level::Info, 'Event was manually updated.');
             $this->repo->save($entity);
         }
 

--- a/src/Backends/Emby/Action/ParseWebhook.php
+++ b/src/Backends/Emby/Action/ParseWebhook.php
@@ -281,7 +281,7 @@ final class ParseWebhook
                                 'payload' => $request->getParsedBody(),
                             ],
                         ],
-                        level: Levels::ERROR,
+                        level: Levels::WARNING,
                     ),
                     extra: [
                         'http_code' => Status::OK->value,

--- a/src/Backends/Jellyfin/Action/ParseWebhook.php
+++ b/src/Backends/Jellyfin/Action/ParseWebhook.php
@@ -252,7 +252,7 @@ final class ParseWebhook
                                 'payload' => $request->getParsedBody(),
                             ],
                         ],
-                        level: Levels::ERROR,
+                        level: Levels::WARNING,
                     ),
                     extra: [
                         'http_code' => Status::OK->value,

--- a/src/Backends/Jellyfin/JellyfinActionTrait.php
+++ b/src/Backends/Jellyfin/JellyfinActionTrait.php
@@ -16,6 +16,7 @@ use App\Libs\Exceptions\Backends\InvalidArgumentException;
 use App\Libs\Exceptions\Backends\RuntimeException;
 use App\Libs\Guid;
 use App\Libs\Options;
+use App\Libs\PathGuid;
 use Psr\Http\Message\UriInterface as iUri;
 use Psr\SimpleCache\CacheInterface as iCache;
 
@@ -188,13 +189,42 @@ trait JellyfinActionTrait
         }
 
         $metadata[iState::COLUMN_META_MULTI] = false;
-        if (null !== ($mediaPath = ag($item, 'Path')) && !empty($mediaPath)) {
+        $mediaPath = ag(
+            $item,
+            'Path',
+            $opts['override'][iState::COLUMN_META_DATA][$context->backendName][iState::COLUMN_META_PATH] ?? null,
+        );
+        if (null !== $mediaPath && !empty($mediaPath)) {
             $metadata[iState::COLUMN_META_PATH] = (string) $mediaPath;
             if (
                 iState::TYPE_EPISODE === $type
                 && true === ag(parse_episode_range(basename((string) $mediaPath)), iState::COLUMN_META_MULTI, false)
             ) {
                 $metadata[iState::COLUMN_META_MULTI] = true;
+            }
+        }
+
+        if (true === (bool) Config::get('guid.path.enabled', false) && null !== $mediaPath && !empty($mediaPath)) {
+            $pathGuids = PathGuid::get(
+                type: $type,
+                path: (string) $mediaPath,
+                season: null !== ($builder[iState::COLUMN_SEASON] ?? null) ? (int) $builder[iState::COLUMN_SEASON] : null,
+                episode: null !== ($builder[iState::COLUMN_EPISODE] ?? null) ? (int) $builder[iState::COLUMN_EPISODE] : null,
+            );
+
+            if (null !== ($pathGuids[iState::COLUMN_GUIDS] ?? null)) {
+                $builder[iState::COLUMN_GUIDS] = array_replace(
+                    $builder[iState::COLUMN_GUIDS] ?? [],
+                    $pathGuids[iState::COLUMN_GUIDS],
+                );
+            }
+
+            if (null !== ($pathGuids[iState::COLUMN_PARENT] ?? null)) {
+                $builder[iState::COLUMN_PARENT] = array_replace(
+                    $builder[iState::COLUMN_PARENT] ?? [],
+                    $pathGuids[iState::COLUMN_PARENT],
+                );
+                $metadata[iState::COLUMN_PARENT] = $builder[iState::COLUMN_PARENT];
             }
         }
 

--- a/src/Backends/Plex/Action/ParseWebhook.php
+++ b/src/Backends/Plex/Action/ParseWebhook.php
@@ -268,7 +268,7 @@ final class ParseWebhook
                                 'payload' => $request->getParsedBody(),
                             ],
                         ],
-                        level: Levels::ERROR,
+                        level: Levels::WARNING,
                     ),
                     extra: [
                         'http_code' => Status::OK->value,

--- a/src/Backends/Plex/PlexActionTrait.php
+++ b/src/Backends/Plex/PlexActionTrait.php
@@ -10,6 +10,7 @@ use App\Backends\Common\Response;
 use App\Backends\Plex\Action\GetLibrariesList;
 use App\Backends\Plex\Action\GetMetaData;
 use App\Backends\Plex\Action\GetWebUrl;
+use App\Libs\Config;
 use App\Libs\Container;
 use App\Libs\Entity\StateEntity;
 use App\Libs\Entity\StateInterface as iState;
@@ -17,6 +18,7 @@ use App\Libs\Exceptions\Backends\InvalidArgumentException;
 use App\Libs\Exceptions\Backends\RuntimeException;
 use App\Libs\Guid;
 use App\Libs\Options;
+use App\Libs\PathGuid;
 use Psr\Http\Message\UriInterface as iUri;
 use Psr\SimpleCache\CacheInterface as iCache;
 
@@ -213,6 +215,30 @@ trait PlexActionTrait
 
         if (null === $mediaPath && null !== ($showPath = ag($item, 'Location.0.path')) && !empty($showPath)) {
             $metadata[iState::COLUMN_META_PATH] = (string) $showPath;
+        }
+
+        if (true === (bool) Config::get('guid.path.enabled', false) && null !== $mediaPath && !empty($mediaPath)) {
+            $pathGuids = PathGuid::get(
+                type: $type,
+                path: (string) $mediaPath,
+                season: null !== ($builder[iState::COLUMN_SEASON] ?? null) ? (int) $builder[iState::COLUMN_SEASON] : null,
+                episode: null !== ($builder[iState::COLUMN_EPISODE] ?? null) ? (int) $builder[iState::COLUMN_EPISODE] : null,
+            );
+
+            if (null !== ($pathGuids[iState::COLUMN_GUIDS] ?? null)) {
+                $builder[iState::COLUMN_GUIDS] = array_replace(
+                    $builder[iState::COLUMN_GUIDS] ?? [],
+                    $pathGuids[iState::COLUMN_GUIDS],
+                );
+            }
+
+            if (null !== ($pathGuids[iState::COLUMN_PARENT] ?? null)) {
+                $builder[iState::COLUMN_PARENT] = array_replace(
+                    $builder[iState::COLUMN_PARENT] ?? [],
+                    $pathGuids[iState::COLUMN_PARENT],
+                );
+                $metadata[iState::COLUMN_PARENT] = $builder[iState::COLUMN_PARENT];
+            }
         }
 
         if (null !== ($PremieredAt = ag($item, 'originallyAvailableAt'))) {

--- a/src/Commands/Config/ViewCommand.php
+++ b/src/Commands/Config/ViewCommand.php
@@ -155,7 +155,7 @@ final class ViewCommand extends Command
 
         if (empty($list)) {
             $output->writeln(r('<error>{error}</error>', [
-                'error' => $isCustom ? '[-s, --select-backend] did not return any backend.' : 'No backends were found.',
+                'error' => $isCustom ? '[-s, --select-backend] did not return any backend.' : 'No backends were found for view.',
             ]));
             return self::FAILURE;
         }

--- a/src/Commands/Database/MigrateCommand.php
+++ b/src/Commands/Database/MigrateCommand.php
@@ -23,12 +23,15 @@ final class MigrateCommand extends Command
 {
     public const string ROUTE = 'db:migrate';
 
+    private bool $viaInit = false;
+
     public function __construct(
         private readonly PdoFactory $pdoFactory,
         private readonly PackageMigrationFactory $migrations,
         private readonly iLogger $logger,
     ) {
         parent::__construct();
+        $this->viaInit = (bool) env('CONTAINER_INIT', false);
     }
 
     protected function configure(): void
@@ -87,9 +90,12 @@ final class MigrateCommand extends Command
             }
 
             if (empty($result->migrations)) {
-                $output->writeln(r('<comment>{target}: No migration is needed.</comment>', [
-                    'target' => $target['name'],
-                ]));
+                $output->writeln(
+                    messages: r('<comment>{target}: No migration is needed.</comment>', [
+                        'target' => $target['name'],
+                    ]),
+                    options: $this->viaInit ? OutputInterface::VERBOSITY_VERBOSE : OutputInterface::VERBOSITY_NORMAL,
+                );
                 continue;
             }
 

--- a/src/Commands/Events/DispatchCommand.php
+++ b/src/Commands/Events/DispatchCommand.php
@@ -80,7 +80,7 @@ final class DispatchCommand extends Command
             }
 
             if ($input->getOption('reset')) {
-                $event->logs = [];
+                $event->clearLogs();
             }
 
             $this->runEvent($event, visibleLevel: $visibleLevel, debug: $debug);
@@ -168,18 +168,20 @@ final class DispatchCommand extends Command
                 'date' => make_date($event->created_at),
             ];
 
-            $event->logs[] = r($message, $log_data);
-
             $event->status = Status::RUNNING;
             $event->updated_at = (string) make_date();
             $event->attempts += 1;
             if (true === $debug) {
                 $event->options[Options::DEBUG_TRACE] = true;
             }
+
+            $ref = new DataEvent($event)->setVisibleLevel($visibleLevel);
+
+            $ref->addLog(Level::Notice, "Dispatching Event: '{event}' queued at '{date}'.", $log_data);
+            $ref->resetVisibleLogs();
+
             $this->repo->save($event);
 
-            $logCount = count($event->logs);
-            $ref = new DataEvent($event);
             $capturedHandlers = $this->captureLogger($capturedRecords);
 
             try {
@@ -196,13 +198,13 @@ final class DispatchCommand extends Command
 
             $event->updated_at = (string) make_date();
 
-            if ($this->isVisible(array_slice($event->logs, $logCount), $visibleLevel)) {
+            if ($ref->hasVisibleLogs()) {
                 $this->logger->notice($message, $log_data);
             }
 
             $this->replayRecords($capturedHandlers, $capturedRecords);
 
-            $event->logs[] = r("Event '{event}' was dispatched.", ['event' => $event->event]);
+            $ref->addLog(Level::Notice, "Event '{event}' was dispatched.", ['event' => $event->event]);
 
             $this->repo->save($event);
         } catch (Throwable $e) {
@@ -214,8 +216,10 @@ final class DispatchCommand extends Command
                 'error' => $e->getMessage(),
             ]);
 
-            $event->logs[] = $errorLog;
-            array_push($event->logs, ...$e->getTrace());
+            $event->addRawLog($errorLog);
+            foreach ($e->getTrace() as $trace) {
+                $event->addRawLog((string) json_encode($trace, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+            }
             $event->status = Status::FAILED;
             $event->updated_at = (string) make_date();
             $this->repo->save($event);
@@ -287,44 +291,6 @@ final class DispatchCommand extends Command
             OutputInterface::VERBOSITY_VERY_VERBOSE => Level::Info,
             default => Level::Debug,
         };
-    }
-
-    private function isVisible(array $logs, Level $visibleLevel): bool
-    {
-        $count = 0;
-
-        foreach ($logs as $log) {
-            $level = $this->eventLevel($log);
-
-            if (null === $level) {
-                continue;
-            }
-
-            if ($level->value >= $visibleLevel->value) {
-                $count++;
-            }
-        }
-
-        return $count > 0;
-    }
-
-    private function eventLevel(mixed $log): ?Level
-    {
-        if (false === is_string($log)) {
-            return null;
-        }
-
-        $levelRegex = '/^(?:\[[^\]]+]\s*)?(?:[a-z0-9_.-]+\.)?(?<level>EMERGENCY|ALERT|CRITICAL|ERROR|WARNING|NOTICE|INFO|DEBUG):\s*/i';
-
-        if (1 !== preg_match($levelRegex, trim($log), $matches)) {
-            return null;
-        }
-
-        try {
-            return MonologLogger::toMonologLevel(strtoupper($matches['level']));
-        } catch (Throwable) {
-            return null;
-        }
     }
 
     /**

--- a/src/Commands/Events/DispatchCommand.php
+++ b/src/Commands/Events/DispatchCommand.php
@@ -61,6 +61,7 @@ final class DispatchCommand extends Command
             ->setName(self::ROUTE)
             ->addOption('id', 'i', InputOption::VALUE_REQUIRED, 'Force run this event.')
             ->addOption('reset', 'r', InputOption::VALUE_NONE, 'Reset event logs.')
+            ->addOption('limit', 'L', InputOption::VALUE_REQUIRED, 'How many events to run at per run.', 15)
             ->setDescription('Run queued events.');
     }
 
@@ -88,14 +89,15 @@ final class DispatchCommand extends Command
             return self::SUCCESS;
         }
 
-        return $this->runEvents(visibleLevel: $visibleLevel, debug: $debug);
+        return $this->runEvents(visibleLevel: $visibleLevel, limit: (int) $input->getOption('limit'), debug: $debug);
     }
 
-    protected function runEvents(Level $visibleLevel, bool $debug = false): int
+    protected function runEvents(Level $visibleLevel, int $limit, bool $debug = false): int
     {
         $repo = $this->repo
             ->setSort(EventsTable::COLUMN_CREATED_AT)
             ->setAscendingOrder()
+            ->setPerpage($limit)
             ->findAll([EventsTable::COLUMN_STATUS => Status::PENDING->value]);
 
         $events = [];

--- a/src/Commands/State/BackupCommand.php
+++ b/src/Commands/State/BackupCommand.php
@@ -295,7 +295,7 @@ class BackupCommand extends Command
 
         if (empty($list)) {
             $this->logger->warning(
-                $isCustom ? '[-s, --select-backend] flag did not match any backend.' : 'No backends were found.',
+                $isCustom ? '[-s, --select-backend] flag did not match any backend.' : 'No backends were found for backup.',
             );
             return;
         }

--- a/src/Commands/State/ExportCommand.php
+++ b/src/Commands/State/ExportCommand.php
@@ -255,7 +255,7 @@ class ExportCommand extends Command
                 }
 
                 if (empty($backends)) {
-                    $message = $isCustom ? '[-s, --select-backend] flag did not match any backend.' : 'No backends were found.';
+                    $message = $isCustom ? '[-s, --select-backend] flag did not match any backend.' : 'No backends were found for export.';
                     $this->logger->warning("{message}. For '{user}'.", [
                         'message' => $message,
                         'user' => $userContext->name,

--- a/src/Commands/State/ImportCommand.php
+++ b/src/Commands/State/ImportCommand.php
@@ -124,7 +124,7 @@ class ImportCommand extends Command
                 'always-update-metadata',
                 null,
                 InputOption::VALUE_NONE,
-                'Mapper option. Always update the locally stored metadata from backend.',
+                'Replace existing metadata with data from backend even if there is no change.',
             )
             ->addOption('show-messages', null, InputOption::VALUE_NONE, 'Show internal messages.')
             ->addOption('logfile', null, InputOption::VALUE_REQUIRED, 'Save console output to file.');

--- a/src/Commands/State/ImportCommand.php
+++ b/src/Commands/State/ImportCommand.php
@@ -284,7 +284,7 @@ class ImportCommand extends Command
                     $isCustom
                         ? r("[-s, --select-backend] flag did not match any backend for '{user}'.", [
                             'user' => $userContext->name,
-                        ]) : 'No backends were found.',
+                        ]) : 'No backends were found for import.',
                 );
                 continue;
             }

--- a/src/Commands/System/SchedulerCommand.php
+++ b/src/Commands/System/SchedulerCommand.php
@@ -71,7 +71,7 @@ final class SchedulerCommand extends Command
 
                 $output->writeln('Running tasks', iOutput::VERBOSITY_DEBUG);
                 $out = run_command(TasksCommand::ROUTE, ['--run', '--save-log'], asArray: true, opts: [
-                    'timeout' => 3600 * 4,
+                    'timeout' => 3600 * 8,
                 ]);
 
                 foreach ($out as $line) {

--- a/src/Commands/System/TasksCommand.php
+++ b/src/Commands/System/TasksCommand.php
@@ -13,6 +13,7 @@ use App\Libs\Events\DataEvent;
 use App\Libs\Extends\ConsoleOutput;
 use App\Libs\LogSuppressor;
 use App\Libs\Stream;
+use App\Model\Events\Event as EventModel;
 use App\Model\Events\EventListener;
 use App\Model\Events\EventsRepository;
 use App\Model\Events\EventStatus;
@@ -20,6 +21,7 @@ use Closure;
 use Cron\CronExpression;
 use DateInterval;
 use Exception;
+use Monolog\Level;
 use Psr\Log\LoggerInterface as iLogger;
 use Psr\SimpleCache\CacheInterface as iCache;
 use Symfony\Component\Console\Completion\CompletionInput;
@@ -211,21 +213,21 @@ final class TasksCommand extends Command
         switch ($eventName) {
             case self::NAME:
                 if (null === ($name = ag($event->getData(), 'name'))) {
-                    $event->addLog(r('No task name was specified.'));
+                    $event->addLog(Level::Error, 'No task name was specified.');
                     return $event;
                 }
 
                 $task = self::getTasks($name);
                 if (empty($task)) {
-                    $event->addLog(
-                        r("Invalid task '{name}'. There are no task with that name registered.", ['name' => $name]),
-                    );
+                    $event->addLog(Level::Error, "Invalid task '{task_id}'. There are no task with that name registered.", [
+                        'task_id' => $name,
+                    ]);
                     return $event;
                 }
                 break;
             case self::CNAME:
                 if (null === ag($event->getData(), 'command')) {
-                    $event->addLog(r('No command name was specified.'));
+                    $event->addLog(Level::Error, 'No command name was specified.');
                     return $event;
                 }
                 break;
@@ -253,7 +255,7 @@ final class TasksCommand extends Command
                     $lastSave = $timeNow;
                 }
 
-                $event->addLog($msg);
+                $event->addRawLog($msg);
 
                 if ($timeNow >= $lastSave) {
                     ($this->save)();
@@ -265,26 +267,44 @@ final class TasksCommand extends Command
             };
 
             if (self::CNAME === $eventName) {
-                $event->addLog(r("Task: Run '{name}'.", ['name' => $eventName]));
+                $event->addLog(Level::Info, "Task '{task_id}' started: {command}.", [
+                    'task_id' => $eventName,
+                    'command' => ag($event->getData(), 'command'),
+                ]);
                 $exitCode = $this->run_command(
                     ag($event->getData(), 'command'),
                     ag($event->getData(), 'args', []),
                     $input,
                     Container::get(iOutput::class),
                 );
-                $event->addLog(r("Task: End '{name}' (Exit Code: {code})", [
-                    'name' => $eventName,
-                    'code' => $exitCode,
-                ]));
+                $event->addLog(
+                    0 === $exitCode ? Level::Info : Level::Error,
+                    "Task '{task_id}' {status} with exit code {exit_code}.",
+                    [
+                        'task_id' => $eventName,
+                        'exit_code' => $exitCode,
+                        'status' => 0 === $exitCode ? 'completed' : 'failed',
+                        'command' => ag($event->getData(), 'command'),
+                    ],
+                );
             }
 
             if (self::NAME === $eventName && !empty($task)) {
-                $event->addLog(r("Task: Run '{command}'.", ['command' => ag($task, 'command')]));
-                $exitCode = $this->runTask($task, $input, Container::get(iOutput::class));
-                $event->addLog(r("Task: End '{command}' (Exit Code: {code})", [
+                $event->addLog(Level::Info, "Task '{task_id}' started: {command}.", [
+                    'task_id' => ag($task, 'name'),
                     'command' => ag($task, 'command'),
-                    'code' => $exitCode,
-                ]));
+                ]);
+                $exitCode = $this->runTask($task, $input, Container::get(iOutput::class));
+                $event->addLog(
+                    0 === $exitCode ? Level::Info : Level::Error,
+                    "Task '{task_id}' {status} with exit code {exit_code}.",
+                    [
+                        'task_id' => ag($task, 'name'),
+                        'exit_code' => $exitCode,
+                        'status' => 0 === $exitCode ? 'completed' : 'failed',
+                        'command' => ag($task, 'command'),
+                    ],
+                );
             }
         } finally {
             $this->needToSave = false;
@@ -462,27 +482,33 @@ final class TasksCommand extends Command
             $event->event = self::NAME . '.' . $task['name'];
             $event->created_at = $started;
             $event->updated_at = $ended;
-            $event->logs[] = '--------------------------';
-            $event->logs[] = r('Task: {name} (Started: {start_date})', [
+            $event->addRawLog('--------------------------');
+            $event->addRawLog(r('Task: {name} (Started: {start_date})', [
                 'name' => $task['name'],
                 'start_date' => $started->format('D, H:i:s T'),
-            ]);
-            $event->logs[] = r('Command: {cmd}', ['cmd' => $process->getCommandLine()]);
-            $event->logs[] = r('Exit Code: {code}:{status} (Ended: {end_date}) - Took {duration}s', [
+            ]));
+            $event->addRawLog(r('Command: {cmd}', ['cmd' => $process->getCommandLine()]));
+            $event->addRawLog(r('Exit Code: {code}:{status} (Ended: {end_date}) - Took {duration}s', [
                 'status' => 0 === $process->getExitCode() ? 'Success' : 'Failed',
                 'code' => $process->getExitCode() ?? self::INVALID,
                 'end_date' => $ended->format('D, H:i:s T'),
                 'duration' => $ended->getTimestamp() - $started->getTimestamp(),
-            ]);
-            $event->logs[] = '--------------------------';
+            ]));
+            $event->addRawLog('--------------------------');
             if (count($this->taskOutput) < 1) {
                 if (0 === $process->getExitCode()) {
-                    $event->logs[] = 'Task completed successfully. And did not produce any output.';
+                    $event->addRawLog('Task completed successfully. And did not produce any output.');
                 } else {
-                    $event->logs[] = 'Task failed to complete. And did not produce any output.';
+                    $event->addRawLog('Task failed to complete. And did not produce any output.');
                 }
             } else {
-                $event->logs = array_merge($event->logs, array_slice($this->taskOutput, -200));
+                $limit = max(0, EventModel::MAX_LOG_ENTRIES - count($event->logs));
+
+                if ($limit > 0) {
+                    foreach (array_slice($this->taskOutput, -$limit) as $line) {
+                        $event->addRawLog($line);
+                    }
+                }
             }
             $this->eventsRepo->save($event);
         }

--- a/src/Libs/Events/DataEvent.php
+++ b/src/Libs/Events/DataEvent.php
@@ -6,11 +6,14 @@ namespace App\Libs\Events;
 
 use App\Model\Events\Event as EventInfo;
 use App\Model\Events\EventStatus;
+use Monolog\Level;
 use Symfony\Contracts\EventDispatcher\Event;
 
 class DataEvent extends Event
 {
     private EventStatus $status;
+    private ?Level $visibleLevel = null;
+    private bool $hasVisibleLogs = false;
 
     public function __construct(
         private readonly EventInfo $eventInfo,
@@ -39,17 +42,57 @@ class DataEvent extends Event
         return $this->eventInfo->reference;
     }
 
-    public function addLog(string $log): void
+    public function addLog(Level $level, string $message, array $context = []): bool
     {
-        if (count($this->eventInfo->logs) >= 200) {
-            array_shift($this->eventInfo->logs);
+        $added = $this->eventInfo->addLog($level, $message, $context);
+
+        if (true === $added && null !== $this->visibleLevel && $level->value >= $this->visibleLevel->value) {
+            $this->hasVisibleLogs = true;
         }
-        $this->eventInfo->logs[] = $log;
+
+        return $added;
+    }
+
+    /**
+     * Track persisted typed logs at or above the dispatch-visible level.
+     */
+    public function setVisibleLevel(?Level $visibleLevel): DataEvent
+    {
+        $this->visibleLevel = $visibleLevel;
+        $this->hasVisibleLogs = false;
+        return $this;
+    }
+
+    /**
+     * Check whether a persisted typed log met the tracked visible level.
+     */
+    public function hasVisibleLogs(): bool
+    {
+        return $this->hasVisibleLogs;
+    }
+
+    /**
+     * Reset the tracked visible-log flag.
+     */
+    public function resetVisibleLogs(): void
+    {
+        $this->hasVisibleLogs = false;
+    }
+
+    /**
+     * Direct usage of this function is discouraged.
+     * Use {@see self::addLog()} instead to ensure log levels are respected.
+     *
+     * @param string $log The log message to add.
+     */
+    public function addRawLog(string $log): void
+    {
+        $this->eventInfo->addRawLog($log);
     }
 
     public function clearLogs(): void
     {
-        $this->eventInfo->logs = [];
+        $this->eventInfo->clearLogs();
     }
 
     public function getLogs(): array

--- a/src/Libs/Guid.php
+++ b/src/Libs/Guid.php
@@ -33,6 +33,7 @@ final class Guid implements JsonSerializable, Stringable
     public const string GUID_ANIDB = 'guid_anidb';
     public const string GUID_YOUTUBE = 'guid_youtube';
     public const string GUID_CMDB = 'guid_cmdb';
+    public const string GUID_PATH = 'guid_path';
 
     /**
      * @var array GUID types and their respective data types.
@@ -46,6 +47,7 @@ final class Guid implements JsonSerializable, Stringable
         Guid::GUID_ANIDB => 'string',
         Guid::GUID_YOUTUBE => 'string',
         Guid::GUID_CMDB => 'string',
+        Guid::GUID_PATH => 'string',
     ];
 
     private static array $supported = self::DEFAULT_SUPPORTED;
@@ -113,6 +115,15 @@ final class Guid implements JsonSerializable, Stringable
             'tests' => [
                 'valid' => ['123456'],
                 'invalid' => ['123456a', 'd123456'],
+            ],
+        ],
+        Guid::GUID_PATH => [
+            'description' => 'The path ID Parser.',
+            'pattern' => '/^(?<guid>[a-f0-9]{32}(?:\/[0-9]+\/[0-9]+)?)$/',
+            'example' => '32 character md5 hash',
+            'tests' => [
+                'valid' => ['0123456789abcdef0123456789abcdef', '0123456789abcdef0123456789abcdef/1/2'],
+                'invalid' => ['0123456789abcdef0123456789abcdeg', '0123456789abcdef0123456789abcdef/1', '123456'],
             ],
         ],
     ];

--- a/src/Libs/PathGuid.php
+++ b/src/Libs/PathGuid.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Libs;
+
+use App\Libs\Entity\StateInterface as iState;
+
+final class PathGuid
+{
+    private const string SCOPE_MOVIE = 'movie';
+    private const string SCOPE_EPISODE = 'episode';
+    private const string SCOPE_SHOW = 'show';
+
+    /**
+     * Generate path-derived GUID fields for a state entity.
+     *
+     * @param string $type Entity type.
+     * @param string $path Raw backend media path.
+     * @param int|null $season Episode season number.
+     * @param int|null $episode Episode number.
+     *
+     * @return array<string,array<string,string>> Entity GUID fields keyed by `guids` and/or `parent`.
+     */
+    public static function get(string $type, string $path, ?int $season = null, ?int $episode = null): array
+    {
+        if (null === ($segments = self::segments($path))) {
+            return [];
+        }
+
+        if (iState::TYPE_MOVIE === $type) {
+            if (count($segments) < 2) {
+                return [];
+            }
+
+            return [
+                iState::COLUMN_GUIDS => [
+                    Guid::GUID_PATH => self::hash(self::SCOPE_MOVIE, self::suffix($segments, 2)),
+                ],
+            ];
+        }
+
+        if (iState::TYPE_EPISODE !== $type || count($segments) < 3 || null === $season || null === $episode) {
+            return [];
+        }
+
+        $episodeSuffix = self::suffix($segments, 3) . '/' . $season . '/' . $episode;
+        $parentSuffix = '/' . implode('/', array_slice($segments, -3, 2));
+
+        return [
+            iState::COLUMN_GUIDS => [
+                Guid::GUID_PATH => self::hash(self::SCOPE_EPISODE, $episodeSuffix),
+            ],
+            iState::COLUMN_PARENT => [
+                Guid::GUID_PATH => self::hash(self::SCOPE_SHOW, $parentSuffix),
+            ],
+        ];
+    }
+
+    /**
+     * Normalize a raw path into lowercase path segments.
+     *
+     * @param string $path Raw path.
+     *
+     * @return array<string>|null Normalized path segments, or null when not a file path.
+     */
+    private static function segments(string $path): ?array
+    {
+        if ('' === ($path = trim(str_replace('\\', '/', $path)))) {
+            return null;
+        }
+
+        if (null === ($normalized = preg_replace('#/+#', '/', $path))) {
+            return null;
+        }
+
+        if ('' === ($normalized = rtrim($normalized, '/'))) {
+            return null;
+        }
+
+        $segments = array_values(array_filter(explode('/', $normalized), static fn(string $segment): bool => '' !== $segment));
+        if (count($segments) < 1) {
+            return null;
+        }
+
+        $file = end($segments);
+        if (false === is_string($file) || '' === pathinfo($file, PATHINFO_EXTENSION)) {
+            return null;
+        }
+
+        return array_map(static fn(string $segment): string => mb_strtolower($segment), $segments);
+    }
+
+    /**
+     * Build a normalized path suffix from the final path segments.
+     *
+     * @param array<string> $segments Normalized path segments.
+     * @param int $length Number of final segments to include.
+     */
+    private static function suffix(array $segments, int $length): string
+    {
+        return '/' . implode('/', array_slice($segments, -$length));
+    }
+
+    /**
+     * Hash a scoped path suffix.
+     *
+     * @param string $scope Hash scope.
+     * @param string $suffix Normalized path suffix.
+     */
+    private static function hash(string $scope, string $suffix): string
+    {
+        return hash('md5', $scope . ':' . $suffix);
+    }
+}

--- a/src/Listeners/ProcessProfileEvent.php
+++ b/src/Listeners/ProcessProfileEvent.php
@@ -27,7 +27,7 @@ final readonly class ProcessProfileEvent
      * Class constructor.
      *
      * @param iLogger $logger The logger object.
-     * @param iHttp $client The http client object.
+     * @param iHttp&\App\Libs\Extends\HttpClient $client The http client object.
      */
     public function __construct(
         private iLogger $logger,
@@ -39,7 +39,7 @@ final readonly class ProcessProfileEvent
     public function __invoke(DataEvent $e): DataEvent
     {
         $writer = function (Level $level, string $message, array $context = []) use ($e) {
-            $e->addLog($level->getName() . ': ' . r($message, $context));
+            $e->addLog($level, $message, $context);
             $this->logger->log($level, $message, $context);
         };
 

--- a/src/Listeners/ProcessProgressEvent.php
+++ b/src/Listeners/ProcessProgressEvent.php
@@ -50,7 +50,7 @@ final readonly class ProcessProgressEvent
     public function __invoke(DataEvent $event): DataEvent
     {
         $writer = function (Level $level, string $message, array $context = []) use ($event) {
-            $event->addLog($level->getName() . ': ' . r($message, $context));
+            $event->addLog($level, $message, $context);
             $this->logger->log($level, $message, $context);
         };
 

--- a/src/Listeners/ProcessPushEvent.php
+++ b/src/Listeners/ProcessPushEvent.php
@@ -48,7 +48,7 @@ final readonly class ProcessPushEvent
     public function __invoke(DataEvent $e): DataEvent
     {
         $writer = function (Level $level, string $message, array $context = []) use ($e) {
-            $e->addLog($level->getName() . ': ' . r($message, $context));
+            $e->addLog($level, $message, $context);
             $this->logger->log($level, $message, $context);
         };
 
@@ -87,7 +87,7 @@ final readonly class ProcessPushEvent
             $type = strtolower(ag($backend, 'type', 'unknown'));
 
             if (true !== (bool) ag($backend, 'export.enabled')) {
-                $writer(Level::Notice, "Export to '{user}@{backend}' is disabled by user.", [
+                $writer(Level::Info, "Export to '{user}@{backend}' is disabled by user.", [
                     'user' => $user,
                     'backend' => $backendName,
                 ]);

--- a/src/Listeners/ProcessWebhookEvent.php
+++ b/src/Listeners/ProcessWebhookEvent.php
@@ -71,7 +71,7 @@ final class ProcessWebhookEvent
         $this->event = $event;
 
         $this->writer = function (Level $level, string $message, array $context = []) use ($event): void {
-            $event->addLog($level->getName() . ': ' . r($message, $context));
+            $event->addLog($level, $message, $context);
             $this->logger->log($level, $message, $context);
         };
 
@@ -499,7 +499,17 @@ final class ProcessWebhookEvent
         $logger = clone $this->logger;
         assert($logger instanceof Logger, 'Expected logger instance for request processing.');
 
-        $handler = ProxyHandler::create($event->addLog(...), Level::Info);
+        $handler = ProxyHandler::create(
+            static function (string $_message, mixed $record) use ($event): void {
+                if (false === $record instanceof \Monolog\LogRecord) {
+                    return;
+                }
+
+                $event->addLog($record->level, $record->message, $record->context);
+            },
+            (bool) ag($options, Options::DEBUG_TRACE, false) ? Level::Debug : Level::Info,
+        );
+
         $logger->pushHandler($handler);
         $mapper->setLogger($logger);
         $opts = [
@@ -567,8 +577,13 @@ final class ProcessWebhookEvent
             $context['attributes'] = $attributes;
         }
 
-        $levelName = $level instanceof Level ? $level->getName() : (string) $level;
-        $this->event?->addLog($levelName . ': ' . r($message, $context));
+        try {
+            $eventLevel = Logger::toMonologLevel($level);
+        } catch (Throwable) {
+            $eventLevel = Level::Notice;
+        }
+
+        $this->event?->addLog($eventLevel, $message, $context);
 
         if (true === (Config::get('logs.context') || $forceContext)) {
             $this->logger->log($level, $message, $context);

--- a/src/Model/Events/Event.php
+++ b/src/Model/Events/Event.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 namespace App\Model\Events;
 
 use App\libs\Extends\Date;
+use App\Libs\Options;
 use App\Model\Base\Transformers\ArrayTransformer;
 use App\Model\Base\Transformers\DateTransformer;
 use App\Model\Base\Transformers\EnumTransformer;
 use App\Model\Events\EventsTable as EntityTable;
 use App\Model\Events\EventValidation as EntityValidation;
+use Monolog\Level;
 
 final class Event extends EntityTable
 {
+    public const int MAX_LOG_ENTRIES = 200;
+
     protected string $primaryKey = EntityTable::TABLE_PRIMARY_KEY;
 
     /**
@@ -80,6 +84,44 @@ final class Event extends EntityTable
     public function getStatusText(): string
     {
         return ucfirst(strtolower($this->status->name));
+    }
+
+    /**
+     * Add a formatted log entry if the current event options allow it.
+     *
+     * @param array<string, mixed> $context
+     *
+     * @return bool True when the log entry was persisted.
+     */
+    public function addLog(Level $level, string $message, array $context = []): bool
+    {
+        if (false === (bool) ($this->options[Options::DEBUG_TRACE] ?? false) && $level->value < Level::Info->value) {
+            return false;
+        }
+
+        $this->addRawLog($level->getName() . ': ' . r($message, $context));
+
+        return true;
+    }
+
+    /**
+     * Add a raw log entry without applying any level-based filtering.
+     */
+    public function addRawLog(string $log): void
+    {
+        if (count($this->logs) >= self::MAX_LOG_ENTRIES) {
+            array_shift($this->logs);
+        }
+
+        $this->logs[] = $log;
+    }
+
+    /**
+     * Remove all log entries for this event.
+     */
+    public function clearLogs(): void
+    {
+        $this->logs = [];
     }
 
     public function validate(): bool

--- a/tests/Backends/MediaBrowser/ToEntityTest.php
+++ b/tests/Backends/MediaBrowser/ToEntityTest.php
@@ -11,8 +11,10 @@ use App\Backends\Jellyfin\Action\ToEntity as JellyfinToEntity;
 use App\Backends\Jellyfin\Action\GetMetaData as JellyfinGetMetaData;
 use App\Backends\Jellyfin\JellyfinGuid;
 use App\Backends\Common\Response;
+use App\Libs\Config;
 use App\Libs\Entity\StateInterface;
 use App\Libs\Container;
+use App\Libs\Guid;
 
 class ToEntityTest extends MediaBrowserTestCase
 {
@@ -66,6 +68,41 @@ class ToEntityTest extends MediaBrowserTestCase
             $this->assertTrue($result->isSuccessful());
             $this->assertInstanceOf(StateInterface::class, $result->response);
             $this->assertNotEmpty($result->response->parent);
+        }
+    }
+
+    public function test_to_entity_path_guid(): void
+    {
+        Config::save('guid.path.enabled', true);
+
+        try {
+            foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass]) {
+                $context = $this->makeContext($clientName);
+                $guid = new $guidClass($this->logger);
+                $action = new $actionClass($guid);
+
+                $movie = $action($context, $this->fixture('metadata'));
+
+                $this->assertTrue($movie->isSuccessful());
+                $this->assertSame(
+                    md5('movie:/test-movie/test-movie.mkv'),
+                    $movie->response->guids[Guid::GUID_PATH] ?? null,
+                );
+
+                $episode = $action($context, $this->fixture('metadata_episode'));
+
+                $this->assertTrue($episode->isSuccessful());
+                $this->assertSame(
+                    md5('episode:/test-show/season-1/pilot.mkv/1/1'),
+                    $episode->response->guids[Guid::GUID_PATH] ?? null,
+                );
+                $this->assertSame(
+                    md5('show:/test-show/season-1'),
+                    $episode->response->parent[Guid::GUID_PATH] ?? null,
+                );
+            }
+        } finally {
+            Config::save('guid.path.enabled', false);
         }
     }
 

--- a/tests/Backends/Plex/ToEntityTest.php
+++ b/tests/Backends/Plex/ToEntityTest.php
@@ -7,9 +7,11 @@ namespace Tests\Backends\Plex;
 use App\Backends\Plex\Action\ToEntity;
 use App\Backends\Plex\Action\GetMetaData;
 use App\Backends\Plex\PlexGuid;
+use App\Libs\Config;
 use App\Libs\Entity\StateInterface;
 use App\Backends\Common\Response;
 use App\Libs\Container;
+use App\Libs\Guid;
 
 class ToEntityTest extends PlexTestCase
 {
@@ -144,5 +146,54 @@ class ToEntityTest extends PlexTestCase
         $this->assertTrue($result->isSuccessful());
         $this->assertInstanceOf(StateInterface::class, $result->response);
         $this->assertSame('72408', $result->response->parent['guid_tvdb'] ?? null);
+    }
+
+    public function test_to_entity_path_guid(): void
+    {
+        Config::save('guid.path.enabled', true);
+
+        try {
+            $context = $this->makeContext();
+            $action = new ToEntity(new PlexGuid($this->logger));
+
+            $movie = ag($this->fixture('library_movie_get_200'), 'response.body.MediaContainer.Metadata.0');
+            $movieResult = $action($context, $movie);
+
+            $this->assertTrue($movieResult->isSuccessful());
+            $this->assertSame(
+                md5('movie:/ferengi rules of acquisition (2000)/ferengi rules of acquisition (2000).mp4'),
+                $movieResult->response->guids[Guid::GUID_PATH] ?? null,
+            );
+
+            $episode = [
+                'ratingKey' => '12',
+                'type' => 'episode',
+                'title' => 'Pilot',
+                'grandparentTitle' => 'Show Title',
+                'parentIndex' => 1,
+                'index' => 1,
+                'addedAt' => 1000,
+                'Media' => [
+                    [
+                        'Part' => [
+                            ['file' => '/media/tv/Show_Title/Season 01/S01E01.MKV'],
+                        ],
+                    ],
+                ],
+            ];
+            $episodeResult = $action($context, $episode);
+
+            $this->assertTrue($episodeResult->isSuccessful());
+            $this->assertSame(
+                md5('episode:/show_title/season 01/s01e01.mkv/1/1'),
+                $episodeResult->response->guids[Guid::GUID_PATH] ?? null,
+            );
+            $this->assertSame(
+                md5('show:/show_title/season 01'),
+                $episodeResult->response->parent[Guid::GUID_PATH] ?? null,
+            );
+        } finally {
+            Config::save('guid.path.enabled', false);
+        }
     }
 }

--- a/tests/Commands/Events/DispatchCommandTest.php
+++ b/tests/Commands/Events/DispatchCommandTest.php
@@ -13,41 +13,35 @@ use App\Model\Events\EventsRepository;
 use Monolog\Handler\TestHandler;
 use Monolog\Level;
 use Monolog\Logger;
-use Psr\Log\LoggerInterface as iLogger;
 use Psr\SimpleCache\CacheInterface as iCache;
 use ReflectionMethod;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 final class DispatchCommandTest extends TestCase
 {
-    public function test_visible_logs(): void
+    public function test_skip_marker_for_raw_logs(): void
     {
-        $method = new ReflectionMethod(DispatchCommand::class, 'isVisible');
-        $command = $this->makeCommand();
+        $handler = new TestHandler(Level::Debug);
+        $logger = new Logger('test', [$handler], [new LogMessageProcessor()]);
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener('on_push', static function (DataEvent $event) use ($logger): void {
+            $event->addRawLog('listener raw output');
+            $logger->notice('Listener raw output.');
+        });
 
-        self::assertTrue($method->invoke(
-            $command,
-            [
-                'INFO: hidden',
-                'NOTICE: visible',
-                '[2026-04-27T10:17:56+03:00] WARNING: visible',
-                'plain text',
-            ],
-            Level::Notice,
+        $command = new DispatchCommand(
+            $dispatcher,
+            $this->repo(),
+            $this->createStub(iCache::class),
+            $logger,
+        );
+
+        $this->runEvent($command, $this->event(), Level::Notice);
+
+        self::assertSame(['Listener raw output.'], array_map(
+            static fn($record): string => $record->message,
+            $handler->getRecords(),
         ));
-
-        self::assertTrue($method->invoke(
-            $command,
-            [
-                'INFO: visible',
-                'NOTICE: visible',
-                'WARNING: visible',
-                'event.DEBUG: hidden',
-            ],
-            Level::Info,
-        ));
-
-        self::assertFalse($method->invoke($command, ['INFO: hidden'], Level::Warning));
     }
 
     public function test_orders_marker(): void
@@ -56,29 +50,18 @@ final class DispatchCommandTest extends TestCase
         $logger = new Logger('test', [$handler], [new LogMessageProcessor()]);
         $dispatcher = new EventDispatcher();
         $dispatcher->addListener('on_push', static function (DataEvent $event) use ($logger): void {
-            $event->addLog('NOTICE: listener visible');
+            $event->addLog(Level::Notice, 'listener visible');
             $logger->notice('Listener visible.');
         });
 
-        $repo = $this->createMock(EventsRepository::class);
-        $repo->expects(self::exactly(2))->method('save')->willReturn('event-id');
-
-        $event = new Event([]);
-        $event->id = '550e8400-e29b-41d4-a716-446655440000';
-        $event->event = 'on_push';
-        $event->created_at = make_date('2026-05-17T08:25:02+00:00');
-
-        $method = new ReflectionMethod(DispatchCommand::class, 'runEvent');
-        $method->invoke(
-            new DispatchCommand(
-                $dispatcher,
-                $repo,
-                $this->createStub(iCache::class),
-                $logger,
-            ),
-            $event,
-            Level::Notice,
+        $command = new DispatchCommand(
+            $dispatcher,
+            $this->repo(),
+            $this->createStub(iCache::class),
+            $logger,
         );
+
+        $this->runEvent($command, $this->event(), Level::Notice);
 
         $records = $handler->getRecords();
         self::assertSame(
@@ -88,13 +71,57 @@ final class DispatchCommandTest extends TestCase
         self::assertSame('Listener visible.', $records[1]->message);
     }
 
-    private function makeCommand(): DispatchCommand
+    public function test_allow_debug_marker(): void
     {
-        return new DispatchCommand(
-            new EventDispatcher(),
-            $this->createStub(EventsRepository::class),
+        $handler = new TestHandler(Level::Debug);
+        $logger = new Logger('test', [$handler], [new LogMessageProcessor()]);
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener('on_push', static function (DataEvent $event): void {
+            $event->addLog(Level::Debug, 'listener debug');
+        });
+
+        $command = new DispatchCommand(
+            $dispatcher,
+            $this->repo(),
             $this->createStub(iCache::class),
-            $this->createStub(iLogger::class),
+            $logger,
         );
+
+        $event = $this->event();
+        $this->runEvent($command, $event, Level::Debug, true);
+
+        self::assertSame([
+            "NOTICE: Dispatching Event: 'on_push' queued at '2026-05-17T08:25:02+00:00'.",
+            'DEBUG: listener debug',
+            "NOTICE: Event 'on_push' was dispatched.",
+        ], $event->logs);
+        self::assertSame(
+            ["[event:550e8400-e29b-41d4-a716-446655440000] Dispatching Event: 'on_push' queued at '2026-05-17T08:25:02+00:00'."],
+            array_map(static fn($record): string => $record->message, $handler->getRecords()),
+        );
+    }
+
+    private function event(): Event
+    {
+        $event = new Event([]);
+        $event->id = '550e8400-e29b-41d4-a716-446655440000';
+        $event->event = 'on_push';
+        $event->created_at = make_date('2026-05-17T08:25:02+00:00');
+
+        return $event;
+    }
+
+    private function repo(): EventsRepository
+    {
+        $repo = $this->createMock(EventsRepository::class);
+        $repo->expects(self::exactly(2))->method('save')->willReturn('event-id');
+
+        return $repo;
+    }
+
+    private function runEvent(DispatchCommand $command, Event $event, Level $level, bool $debug = false): void
+    {
+        $method = new ReflectionMethod(DispatchCommand::class, 'runEvent');
+        $method->invoke($command, $event, $level, $debug);
     }
 }

--- a/tests/Database/PDOAdapterTest.php
+++ b/tests/Database/PDOAdapterTest.php
@@ -237,6 +237,47 @@ class PDOAdapterTest extends TestCase
         );
     }
 
+    public function test_get_path_guid(): void
+    {
+        $movieGuid = md5('movie:/movie title/movie title.mkv');
+        $movie = $this->testMovie;
+        $movie[iState::COLUMN_GUIDS] = [Guid::GUID_PATH => $movieGuid];
+        $storedMovie = $this->db->insert(new StateEntity($movie));
+
+        $movieQuery = $movie;
+        $movieQuery[iState::COLUMN_META_DATA] = [];
+
+        $this->assertSame(
+            $storedMovie->id,
+            $this->db->get(new StateEntity($movieQuery))->id,
+        );
+
+        $episodeGuid = md5('episode:/series title/season 01/episode.mkv/1/2');
+        $parentGuid = md5('show:/series title/season 01');
+        $episode = $this->testEpisode;
+        $episode[iState::COLUMN_GUIDS] = [Guid::GUID_PATH => $episodeGuid];
+        $episode[iState::COLUMN_PARENT] = [Guid::GUID_PATH => $parentGuid];
+        $storedEpisode = $this->db->insert(new StateEntity($episode));
+
+        $relativeQuery = $episode;
+        $relativeQuery[iState::COLUMN_GUIDS] = [];
+        $relativeQuery[iState::COLUMN_META_DATA] = [];
+
+        $this->assertSame(
+            $storedEpisode->id,
+            $this->db->get(new StateEntity($relativeQuery))->id,
+        );
+
+        $directQuery = $episode;
+        $directQuery[iState::COLUMN_PARENT] = [];
+        $directQuery[iState::COLUMN_META_DATA] = [];
+
+        $this->assertSame(
+            $storedEpisode->id,
+            $this->db->get(new StateEntity($directQuery))->id,
+        );
+    }
+
     public function test_getAll_conditions(): void
     {
         $item = new StateEntity($this->testEpisode);

--- a/tests/Libs/Events/DataEventTest.php
+++ b/tests/Libs/Events/DataEventTest.php
@@ -6,10 +6,12 @@ namespace Tests\Libs\Events;
 
 use App\Libs\Container;
 use App\Libs\Events\DataEvent;
+use App\Libs\Options;
 use App\Libs\TestCase;
 use App\Model\Events\Event;
 use App\Model\Events\EventsTable;
 use App\Model\Events\EventStatus;
+use Monolog\Level;
 
 class DataEventTest extends TestCase
 {
@@ -57,16 +59,84 @@ class DataEventTest extends TestCase
         $dataEvent = $this->getDataEvent();
 
         $this->assertSame(['test entry'], $dataEvent->getLogs(), 'getLogs() does not return the expected value');
-        $dataEvent->addLog('new entry');
+        $dataEvent->addRawLog('new entry');
 
         $this->assertSame(['test entry', 'new entry'],
             $dataEvent->getLogs(),
             'addLog() does not return the expected value');
 
         for ($i = 0; $i < 203; $i++) {
-            $dataEvent->addLog('new entry');
+            $dataEvent->addRawLog('new entry');
         }
 
         $this->assertCount(200, $dataEvent->getLogs(), 'addLog() Logs should not exceed 200 entries per event.');
+    }
+
+    public function test_skip_debug(): void
+    {
+        $dataEvent = $this->getDataEvent([
+            EventsTable::COLUMN_ID => generate_uuid(),
+            EventsTable::COLUMN_STATUS => EventStatus::PENDING->value,
+            EventsTable::COLUMN_REFERENCE => 'test',
+            EventsTable::COLUMN_EVENT => 'test',
+            EventsTable::COLUMN_EVENT_DATA => json_encode(['foo' => 'bar']),
+            EventsTable::COLUMN_OPTIONS => json_encode([]),
+            EventsTable::COLUMN_ATTEMPTS => 0,
+            EventsTable::COLUMN_LOGS => json_encode([]),
+            EventsTable::COLUMN_CREATED_AT => '2024-01-01 01:01:01',
+            EventsTable::COLUMN_UPDATED_AT => '2024-01-02 02:02:02',
+        ]);
+
+        self::assertFalse($dataEvent->addLog(Level::Debug, 'hidden debug'));
+
+        self::assertSame([], $dataEvent->getLogs());
+    }
+
+    public function test_allow_debug_trace(): void
+    {
+        $dataEvent = $this->getDataEvent([
+            EventsTable::COLUMN_ID => generate_uuid(),
+            EventsTable::COLUMN_STATUS => EventStatus::PENDING->value,
+            EventsTable::COLUMN_REFERENCE => 'test',
+            EventsTable::COLUMN_EVENT => 'test',
+            EventsTable::COLUMN_EVENT_DATA => json_encode(['foo' => 'bar']),
+            EventsTable::COLUMN_OPTIONS => json_encode([Options::DEBUG_TRACE => true]),
+            EventsTable::COLUMN_ATTEMPTS => 0,
+            EventsTable::COLUMN_LOGS => json_encode([]),
+            EventsTable::COLUMN_CREATED_AT => '2024-01-01 01:01:01',
+            EventsTable::COLUMN_UPDATED_AT => '2024-01-02 02:02:02',
+        ]);
+
+        self::assertTrue($dataEvent->addLog(Level::Debug, 'visible debug'));
+
+        self::assertSame(['DEBUG: visible debug'], $dataEvent->getLogs());
+    }
+
+    public function test_visible_logs_flag(): void
+    {
+        $dataEvent = $this->getDataEvent([
+            EventsTable::COLUMN_ID => generate_uuid(),
+            EventsTable::COLUMN_STATUS => EventStatus::PENDING->value,
+            EventsTable::COLUMN_REFERENCE => 'test',
+            EventsTable::COLUMN_EVENT => 'test',
+            EventsTable::COLUMN_EVENT_DATA => json_encode(['foo' => 'bar']),
+            EventsTable::COLUMN_OPTIONS => json_encode([]),
+            EventsTable::COLUMN_ATTEMPTS => 0,
+            EventsTable::COLUMN_LOGS => json_encode([]),
+            EventsTable::COLUMN_CREATED_AT => '2024-01-01 01:01:01',
+            EventsTable::COLUMN_UPDATED_AT => '2024-01-02 02:02:02',
+        ]);
+
+        $dataEvent->setVisibleLevel(Level::Notice);
+        self::assertFalse($dataEvent->hasVisibleLogs());
+
+        $dataEvent->addLog(Level::Info, 'hidden info');
+        self::assertFalse($dataEvent->hasVisibleLogs());
+
+        $dataEvent->addLog(Level::Notice, 'visible notice');
+        self::assertTrue($dataEvent->hasVisibleLogs());
+
+        $dataEvent->resetVisibleLogs();
+        self::assertFalse($dataEvent->hasVisibleLogs());
     }
 }

--- a/tests/Libs/GuidTest.php
+++ b/tests/Libs/GuidTest.php
@@ -115,6 +115,10 @@ class GuidTest extends TestCase
             Guid::validate('guid_cmdb', '12345678'),
             'Assert supported guid with no validator returns true.'
         );
+        $this->assertTrue(
+            Guid::validate('path', '0123456789abcdef0123456789abcdef'),
+            'Assert path guid validates through prefix normalization.'
+        );
     }
 
     public function test_jsonSerialize()
@@ -344,9 +348,10 @@ class GuidTest extends TestCase
 
     public function test_getPointers()
     {
-        $guid = Guid::fromArray(['guid_imdb' => 'tt1234567', 'guid_tvdb' => '123']);
+        $path = '0123456789abcdef0123456789abcdef';
+        $guid = Guid::fromArray(['guid_imdb' => 'tt1234567', 'guid_tvdb' => '123', Guid::GUID_PATH => $path]);
         $this->assertEquals(
-            ['guid_imdb://tt1234567', 'guid_tvdb://123'],
+            ['guid_imdb://tt1234567', 'guid_tvdb://123', 'guid_path://' . $path],
             $guid->getPointers(),
             "Failed to assert that the GUID pointers are correct."
         );

--- a/tests/Libs/PathGuidTest.php
+++ b/tests/Libs/PathGuidTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Libs;
+
+use App\Libs\Entity\StateInterface as iState;
+use App\Libs\Guid;
+use App\Libs\PathGuid;
+use App\Libs\TestCase;
+
+class PathGuidTest extends TestCase
+{
+    public function test_movie_hash(): void
+    {
+        $this->assertSame(
+            [
+                iState::COLUMN_GUIDS => [
+                    Guid::GUID_PATH => md5('movie:/movie_title/movie_title.mkv'),
+                ],
+            ],
+            PathGuid::get(iState::TYPE_MOVIE, '/home/foo/media/movies/Movie_Title/Movie_Title.MKV'),
+        );
+    }
+
+    public function test_episode_hash(): void
+    {
+        $this->assertSame(
+            [
+                iState::COLUMN_GUIDS => [
+                    Guid::GUID_PATH => md5('episode:/show_title/season/s01e01.mp4/1/1'),
+                ],
+                iState::COLUMN_PARENT => [
+                    Guid::GUID_PATH => md5('show:/show_title/season'),
+                ],
+            ],
+            PathGuid::get(iState::TYPE_EPISODE, '/home/foo/media/tv/show_title/season/S01E01.MP4', 1, 1),
+        );
+    }
+
+    public function test_normalizes_path(): void
+    {
+        $expected = PathGuid::get(iState::TYPE_EPISODE, '/media/tv/show/season/s01e01.mkv', 1, 1);
+
+        $this->assertSame(
+            $expected,
+            PathGuid::get(iState::TYPE_EPISODE, 'Z:\\TV\\SHOW\\SEASON\\S01E01.MKV', 1, 1),
+        );
+        $this->assertSame(
+            $expected,
+            PathGuid::get(iState::TYPE_EPISODE, '/media//tv//SHOW//SEASON//S01E01.MKV', 1, 1),
+        );
+    }
+
+    public function test_episode_coordinates(): void
+    {
+        $first = PathGuid::get(iState::TYPE_EPISODE, '/media/tv/show/season/S01E01-E02.mkv', 1, 1);
+        $second = PathGuid::get(iState::TYPE_EPISODE, '/media/tv/show/season/S01E01-E02.mkv', 1, 2);
+
+        $this->assertSame(
+            $first[iState::COLUMN_PARENT][Guid::GUID_PATH],
+            $second[iState::COLUMN_PARENT][Guid::GUID_PATH],
+        );
+        $this->assertNotSame(
+            $first[iState::COLUMN_GUIDS][Guid::GUID_PATH],
+            $second[iState::COLUMN_GUIDS][Guid::GUID_PATH],
+        );
+    }
+
+    public function test_rejects_invalid(): void
+    {
+        $this->assertSame([], PathGuid::get(iState::TYPE_MOVIE, ''));
+        $this->assertSame([], PathGuid::get(iState::TYPE_MOVIE, '/media/movies/movie_title'));
+        $this->assertSame([], PathGuid::get(iState::TYPE_MOVIE, '/movie.mkv'));
+        $this->assertSame([], PathGuid::get(iState::TYPE_EPISODE, '/season/s01e01.mkv', 1, 1));
+        $this->assertSame([], PathGuid::get(iState::TYPE_EPISODE, '/tv/show/season/s01e01.mkv'));
+    }
+}

--- a/tests/Libs/StateEntityTest.php
+++ b/tests/Libs/StateEntityTest.php
@@ -1148,6 +1148,31 @@ class StateEntityTest extends TestCase
         );
     }
 
+    public function test_episode_path_guid_disabled(): void
+    {
+        $guid = md5('episode:/series title/season 01/episode.mkv/1/2');
+        $parent = md5('show:/series title/season 01');
+        $data = $this->testEpisode;
+        $data[iState::COLUMN_GUIDS][Guid::GUID_PATH] = $guid;
+        $data[iState::COLUMN_PARENT][Guid::GUID_PATH] = $parent;
+        $entity = new StateEntity($data);
+
+        try {
+            Config::save('guid.disable.episode', true);
+
+            $this->assertSame($guid, $entity->guids[Guid::GUID_PATH]);
+            $this->assertSame([], $entity->getGuids());
+            $this->assertSame([], $entity->getPointers());
+            $this->assertContains('rguid_path://' . $parent . '/1/2', $entity->getRelativePointers());
+
+            Config::save('guid.disable.episode', false);
+
+            $this->assertContains('guid_path://' . $guid, $entity->getPointers());
+        } finally {
+            Config::save('guid.disable.episode', false);
+        }
+    }
+
     public function test_removeMetadata()
     {
         $data = $this->testMovie;

--- a/tests/Listeners/ProcessProgressEventTest.php
+++ b/tests/Listeners/ProcessProgressEventTest.php
@@ -23,9 +23,12 @@ use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use PDO;
 use Psr\SimpleCache\CacheInterface as iCache;
+use Tests\Support\StateCommandTestSupport;
 
 final class ProcessProgressEventTest extends TestCase
 {
+    use StateCommandTestSupport;
+
     public function test_logs_shared_missing_metadata(): void
     {
         $this->initTempApp();
@@ -87,6 +90,65 @@ final class ProcessProgressEventTest extends TestCase
             ),
         );
         self::assertTrue($handler->hasWarningRecords());
+    }
+
+    public function test_skip_debug_backend_logs(): void
+    {
+        $logger = $this->initFakeBackendApp($this->fakeBackendConfig('fake_progress'));
+        $db = $this->migrateMainDb($logger);
+        $handler = new TestHandler();
+        $logger->pushHandler($handler);
+
+        $entity = StateEntity::fromArray([
+            iState::COLUMN_TYPE => iState::TYPE_MOVIE,
+            iState::COLUMN_UPDATED => time(),
+            iState::COLUMN_WATCHED => 0,
+            iState::COLUMN_VIA => 'other',
+            iState::COLUMN_TITLE => 'Fake Progress Movie',
+            iState::COLUMN_YEAR => 2024,
+            iState::COLUMN_GUIDS => ['imdb' => 'tt-fake-progress'],
+            iState::COLUMN_META_DATA => [
+                'other' => [
+                    iState::COLUMN_META_DATA_PROGRESS => 120000,
+                ],
+                'fake_progress' => [
+                    iState::COLUMN_ID => 202,
+                    iState::COLUMN_TYPE => iState::TYPE_MOVIE,
+                    iState::COLUMN_WATCHED => 0,
+                ],
+            ],
+            iState::COLUMN_EXTRA => [
+                'other' => [
+                    iState::COLUMN_EXTRA_DATE => (string) make_date(time()),
+                ],
+            ],
+            iState::COLUMN_CREATED_AT => time(),
+            iState::COLUMN_UPDATED_AT => time(),
+        ]);
+        $entity = $db->insert($entity);
+
+        $cache = Container::get(iCache::class);
+        assert($cache instanceof iCache, 'Expected cache service for progress event test.');
+
+        $queue = Container::get(QueueRequests::class);
+        assert($queue instanceof QueueRequests, 'Expected queue service for progress event test.');
+
+        $listener = new ProcessProgressEvent(new DirectMapper($logger, $db, $cache), $logger, $queue);
+        $event = $this->event($entity);
+
+        $listener($event);
+
+        self::assertSame(EventStatus::RUNNING, $event->getStatus());
+        self::assertFalse(array_any(
+            $event->getLogs(),
+            static fn(string $log): bool => str_contains($log, 'fake.progress: hidden debug'),
+        ));
+        self::assertTrue(array_any(
+            $event->getLogs(),
+            static fn(string $log): bool => str_contains($log, 'fake.progress: visible info'),
+        ));
+        self::assertTrue($handler->hasDebugRecords());
+        self::assertTrue($handler->hasInfoRecords());
     }
 
     private function event(StateEntity $entity): DataEvent

--- a/tests/Listeners/ProcessPushEventTest.php
+++ b/tests/Listeners/ProcessPushEventTest.php
@@ -21,9 +21,12 @@ use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use PDO;
 use Psr\SimpleCache\CacheInterface as iCache;
+use Tests\Support\StateCommandTestSupport;
 
 final class ProcessPushEventTest extends TestCase
 {
+    use StateCommandTestSupport;
+
     public function test_logs_shared_missing_metadata(): void
     {
         $this->initTempApp();
@@ -77,6 +80,58 @@ final class ProcessPushEventTest extends TestCase
             $event->getLogs(),
         );
         self::assertTrue($handler->hasWarningRecords());
+    }
+
+    public function test_skip_debug_backend_logs(): void
+    {
+        $logger = $this->initFakeBackendApp($this->fakeBackendConfig('fake_push'));
+        $db = $this->migrateMainDb($logger);
+        $handler = new TestHandler();
+        $logger->pushHandler($handler);
+
+        $entity = StateEntity::fromArray([
+            iState::COLUMN_TYPE => iState::TYPE_MOVIE,
+            iState::COLUMN_UPDATED => time(),
+            iState::COLUMN_WATCHED => 1,
+            iState::COLUMN_VIA => 'other',
+            iState::COLUMN_TITLE => 'Fake Push Movie',
+            iState::COLUMN_YEAR => 2024,
+            iState::COLUMN_GUIDS => ['imdb' => 'tt-fake-push'],
+            iState::COLUMN_META_DATA => [
+                'fake_push' => [
+                    iState::COLUMN_ID => 101,
+                    iState::COLUMN_TYPE => iState::TYPE_MOVIE,
+                    iState::COLUMN_WATCHED => 0,
+                ],
+            ],
+            iState::COLUMN_EXTRA => [],
+            iState::COLUMN_CREATED_AT => time(),
+            iState::COLUMN_UPDATED_AT => time(),
+        ]);
+        $entity = $db->insert($entity);
+
+        $cache = Container::get(iCache::class);
+        assert($cache instanceof iCache, 'Expected cache service for push event test.');
+
+        $queue = Container::get(QueueRequests::class);
+        assert($queue instanceof QueueRequests, 'Expected queue service for push event test.');
+
+        $listener = new ProcessPushEvent(new DirectMapper($logger, $db, $cache), $logger, $queue);
+        $event = $this->event($entity);
+
+        $listener($event);
+
+        self::assertSame(EventStatus::RUNNING, $event->getStatus());
+        self::assertFalse(array_any(
+            $event->getLogs(),
+            static fn(string $log): bool => str_contains($log, 'fake.push: hidden debug'),
+        ));
+        self::assertTrue(array_any(
+            $event->getLogs(),
+            static fn(string $log): bool => str_contains($log, 'fake.push: visible info'),
+        ));
+        self::assertTrue($handler->hasDebugRecords());
+        self::assertTrue($handler->hasInfoRecords());
     }
 
     private function event(StateEntity $entity): DataEvent

--- a/tests/Mappers/Import/MapperAbstract.php
+++ b/tests/Mappers/Import/MapperAbstract.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Mappers\Import;
 
 use App\Libs\Container;
+use App\Libs\Config;
 use App\Libs\Database\DatabaseInterface as iDB;
 use App\Libs\Entity\StateEntity;
 use App\Libs\Entity\StateInterface as iState;
@@ -20,6 +21,7 @@ use App\Model\Events\EventsRepository;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -35,6 +37,9 @@ abstract class MapperAbstract extends TestCase
     protected ImportInterface|null $mapper = null;
     protected iDB|null $db = null;
     protected TestHandler|null $handler = null;
+    /**
+     * @var LoggerInterface&Logger|null
+     */
     protected LoggerInterface|null $logger = null;
     protected OutputInterface|null $output = null;
     protected InputInterface|null $input = null;
@@ -362,6 +367,37 @@ abstract class MapperAbstract extends TestCase
             $this->mapper->get($testMovie)->getAll(),
             'get() should return the correct data for the movie.'
         );
+    }
+
+    public function test_path_guid_conditions(): void
+    {
+        $movieGuid = md5('movie:/movie title/movie title.mkv');
+        $movie = $this->testMovie;
+        $movie[iState::COLUMN_GUIDS] = [Guid::GUID_PATH => $movieGuid];
+        $storedMovie = new StateEntity($movie);
+
+        $episodeGuid = md5('episode:/series title/season 01/episode.mkv/1/2');
+        $parentGuid = md5('show:/series title/season 01');
+        $episode = $this->testEpisode;
+        $episode[iState::COLUMN_GUIDS] = [Guid::GUID_PATH => $episodeGuid];
+        $episode[iState::COLUMN_PARENT] = [Guid::GUID_PATH => $parentGuid];
+        $storedEpisode = new StateEntity($episode);
+
+        try {
+            Config::save('guid.disable.episode', true);
+            $this->db->commit([$storedMovie, $storedEpisode]);
+            $this->mapper->loadData();
+
+            $foundMovie = $this->mapper->get(new StateEntity($movie));
+            $foundEpisode = $this->mapper->get(new StateEntity($episode));
+
+            $this->assertInstanceOf(iState::class, $foundMovie);
+            $this->assertInstanceOf(iState::class, $foundEpisode);
+            $this->assertSame($storedMovie->title, $foundMovie->title);
+            $this->assertSame($storedEpisode->title, $foundEpisode->title);
+        } finally {
+            Config::save('guid.disable.episode', false);
+        }
     }
 
     /**

--- a/tests/Support/FakeBackendClient.php
+++ b/tests/Support/FakeBackendClient.php
@@ -186,6 +186,15 @@ class FakeBackendClient implements ClientInterface
     {
         $context = $this->requireContext();
 
+        $this->logger?->debug('fake.push: hidden debug for {user}@{backend}', [
+            'user' => $context->userContext->name,
+            'backend' => $context->backendName,
+        ]);
+        $this->logger?->info('fake.push: visible info for {user}@{backend}', [
+            'user' => $context->userContext->name,
+            'backend' => $context->backendName,
+        ]);
+
         self::record('push', [
             'backend' => $context->backendName,
             'user' => $context->userContext->name,
@@ -199,6 +208,15 @@ class FakeBackendClient implements ClientInterface
     public function progress(array $entities, QueueRequests $queue, ?iDate $after = null): array
     {
         $context = $this->requireContext();
+
+        $this->logger?->debug('fake.progress: hidden debug for {user}@{backend}', [
+            'user' => $context->userContext->name,
+            'backend' => $context->backendName,
+        ]);
+        $this->logger?->info('fake.progress: visible info for {user}@{backend}', [
+            'user' => $context->userContext->name,
+            'backend' => $context->backendName,
+        ]);
 
         self::record('progress', [
             'backend' => $context->backendName,


### PR DESCRIPTION
# Path Matching Feature:

* Added the ability to generate and use path-derived local GUIDs (`guid_path`) for matching media items across backends when enabled via the `WS_GUID_PATH_ENABLED` configuration. 
* Added a detailed user guide explaining when and how to use path matching, including setup and backfill instructions.
* Updated documentation help page to announce and explain the new feature, and added a link to the path matching guide in relevant places.

## Event Logging Improvements:

* Refactored event logging to use structured log methods (e.g., `addLog`, `clearLogs`) instead of direct array manipulation.
* Removed legacy log visibility and level parsing logic, simplifying event log management.

## Error Handling Adjustments:

* Adjusted webhook error logging in Emby, Jellyfin, and Plex backends to use the "WARNING" log level instead of "ERROR" for certain cases, reducing noise for non-critical issues. 

## Other Updates:

* Increased the scheduler command timeout to accommodate longer-running tasks.
