### PR TITLE
refactor: clerify import vs export wording

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,5 +1,27 @@
 # FAQ
 
+# Import vs Export
+
+## What does it mean to export or import in WatchState terminology?
+
+WatchState syncs data between your configured backends.
+
+For each backend:
+
+* **Import** allows WatchState to read data from that backend.
+* **Export** allows WatchState to write data to that backend.
+
+Put simply, **Import** controls what WatchState can use as a source, while **Export** controls what WatchState can update as a target.
+
+For example, if Plex should provide the data and Jellyfin should be updated to match it, enable:
+
+* **Import** on Plex
+* **Export** on Jellyfin
+
+If both options are enabled on the same backend, WatchState can both read from it and write updates back to it during sync.
+
+---
+
 # How to enable scheduled/automatic tasks?
 
 To turn on automatic import or export tasks:

--- a/frontend/app/components/BackendAdd.vue
+++ b/frontend/app/components/BackendAdd.vue
@@ -454,20 +454,22 @@
             class="flex items-start justify-between gap-4 rounded-md border border-default bg-elevated/20 px-3 py-3"
           >
             <div class="min-w-0">
-              <p class="text-sm font-medium text-highlighted">
-                <UIcon
-                  name="i-lucide-circle-check"
-                  class="text-success"
-                  v-if="!backend.import.enabled"
-                />
-                {{ backend.import.enabled ? 'Import Play State' : 'Metadata Only' }}
-              </p>
-              <p class="mt-1 text-sm text-toned">
-                {{
-                  backend.import.enabled
-                    ? 'Retrieve play/progress from this backend.'
-                    : 'Retrieve metadata only when import is disabled.'
-                }}
+              <p class="text-sm font-medium text-highlighted">Enable Import</p>
+              <p class="mt-1 text-sm">
+                Get
+                <template v-if="backend.import.enabled">
+                  <UTooltip text="Watched status, playlists, progress and metadata">
+                    <span class="text-success underline cursor-help">everything</span>
+                  </UTooltip>
+                </template>
+                <template v-else>
+                  <UTooltip
+                    text="Import only metadata no watched status, playlists or progress will be imported"
+                  >
+                    <span class="text-error underline cursor-help">metadata</span>
+                  </UTooltip>
+                </template>
+                from this backend.
               </p>
             </div>
 
@@ -483,10 +485,8 @@
             class="flex items-start justify-between gap-4 rounded-md border border-default bg-elevated/20 px-3 py-3"
           >
             <div class="min-w-0">
-              <p class="text-sm font-medium text-highlighted">Send play and progress updates</p>
-              <p class="mt-1 text-sm text-toned">
-                The backend will not receive any data from WatchState if this is disabled.
-              </p>
+              <p class="text-sm font-medium text-highlighted">Enable Export</p>
+              <p class="mt-1 text-sm text-toned">Send state updates to this backend.</p>
             </div>
 
             <USwitch
@@ -639,10 +639,10 @@ const backend = ref<Backend>({
   uuid: '',
   user: '',
   import: {
-    enabled: false,
+    enabled: true,
   },
   export: {
-    enabled: false,
+    enabled: true,
   },
   options: {
     client: {

--- a/frontend/app/components/BackendEditForm.vue
+++ b/frontend/app/components/BackendEditForm.vue
@@ -433,20 +433,22 @@
                 class="flex items-start justify-between gap-4 rounded-md border border-default bg-elevated/20 px-3 py-3"
               >
                 <div class="min-w-0">
-                  <p class="text-sm font-medium text-highlighted">
-                    <UIcon
-                      name="i-lucide-circle-check"
-                      class="text-success"
-                      v-if="!backend.import.enabled"
-                    />
-                    {{ backend.import.enabled ? 'Import Play State' : 'Metadata Only' }}
-                  </p>
-                  <p class="mt-1 text-sm text-toned">
-                    {{
-                      backend.import.enabled
-                        ? 'Retrieve play/progress from this backend.'
-                        : 'Retrieve metadata only when import is disabled.'
-                    }}
+                  <p class="text-sm font-medium text-highlighted">Enable Import</p>
+                  <p class="mt-1 text-sm">
+                    Get
+                    <template v-if="backend.import.enabled">
+                      <UTooltip text="Watched status, playlists, progress and metadata">
+                        <span class="text-success underline cursor-help">everything</span>
+                      </UTooltip>
+                    </template>
+                    <template v-else>
+                      <UTooltip
+                        text="Import only metadata no watched status, playlists or progress will be imported"
+                      >
+                        <span class="text-error underline cursor-help">metadata</span>
+                      </UTooltip>
+                    </template>
+                    from this backend.
                   </p>
                 </div>
 
@@ -462,12 +464,8 @@
                 class="flex items-start justify-between gap-4 rounded-md border border-default bg-elevated/20 px-3 py-3"
               >
                 <div class="min-w-0">
-                  <p class="text-sm font-medium text-highlighted">
-                    Export play and progress updates
-                  </p>
-                  <p class="mt-1 text-sm text-toned">
-                    Send current WatchState play state updates to this backend.
-                  </p>
+                  <p class="text-sm font-medium text-highlighted">Enable Export</p>
+                  <p class="mt-1 text-sm text-toned">Send state updates to this backend.</p>
                 </div>
 
                 <USwitch

--- a/frontend/app/pages/backends/index.vue
+++ b/frontend/app/pages/backends/index.vue
@@ -81,7 +81,7 @@
         variant="soft"
         icon="i-lucide-loader-circle"
         title="Loading"
-        description="Requesting active play sessions. Please wait..."
+        description="Loading backends. Please wait..."
         :ui="{ icon: 'animate-spin' }"
       />
 
@@ -174,7 +174,7 @@
                 <div class="flex items-start justify-between gap-4">
                   <div class="min-w-0">
                     <p class="text-sm font-medium text-highlighted">Enable Export</p>
-                    <p class="mt-1 text-sm text-toned">Send data to this backend.</p>
+                    <p class="mt-1 text-sm text-toned">Send state updates to this backend.</p>
                   </div>
 
                   <USwitch
@@ -190,20 +190,22 @@
               <div class="rounded-md border border-default bg-elevated/30 p-4">
                 <div class="flex items-start justify-between gap-4">
                   <div class="min-w-0">
-                    <p class="text-sm font-medium text-highlighted">
-                      <UIcon
-                        name="i-lucide-circle-check"
-                        class="text-success"
-                        v-if="!backend.import.enabled"
-                      />
-                      {{ backend.import.enabled ? 'Import Play State' : 'Metadata Only' }}
-                    </p>
-                    <p class="mt-1 text-sm text-toned">
-                      {{
-                        backend.import.enabled
-                          ? 'Retrieve play/progress from this backend.'
-                          : 'Retrieve metadata only when import is disabled.'
-                      }}
+                    <p class="text-sm font-medium text-highlighted">Enable Import</p>
+                    <p class="mt-1 text-sm">
+                      Get
+                      <template v-if="backend.import.enabled">
+                        <UTooltip text="Watched status, playlists, progress and metadata">
+                          <span class="text-success underline cursor-help">everything</span>
+                        </UTooltip>
+                      </template>
+                      <template v-else>
+                        <UTooltip
+                          text="Import only metadata no watched status, playlists or progress will be imported"
+                        >
+                          <span class="text-error underline cursor-help">metadata</span>
+                        </UTooltip>
+                      </template>
+                      from this backend.
                     </p>
                   </div>
 
@@ -257,7 +259,7 @@
                     class="inline-flex min-w-0 items-center gap-2 text-xs font-medium uppercase tracking-[0.16em] text-toned"
                   >
                     <UIcon name="i-lucide-download" class="size-3.5 shrink-0" />
-                    <span>Last Import</span>
+                    <span>Last Import ({{ backend.import.enabled ? 'Full' : 'Basic' }})</span>
                   </div>
 
                   <div class="min-w-0 sm:ml-auto sm:text-right">

--- a/guides/one-way-sync.md
+++ b/guides/one-way-sync.md
@@ -16,9 +16,9 @@ environment without modifying the original data.
 ### Adding your backend with has the most accurate data
 
 First, go to <!--i:i-lucide-server--> **Backends** and click on the <!--i:i-lucide-plus--> **Add Backend** button. Follow the
-interactive setup guide. When you reach the step asking *`Send play and progress updates`*, disable it,
+interactive setup guide. When you reach the step asking *`Enable export`*, disable it,
 this applies to
-your main backend as you don’t want to alter its data. Keep *`Import play and progress updates`*
+your main backend as you don’t want to alter its data. Keep *`Enable Import`*
 enabled, which will allow
 you to import data from the backend.
 
@@ -64,15 +64,15 @@ For each backend, follow these steps:
 
 Do exactly as you did for the main backend, but make the following changes:
 
-- *`Import play and progress updates`*: No
-- *`Send play and progress updates`*: Yes
+- *`Enable Import`*: No
+- *`Enable export`*: Yes
 - *`Force export local data to this backend: Yes`*: This depends on your setup:
     - If you have only one extra backend and have already imported your main backend data, select *Yes* and skip Step 2.
     - If you have multiple backends, keep this option disabled and proceed to Step 2.
 
 > [!IMPORTANT]  
 > Selecting the correct options is crucial to avoid altering the data in the main backend. When
-> *`Import play and progress updates`* is disabled, WatchState automatically keeps metadata refresh
+> *`Enable Import`* is disabled, WatchState automatically keeps metadata refresh
 > enabled for that backend.
 
 ### Step 2

--- a/guides/three-way-sync.md
+++ b/guides/three-way-sync.md
@@ -38,12 +38,12 @@ For each individual account (yours and your spouse's)
 2. Follow the usual add backend process to add the share account.
 3. Configure the settings as follows:
     - *`Name`*: Choose a unique name that isn't already used. e.g. `shared_family_one` or `shared_family_two`
-    - *`Import play and progress updates`*: Yes
-    - *`Send play and progress updates`*: No
+    - *`Enable Import`*: Yes
+    - *`Enable export`*: No
 
 > [!IMPORTANT]
-> Keeping *`Import play and progress updates`* enabled ensures the shared account's watch state
-> overrides the individual accounts. Disabling *`Send play and progress updates`* prevents individual
+> Keeping *`Enable Import`* enabled ensures the shared account's watch state
+> overrides the individual accounts. Disabling *`Enable export`* prevents individual
 > accounts from modifying the shared account's data.
 
 # Verify the Setup

--- a/guides/two-way-sync.md
+++ b/guides/two-way-sync.md
@@ -19,8 +19,8 @@ On the export side, we compare the backend's last sync date with any local chang
 items that need updating for each backend. If there are only a few changes, we trigger a quick sync operation
 `push mode`. If the changes are more extensive, we perform a full export, which compares all remote data with the local
 data. This full export only happens when there are many changes and/or metadata is missing from the backend, which is
-why it's crucial to keep the `Import play and progress updates` option enabled, or disable it only
-when you want that backend to stay in metadata-only mode.
+why it's crucial to keep the `Enable Import` option enabled, or disable it only when you want that
+backend to stay in metadata-only mode.
 
 # Setting Up Two-Way Sync
 

--- a/guides/using-ws-as-backup-solution.md
+++ b/guides/using-ws-as-backup-solution.md
@@ -27,8 +27,8 @@ When you enable single backend mode:
 First, go to <!--i:i-lucide-server--> **Backends** and click on the <!--i:i-lucide-plus--> **Add Backend** button. Follow the
 interactive setup guide. Configure your media server backend (Plex, Jellyfin, or Emby) with the following settings:
 
-- *`Import play and progress updates`*: **Yes**
-- *`Send play and progress updates`*: **No**
+- *`Enable Import`*: **Yes**
+- *`Enable export`*: **No**
 - *`Create backup for this backend data: Yes`*: **No**
 - *`Force one time import from this backend: Yes`*: **No**
 


### PR DESCRIPTION
* Replaced ambiguous labels like "Import Play State" and "Send play and progress updates" with clearer "Enable Import" and "Enable Export" across all backend forms and lists. Tooltips now explain exactly what is imported (e.g., "everything" vs "metadata only") and what export means. 
* Updated the default state for new backends to have both import and export enabled by default.
* Standardized documentation and guides to use "Enable Import" and "Enable Export" instead of confusing phrases.
* Added a new FAQ section to clearly define what "import" and "export" mean in WatchState, with practical examples for different backend configurations.