### PR TITLE
feat: Implement replay progress functionality

### DIFF
--- a/src/Backends/Emby/Action/ParseWebhook.php
+++ b/src/Backends/Emby/Action/ParseWebhook.php
@@ -254,6 +254,7 @@ final class ParseWebhook
             $allowUpdate = (int) Config::get('progress.threshold', 0);
             $progCheck = $allowUpdate || 0 === $isPlayed;
 
+            $progress = null;
             if ($progCheck && null !== ($progress = ag($json, 'PlaybackInfo.PositionTicks', null))) {
                 $fields[iState::COLUMN_META_DATA][$context->backendName][iState::COLUMN_META_DATA_PROGRESS] = (string) floor(
                     $progress / 1_00_00,
@@ -266,6 +267,23 @@ final class ParseWebhook
                 item: $obj,
                 opts: ['override' => $fields],
             )->setIsTainted(isTainted: true === in_array($event, self::WEBHOOK_TAINTED_EVENTS, true));
+
+            if (
+                1 === $isPlayed
+                && null !== $progress
+                && true === in_array(
+                    $event,
+                    [
+                        'playback.pause',
+                        'playback.unpause',
+                        'playback.start',
+                        'playback.stop',
+                    ],
+                    true,
+                )
+            ) {
+                $entity = $entity->setContext(Options::REPLAY_PROGRESS, true);
+            }
 
             if (false === $entity->hasGuids() && false === $entity->hasRelativeGuid()) {
                 return new Response(

--- a/src/Backends/Emby/Action/Progress.php
+++ b/src/Backends/Emby/Action/Progress.php
@@ -76,6 +76,7 @@ class Progress
     ): Response {
         $sessions = [];
         $ignoreDate = (bool) ag($context->options, Options::IGNORE_DATE, false);
+        $replayProgress = (bool) ag($context->options, Options::REPLAY_PROGRESS, false);
 
         try {
             $remoteSessions = Container::get(GetSessions::class)($context);
@@ -122,7 +123,7 @@ class Progress
                 ],
             ];
 
-            if ($context->backendName === $entity->via) {
+            if ($context->backendName === $entity->via && false === $replayProgress) {
                 $this->logger->info(
                     message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. Event originated from this backend.",
                     context: $logContext,
@@ -173,6 +174,8 @@ class Progress
                 continue;
             }
 
+            $unwatchFirst = false;
+
             try {
                 $remoteItem = $this->createEntity(
                     $context,
@@ -198,14 +201,18 @@ class Progress
                 }
 
                 if ($remoteItem->isWatched()) {
-                    $minThreshold = (int) Config::get('progress.minThreshold', 86_400);
-                    $allowUpdate = (int) Config::get('progress.threshold', 0);
-                    if (false === ($allowUpdate >= $minThreshold && time() > ($entity->updated + $allowUpdate))) {
-                        $this->logger->info(
-                            message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. The backend says the item is marked as watched.",
-                            context: $logContext,
-                        );
-                        continue;
+                    if (true === $replayProgress) {
+                        $unwatchFirst = true;
+                    } else {
+                        $minThreshold = (int) Config::get('progress.minThreshold', 86_400);
+                        $allowUpdate = (int) Config::get('progress.threshold', 0);
+                        if (false === ($allowUpdate >= $minThreshold && time() > ($entity->updated + $allowUpdate))) {
+                            $this->logger->info(
+                                message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. The backend says the item is marked as watched.",
+                                context: $logContext,
+                            );
+                            continue;
+                        }
                     }
                 }
             } catch (\App\Libs\Exceptions\RuntimeException|RuntimeException|InvalidArgumentException $e) {
@@ -260,36 +267,30 @@ class Progress
                         'progress' => format_duration($entity->getPlayProgress()),
                     ];
 
-                    $queue->add(
-                        new Request(
-                            method: Method::POST,
-                            url: $url,
-                            options: array_replace_recursive($context->getHttpOptions(), [
-                                'headers' => [
-                                    'Content-Type' => 'application/json',
-                                ],
-                                'json' => [
-                                    'PlaybackPositionTicks' => (string) floor($entity->getPlayProgress() * 1_00_00),
-                                    'LastPlayedDate' => make_date($senderDate)->format(Date::ATOM),
-                                ],
-                            ]),
-                            success: function (ResponseInterface $response) use ($requestContext): array {
-                                $statusCode = $response->getStatusCode();
+                    $json = [
+                        'PlaybackPositionTicks' => (string) floor($entity->getPlayProgress() * 1_00_00),
+                        'LastPlayedDate' => make_date($senderDate)->format(Date::ATOM),
+                    ];
 
-                                if (false === in_array(Status::tryFrom($statusCode), [Status::OK, Status::NO_CONTENT], true)) {
-                                    $this->logger->error(
-                                        message: "{action}: Request to change '{client}: {user}@{backend}' {item.type} '{item.title}' watch progress returned with unexpected '{status_code}' status code.",
-                                        context: [
-                                            ...$requestContext,
-                                            'status_code' => $statusCode,
-                                        ],
-                                    );
+                    if (true === $unwatchFirst) {
+                        $json['Played'] = false;
+                    }
 
-                                    return [];
-                                }
+                    $progressRequest = new Request(
+                        method: Method::POST,
+                        url: $url,
+                        options: array_replace_recursive($context->getHttpOptions(), [
+                            'headers' => [
+                                'Content-Type' => 'application/json',
+                            ],
+                            'json' => $json,
+                        ]),
+                        success: function (ResponseInterface $response) use ($requestContext): array {
+                            $statusCode = $response->getStatusCode();
 
-                                $this->logger->notice(
-                                    message: "{action}: Updated '{client}: {user}@{backend}' '{item.title}' watch progress to '{progress}'.",
+                            if (false === in_array(Status::tryFrom($statusCode), [Status::OK, Status::NO_CONTENT], true)) {
+                                $this->logger->error(
+                                    message: "{action}: Request to change '{client}: {user}@{backend}' {item.type} '{item.title}' watch progress returned with unexpected '{status_code}' status code.",
                                     context: [
                                         ...$requestContext,
                                         'status_code' => $statusCode,
@@ -297,26 +298,103 @@ class Progress
                                 );
 
                                 return [];
-                            },
-                            error: function (Throwable $e) use ($requestContext): array {
-                                $this->logger->error(
-                                    ...lw(
-                                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request to change watch progress of {item.type} '{item.title}'. '{error.message}' at '{error.file}:{error.line}'.",
-                                        context: [
-                                            ...$requestContext,
-                                            ...exception_log($e),
-                                        ],
-                                        e: $e,
-                                    ),
-                                );
+                            }
 
-                                return [];
-                            },
-                            extras: [
-                                'context' => $requestContext,
-                                HttpClientInterface::class => $this->http,
-                            ],
-                        ),
+                            $this->logger->notice(
+                                message: "{action}: Updated '{client}: {user}@{backend}' '{item.title}' watch progress to '{progress}'.",
+                                context: [
+                                    ...$requestContext,
+                                    'status_code' => $statusCode,
+                                ],
+                            );
+
+                            return [];
+                        },
+                        error: function (Throwable $e) use ($requestContext): array {
+                            $this->logger->error(
+                                ...lw(
+                                    message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request to change watch progress of {item.type} '{item.title}'. '{error.message}' at '{error.file}:{error.line}'.",
+                                    context: [
+                                        ...$requestContext,
+                                        ...exception_log($e),
+                                    ],
+                                    e: $e,
+                                ),
+                            );
+
+                            return [];
+                        },
+                        extras: [
+                            'context' => $requestContext,
+                            HttpClientInterface::class => $this->http,
+                        ],
+                    );
+
+                    if (true === $unwatchFirst) {
+                        $unwatchContext = $requestContext;
+                        $unwatchContext['remote']['url'] = (string) $context->backendUrl->withPath(
+                            r('/Users/{user_id}/PlayedItems/{item_id}', [
+                                'user_id' => $context->backendUser,
+                                'item_id' => $logContext['remote']['id'],
+                            ]),
+                        );
+
+                        $queue->add(
+                            new Request(
+                                method: Method::DELETE,
+                                url: $unwatchContext['remote']['url'],
+                                options: array_replace_recursive($context->getHttpOptions(), [
+                                    'user_data' => [Options::NO_LOGGING => true],
+                                ]),
+                                success: function (ResponseInterface $response) use ($progressRequest, $unwatchContext): array {
+                                    $statusCode = $response->getStatusCode();
+                                    if (false === in_array(Status::tryFrom($statusCode), [Status::OK, Status::NO_CONTENT], true)) {
+                                        $this->logger->error(
+                                            message: "{action}: Request to mark '{client}: {user}@{backend}' {item.type} '{item.title}' as unplayed before progress update returned with unexpected '{status_code}' status code.",
+                                            context: [
+                                                ...$unwatchContext,
+                                                'event_name' => 'backend.response.failed',
+                                                'subsystem' => 'backend',
+                                                'operation' => 'progress_unwatch',
+                                                'outcome' => 'failed',
+                                                'reason' => 'unexpected_status',
+                                                'status_code' => $statusCode,
+                                            ],
+                                        );
+
+                                        return [];
+                                    }
+
+                                    return [$progressRequest];
+                                },
+                                error: function (Throwable $e) use ($unwatchContext): array {
+                                    $this->logger->error(
+                                        ...lw(
+                                            message: "Exception was thrown during '{client}: {user}@{backend}' unplayed request before progress update.",
+                                            context: [
+                                                ...$unwatchContext,
+                                                'event_name' => 'backend.client.request_failed',
+                                                'subsystem' => 'backend',
+                                                'operation' => 'progress_unwatch',
+                                                'outcome' => 'failed',
+                                                'reason' => 'request_exception',
+                                                ...exception_log($e),
+                                            ],
+                                            e: $e,
+                                        ),
+                                    );
+
+                                    return [];
+                                },
+                                extras: [HttpClientInterface::class => $this->http],
+                            ),
+                        );
+
+                        continue;
+                    }
+
+                    $queue->add(
+                        $progressRequest,
                     );
                 }
             } catch (Throwable $e) {

--- a/src/Backends/Jellyfin/Action/ParseWebhook.php
+++ b/src/Backends/Jellyfin/Action/ParseWebhook.php
@@ -222,6 +222,7 @@ final class ParseWebhook
             $allowUpdate = (int) Config::get('progress.threshold', 0);
             $progCheck = $allowUpdate || 0 === $isPlayed;
 
+            $progress = null;
             if ($progCheck && null !== ($progress = ag($json, 'PlaybackPositionTicks', null))) {
                 $fields[iState::COLUMN_META_DATA][$context->backendName][iState::COLUMN_META_DATA_PROGRESS] = (string) floor(
                     $progress / 1_00_00,
@@ -237,6 +238,10 @@ final class ParseWebhook
 
             $entity = $this->createEntity(context: $context, guid: $guid, item: $obj, opts: $entityOpts)
                 ->setIsTainted(isTainted: true === in_array($event, self::WEBHOOK_TAINTED_EVENTS, true));
+
+            if (true === $isPlayed && null !== $progress && true === in_array($event, ['PlaybackStart', 'PlaybackStop'], true)) {
+                $entity = $entity->setContext(Options::REPLAY_PROGRESS, true);
+            }
 
             if (false === $entity->hasGuids() && false === $entity->hasRelativeGuid()) {
                 return new Response(

--- a/src/Backends/Jellyfin/Action/Progress.php
+++ b/src/Backends/Jellyfin/Action/Progress.php
@@ -103,6 +103,7 @@ class Progress
     ): Response {
         $sessions = [];
         $ignoreDate = (bool) ag($context->options, Options::IGNORE_DATE, false);
+        $replayProgress = (bool) ag($context->options, Options::REPLAY_PROGRESS, false);
 
         try {
             $remoteSessions = Container::get(GetSessions::class)($context);
@@ -149,7 +150,7 @@ class Progress
                 ],
             ];
 
-            if ($context->backendName === $entity->via) {
+            if ($context->backendName === $entity->via && false === $replayProgress) {
                 $this->logger->info(
                     message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. Event originated from this backend.",
                     context: $logContext,
@@ -200,6 +201,8 @@ class Progress
                 continue;
             }
 
+            $unwatchFirst = false;
+
             try {
                 $remoteData = $this->getItemDetails($context, $logContext['remote']['id'], [Options::NO_CACHE => true]);
                 $remoteItem = $this->createEntity($context, $guid, $remoteData, ['latest_date' => true]);
@@ -221,14 +224,18 @@ class Progress
                 }
 
                 if ($remoteItem->isWatched()) {
-                    $allowUpdate = (int) Config::get('progress.threshold', 0);
-                    $minThreshold = (int) Config::get('progress.minThreshold', 86_400);
-                    if (false === ($allowUpdate >= $minThreshold && time() > ($entity->updated + $allowUpdate))) {
-                        $this->logger->info(
-                            message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. The backend says the item is marked as watched.",
-                            context: $logContext,
-                        );
-                        continue;
+                    if (true === $replayProgress) {
+                        $unwatchFirst = true;
+                    } else {
+                        $allowUpdate = (int) Config::get('progress.threshold', 0);
+                        $minThreshold = (int) Config::get('progress.minThreshold', 86_400);
+                        if (false === ($allowUpdate >= $minThreshold && time() > ($entity->updated + $allowUpdate))) {
+                            $this->logger->info(
+                                message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. The backend says the item is marked as watched.",
+                                context: $logContext,
+                            );
+                            continue;
+                        }
                     }
                 }
             } catch (\App\Libs\Exceptions\RuntimeException|RuntimeException|InvalidArgumentException $e) {
@@ -287,36 +294,30 @@ class Progress
                         'progress' => format_duration($entity->getPlayProgress()),
                     ];
 
-                    $queue->add(
-                        new Request(
-                            method: Method::POST,
-                            url: $url,
-                            options: array_replace_recursive($context->getHttpOptions(), [
-                                'headers' => [
-                                    'Content-Type' => 'application/json',
-                                ],
-                                'json' => [
-                                    'PlaybackPositionTicks' => (string) floor($entity->getPlayProgress() * 1_00_00),
-                                    'LastPlayedDate' => make_date($senderDate)->format(Date::ATOM),
-                                ],
-                            ]),
-                            success: function (ResponseInterface $response) use ($requestContext): array {
-                                $statusCode = $response->getStatusCode();
+                    $json = [
+                        'PlaybackPositionTicks' => (string) floor($entity->getPlayProgress() * 1_00_00),
+                        'LastPlayedDate' => make_date($senderDate)->format(Date::ATOM),
+                    ];
 
-                                if (false === in_array(Status::tryFrom($statusCode), [Status::OK, Status::NO_CONTENT], true)) {
-                                    $this->logger->error(
-                                        message: "{action}: Request to change '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' watch progress returned with unexpected '{status_code}' status code.",
-                                        context: [
-                                            ...$requestContext,
-                                            'status_code' => $statusCode,
-                                        ],
-                                    );
+                    if (true === $unwatchFirst) {
+                        $json['Played'] = false;
+                    }
 
-                                    return [];
-                                }
+                    $progressRequest = new Request(
+                        method: Method::POST,
+                        url: $url,
+                        options: array_replace_recursive($context->getHttpOptions(), [
+                            'headers' => [
+                                'Content-Type' => 'application/json',
+                            ],
+                            'json' => $json,
+                        ]),
+                        success: function (ResponseInterface $response) use ($requestContext): array {
+                            $statusCode = $response->getStatusCode();
 
-                                $this->logger->notice(
-                                    message: "{action}: Updated '{client}: {user}@{backend}' '#{item.id}: {item.title}' watch progress to '{progress}'.",
+                            if (false === in_array(Status::tryFrom($statusCode), [Status::OK, Status::NO_CONTENT], true)) {
+                                $this->logger->error(
+                                    message: "{action}: Request to change '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' watch progress returned with unexpected '{status_code}' status code.",
                                     context: [
                                         ...$requestContext,
                                         'status_code' => $statusCode,
@@ -324,26 +325,103 @@ class Progress
                                 );
 
                                 return [];
-                            },
-                            error: function (Throwable $e) use ($requestContext): array {
-                                $this->logger->error(
-                                    ...lw(
-                                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request to change watch progress of {item.type} '#{item.id}: {item.title}'. '{error.message}' at '{error.file}:{error.line}'.",
-                                        context: [
-                                            ...$requestContext,
-                                            ...exception_log($e),
-                                        ],
-                                        e: $e,
-                                    ),
-                                );
+                            }
 
-                                return [];
-                            },
-                            extras: [
-                                'context' => $requestContext,
-                                HttpClientInterface::class => $this->http,
-                            ],
-                        ),
+                            $this->logger->notice(
+                                message: "{action}: Updated '{client}: {user}@{backend}' '#{item.id}: {item.title}' watch progress to '{progress}'.",
+                                context: [
+                                    ...$requestContext,
+                                    'status_code' => $statusCode,
+                                ],
+                            );
+
+                            return [];
+                        },
+                        error: function (Throwable $e) use ($requestContext): array {
+                            $this->logger->error(
+                                ...lw(
+                                    message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request to change watch progress of {item.type} '#{item.id}: {item.title}'. '{error.message}' at '{error.file}:{error.line}'.",
+                                    context: [
+                                        ...$requestContext,
+                                        ...exception_log($e),
+                                    ],
+                                    e: $e,
+                                ),
+                            );
+
+                            return [];
+                        },
+                        extras: [
+                            'context' => $requestContext,
+                            HttpClientInterface::class => $this->http,
+                        ],
+                    );
+
+                    if (true === $unwatchFirst) {
+                        $unwatchContext = $requestContext;
+                        $unwatchContext['remote']['url'] = (string) $context->backendUrl->withPath(
+                            r('/Users/{user_id}/PlayedItems/{item_id}', [
+                                'user_id' => $context->backendUser,
+                                'item_id' => $logContext['remote']['id'],
+                            ]),
+                        );
+
+                        $queue->add(
+                            new Request(
+                                method: Method::DELETE,
+                                url: $unwatchContext['remote']['url'],
+                                options: array_replace_recursive($context->getHttpOptions(), [
+                                    'user_data' => [Options::NO_LOGGING => true],
+                                ]),
+                                success: function (ResponseInterface $response) use ($progressRequest, $unwatchContext): array {
+                                    $statusCode = $response->getStatusCode();
+                                    if (false === in_array(Status::tryFrom($statusCode), [Status::OK, Status::NO_CONTENT], true)) {
+                                        $this->logger->error(
+                                            message: "{action}: Request to mark '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' as unplayed before progress update returned with unexpected '{status_code}' status code.",
+                                            context: [
+                                                ...$unwatchContext,
+                                                'event_name' => 'backend.response.failed',
+                                                'subsystem' => 'backend',
+                                                'operation' => 'progress_unwatch',
+                                                'outcome' => 'failed',
+                                                'reason' => 'unexpected_status',
+                                                'status_code' => $statusCode,
+                                            ],
+                                        );
+
+                                        return [];
+                                    }
+
+                                    return [$progressRequest];
+                                },
+                                error: function (Throwable $e) use ($unwatchContext): array {
+                                    $this->logger->error(
+                                        ...lw(
+                                            message: "Exception was thrown during '{client}: {user}@{backend}' unplayed request before progress update.",
+                                            context: [
+                                                ...$unwatchContext,
+                                                'event_name' => 'backend.client.request_failed',
+                                                'subsystem' => 'backend',
+                                                'operation' => 'progress_unwatch',
+                                                'outcome' => 'failed',
+                                                'reason' => 'request_exception',
+                                                ...exception_log($e),
+                                            ],
+                                            e: $e,
+                                        ),
+                                    );
+
+                                    return [];
+                                },
+                                extras: [HttpClientInterface::class => $this->http],
+                            ),
+                        );
+
+                        continue;
+                    }
+
+                    $queue->add(
+                        $progressRequest,
                     );
                 }
             } catch (Throwable $e) {

--- a/src/Backends/Plex/Action/ParseWebhook.php
+++ b/src/Backends/Plex/Action/ParseWebhook.php
@@ -239,6 +239,7 @@ final class ParseWebhook
             $allowUpdate = (int) Config::get('progress.threshold', 0);
             $progCheck = $allowUpdate || false === $isPlayed;
 
+            $progress = null;
             if ($progCheck && null !== ($progress = ag($item, 'viewOffset', null))) {
                 // -- Plex reports play progress in milliseconds already no need to convert.
                 $fields[iState::COLUMN_META_DATA][$context->backendName][iState::COLUMN_META_DATA_PROGRESS] = (string) $progress;
@@ -253,6 +254,10 @@ final class ParseWebhook
 
             $entity = $this->createEntity(context: $context, guid: $guid, item: $obj, opts: $entityOpts)
                 ->setIsTainted(isTainted: true === in_array($event, self::WEBHOOK_TAINTED_EVENTS, true));
+
+            if (true === $isPlayed && null !== $progress && true === in_array($event, self::WEBHOOK_TAINTED_EVENTS, true)) {
+                $entity = $entity->setContext(Options::REPLAY_PROGRESS, true);
+            }
 
             if (false === $entity->hasGuids() && false === $entity->hasRelativeGuid()) {
                 return new Response(

--- a/src/Backends/Plex/Action/Progress.php
+++ b/src/Backends/Plex/Action/Progress.php
@@ -75,6 +75,7 @@ class Progress
     ): Response {
         $sessions = [];
         $ignoreDate = (bool) ag($context->options, Options::IGNORE_DATE, false);
+        $replayProgress = (bool) ag($context->options, Options::REPLAY_PROGRESS, false);
 
         /**
          * as plex act weird if we change the progress of a watched item while the item is playing,
@@ -131,7 +132,7 @@ class Progress
                 ],
             ];
 
-            if ($context->backendName === $entity->via) {
+            if ($context->backendName === $entity->via && false === $replayProgress) {
                 $this->logger->info(
                     message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. Event originated from this backend.",
                     context: $logContext,
@@ -183,6 +184,8 @@ class Progress
                 continue;
             }
 
+            $unwatchFirst = false;
+
             try {
                 $remoteData = ag(
                     $this->getItemDetails($context, $logContext['remote']['id'], [Options::NO_CACHE => true]),
@@ -209,14 +212,18 @@ class Progress
                 }
 
                 if ($remoteItem->isWatched()) {
-                    $allowUpdate = (int) Config::get('progress.threshold', 0);
-                    $minThreshold = (int) Config::get('progress.minThreshold', 86_400);
-                    if (false === ($allowUpdate >= $minThreshold && time() > ($entity->updated + $allowUpdate))) {
-                        $this->logger->info(
-                            message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. The backend says the item is marked as watched.",
-                            context: $logContext,
-                        );
-                        continue;
+                    if (true === $replayProgress) {
+                        $unwatchFirst = true;
+                    } else {
+                        $allowUpdate = (int) Config::get('progress.threshold', 0);
+                        $minThreshold = (int) Config::get('progress.minThreshold', 86_400);
+                        if (false === ($allowUpdate >= $minThreshold && time() > ($entity->updated + $allowUpdate))) {
+                            $this->logger->info(
+                                message: "{action}: Not processing '#{item.id}: {item.title}' for '{client}: {user}@{backend}'. The backend says the item is marked as watched.",
+                                context: $logContext,
+                            );
+                            continue;
+                        }
                     }
                 }
             } catch (\App\Libs\Exceptions\RuntimeException|RuntimeException|InvalidArgumentException $e) {
@@ -280,28 +287,16 @@ class Progress
                         'progress' => format_duration($entity->getPlayProgress()),
                     ];
 
-                    $queue->add(
-                        new Request(
-                            method: Method::POST,
-                            url: $url,
-                            options: $context->getHttpOptions(),
-                            success: function (ResponseInterface $response) use ($requestContext): array {
-                                $statusCode = $response->getStatusCode();
+                    $progressRequest = new Request(
+                        method: Method::POST,
+                        url: $url,
+                        options: $context->getHttpOptions(),
+                        success: function (ResponseInterface $response) use ($requestContext): array {
+                            $statusCode = $response->getStatusCode();
 
-                                if (false === in_array(Status::tryFrom($statusCode), [Status::OK, Status::NO_CONTENT], true)) {
-                                    $this->logger->error(
-                                        message: "{action}: Request to change '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' watch progress returned with unexpected '{status_code}' status code.",
-                                        context: [
-                                            ...$requestContext,
-                                            'status_code' => $statusCode,
-                                        ],
-                                    );
-
-                                    return [];
-                                }
-
-                                $this->logger->notice(
-                                    message: "{action}: Updated '{client}: {user}@{backend}' '#{item.id}: {item.title}' watch progress to '{progress}'.",
+                            if (false === in_array(Status::tryFrom($statusCode), [Status::OK, Status::NO_CONTENT], true)) {
+                                $this->logger->error(
+                                    message: "{action}: Request to change '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' watch progress returned with unexpected '{status_code}' status code.",
                                     context: [
                                         ...$requestContext,
                                         'status_code' => $statusCode,
@@ -309,26 +304,108 @@ class Progress
                                 );
 
                                 return [];
-                            },
-                            error: function (Throwable $e) use ($requestContext): array {
-                                $this->logger->error(
-                                    ...lw(
-                                        message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request to change watch progress of {item.type} '#{item.id}: {item.title}'. '{error.message}' at '{error.file}:{error.line}'.",
-                                        context: [
-                                            ...$requestContext,
-                                            ...exception_log($e),
-                                        ],
-                                        e: $e,
-                                    ),
-                                );
+                            }
 
-                                return [];
-                            },
-                            extras: [
-                                'context' => $requestContext,
-                                HttpClientInterface::class => $this->http,
-                            ],
-                        ),
+                            $this->logger->notice(
+                                message: "{action}: Updated '{client}: {user}@{backend}' '#{item.id}: {item.title}' watch progress to '{progress}'.",
+                                context: [
+                                    ...$requestContext,
+                                    'status_code' => $statusCode,
+                                ],
+                            );
+
+                            return [];
+                        },
+                        error: function (Throwable $e) use ($requestContext): array {
+                            $this->logger->error(
+                                ...lw(
+                                    message: "{action}: Exception '{error.kind}' was thrown unhandled during '{client}: {user}@{backend}' request to change watch progress of {item.type} '#{item.id}: {item.title}'. '{error.message}' at '{error.file}:{error.line}'.",
+                                    context: [
+                                        ...$requestContext,
+                                        ...exception_log($e),
+                                    ],
+                                    e: $e,
+                                ),
+                            );
+
+                            return [];
+                        },
+                        extras: [
+                            'context' => $requestContext,
+                            HttpClientInterface::class => $this->http,
+                        ],
+                    );
+
+                    if (true === $unwatchFirst) {
+                        $unwatchUrl = $context
+                            ->backendUrl
+                            ->withPath('/:/unscrobble')
+                            ->withQuery(
+                                http_build_query([
+                                    'identifier' => 'com.plexapp.plugins.library',
+                                    'key' => $logContext['remote']['id'],
+                                ]),
+                            );
+
+                        $unwatchContext = $requestContext;
+                        $unwatchContext['remote']['url'] = (string) $unwatchUrl;
+
+                        $queue->add(
+                            new Request(
+                                method: Method::GET,
+                                url: $unwatchUrl,
+                                options: array_replace_recursive($context->getHttpOptions(), [
+                                    'user_data' => [Options::NO_LOGGING => true],
+                                ]),
+                                success: function (ResponseInterface $response) use ($progressRequest, $unwatchContext): array {
+                                    $statusCode = $response->getStatusCode();
+                                    if (false === in_array(Status::tryFrom($statusCode), [Status::OK, Status::NO_CONTENT], true)) {
+                                        $this->logger->error(
+                                            message: "{action}: Request to mark '{client}: {user}@{backend}' {item.type} '#{item.id}: {item.title}' as unplayed before progress update returned with unexpected '{status_code}' status code.",
+                                            context: [
+                                                ...$unwatchContext,
+                                                'event_name' => 'backend.response.failed',
+                                                'subsystem' => 'backend',
+                                                'operation' => 'progress_unwatch',
+                                                'outcome' => 'failed',
+                                                'reason' => 'unexpected_status',
+                                                'status_code' => $statusCode,
+                                            ],
+                                        );
+
+                                        return [];
+                                    }
+
+                                    return [$progressRequest];
+                                },
+                                error: function (Throwable $e) use ($unwatchContext): array {
+                                    $this->logger->error(
+                                        ...lw(
+                                            message: "Exception was thrown during '{client}: {user}@{backend}' unplayed request before progress update.",
+                                            context: [
+                                                ...$unwatchContext,
+                                                'event_name' => 'backend.client.request_failed',
+                                                'subsystem' => 'backend',
+                                                'operation' => 'progress_unwatch',
+                                                'outcome' => 'failed',
+                                                'reason' => 'request_exception',
+                                                ...exception_log($e),
+                                            ],
+                                            e: $e,
+                                        ),
+                                    );
+
+                                    return [];
+                                },
+                                extras: [HttpClientInterface::class => $this->http],
+                            ),
+                        );
+
+                        continue;
+                    }
+
+                    $queue->add(
+                        $progressRequest,
                     );
                 }
             } catch (Throwable $e) {

--- a/src/Commands/Events/DispatchCommand.php
+++ b/src/Commands/Events/DispatchCommand.php
@@ -61,7 +61,7 @@ final class DispatchCommand extends Command
             ->setName(self::ROUTE)
             ->addOption('id', 'i', InputOption::VALUE_REQUIRED, 'Force run this event.')
             ->addOption('reset', 'r', InputOption::VALUE_NONE, 'Reset event logs.')
-            ->addOption('limit', 'L', InputOption::VALUE_REQUIRED, 'How many events to run at per run.', 15)
+            ->addOption('limit', 'L', InputOption::VALUE_REQUIRED, 'How many events to run per invocation.', 100)
             ->setDescription('Run queued events.');
     }
 

--- a/src/Libs/Events/EventQueue.php
+++ b/src/Libs/Events/EventQueue.php
@@ -98,6 +98,10 @@ final class EventQueue
             $item->options[Options::FAIL_FAST_ON_LOCK] = true;
         }
 
+        if (true === (bool) ag($opts, Options::REPLAY_PROGRESS, false)) {
+            $item->options[Options::REPLAY_PROGRESS] = true;
+        }
+
         if (null !== ($reference = ag($opts, EventsTable::COLUMN_REFERENCE))) {
             $item->reference = $reference;
         }

--- a/src/Libs/Mappers/Import/DirectMapper.php
+++ b/src/Libs/Mappers/Import/DirectMapper.php
@@ -99,6 +99,8 @@ class DirectMapper implements ImportInterface
 
     private ?int $progressMinThreshold = null;
 
+    private ?int $progressMinimum = null;
+
     /**
      * Class constructor.
      *
@@ -358,6 +360,7 @@ class DirectMapper implements ImportInterface
         $writer = ag($opts, Options::LOG_TO_WRITER, null);
         $keys = [iState::COLUMN_META_DATA];
 
+        $replayProgress = $this->normalizeReplayProgress($local, $entity, $opts);
         $progressChange = $this->shouldProgressUpdate($local, $entity, $opts);
 
         if (true === $progressChange || true === (clone $local)->apply($entity, fields: $keys)->isChanged($keys)) {
@@ -374,8 +377,17 @@ class DirectMapper implements ImportInterface
                     if (true === $progressChange) {
                         $_keys[] = iState::COLUMN_VIA;
                     }
+                    if (true === $replayProgress) {
+                        $_keys[] = iState::COLUMN_WATCHED;
+                        $_keys[] = iState::COLUMN_UPDATED;
+                    }
+
+                    $_keys = array_values(array_unique($_keys));
 
                     $local = $local->apply($entity, fields: $_keys);
+                    if (true === $replayProgress) {
+                        $local = $local->setContext(Options::REPLAY_PROGRESS, true);
+                    }
 
                     $changeLog = $changes;
                     if (true === $progressChange) {
@@ -586,6 +598,7 @@ class DirectMapper implements ImportInterface
             return $this;
         }
 
+        $replayProgress = $this->normalizeReplayProgress($local, $entity, $opts);
         $progressChange = $this->shouldProgressUpdate($local, $entity, $opts);
 
         $updateMeta = true === (bool) ag($this->options, Options::MAPPER_ALWAYS_UPDATE_META);
@@ -607,7 +620,17 @@ class DirectMapper implements ImportInterface
                         if (true === $progressChange) {
                             $_keys[] = iState::COLUMN_VIA;
                         }
+
+                        if (true === $replayProgress) {
+                            $_keys[] = iState::COLUMN_WATCHED;
+                            $_keys[] = iState::COLUMN_UPDATED;
+                        }
+
+                        $_keys = array_values(array_unique($_keys));
                         $local = $local->apply($entity, fields: $_keys);
+                        if (true === $replayProgress) {
+                            $local = $local->setContext(Options::REPLAY_PROGRESS, true);
+                        }
 
                         $changeLog = $changes;
                         if (true === $progressChange) {
@@ -876,6 +899,7 @@ class DirectMapper implements ImportInterface
 
         $cloned = clone $local;
 
+        $replayProgress = $this->normalizeReplayProgress($local, $entity, $opts);
         $progressChange = $this->shouldProgressUpdate($local, $entity, $opts);
         $keys = $opts['diff_keys'] ?? $this->getDefaultDiffKeys();
 
@@ -885,7 +909,17 @@ class DirectMapper implements ImportInterface
             $_keys[] = iState::COLUMN_VIA;
         }
 
+        if (true === $replayProgress) {
+            $_keys[] = iState::COLUMN_WATCHED;
+            $_keys[] = iState::COLUMN_UPDATED;
+        }
+
+        $_keys = array_values(array_unique($_keys));
+
         $local = $local->apply(entity: $entity, fields: $_keys);
+        if (true === $replayProgress) {
+            $local = $local->setContext(Options::REPLAY_PROGRESS, true);
+        }
         $changedKeys = $local->diff(fields: $keys);
 
         if (false === $progressChange && false === $shouldMark && count($changedKeys) < 1) {
@@ -961,10 +995,10 @@ class DirectMapper implements ImportInterface
 
             if (false === $inDryRunMode) {
                 $this->db->update($local, $opts);
-                if (null !== ($onStateUpdate = ag($opts, Options::STATE_UPDATE_EVENT, null))) {
+                if (false === $replayProgress && null !== ($onStateUpdate = ag($opts, Options::STATE_UPDATE_EVENT, null))) {
                     $onStateUpdate($local);
                 }
-                if (true === $progressChange && !$stateChange) {
+                if (true === $progressChange && (false === $stateChange || true === $replayProgress)) {
                     $itemId = r('{type}://{id}:{tainted}@{backend}', [
                         'type' => $entity->type,
                         'backend' => $entity->via,
@@ -1069,12 +1103,18 @@ class DirectMapper implements ImportInterface
                 }
 
                 foreach ($this->progressItems as $entity) {
-                    $opts[EventsTable::COLUMN_REFERENCE] = r($name, [
+                    $eventOpts = $opts;
+                    $eventOpts[EventsTable::COLUMN_REFERENCE] = r($name, [
                         'type' => $entity->type,
                         'backend' => $entity->via,
                         'id' => ag($entity->getMetadata($entity->via), iState::COLUMN_ID, '??'),
                     ]);
-                    queue_event(ProcessProgressEvent::NAME, [iState::COLUMN_ID => $entity->id], $opts);
+
+                    if (true === (bool) $entity->getContext(Options::REPLAY_PROGRESS, false)) {
+                        $eventOpts[Options::REPLAY_PROGRESS] = true;
+                    }
+
+                    queue_event(ProcessProgressEvent::NAME, [iState::COLUMN_ID => $entity->id], $eventOpts);
                 }
             } catch (CacheInvalidArgumentException $e) {
                 $this->logger->error(
@@ -1394,6 +1434,50 @@ class DirectMapper implements ImportInterface
     }
 
     /**
+     * Normalize watched replay progress into an unplayed state with resume progress.
+     */
+    private function normalizeReplayProgress(iState $old, iState $new, array $opts = []): bool
+    {
+        if (true === (bool) ag($opts, Options::IMPORT_METADATA_ONLY, false)) {
+            return false;
+        }
+
+        if (true === (bool) ag($opts, Options::SKIP_STATE, false)) {
+            return false;
+        }
+
+        if (false === $old->isWatched() || false === $new->isWatched()) {
+            return false;
+        }
+
+        if (false === (bool) ag($opts, Options::REPLAY_PROGRESS, $new->getContext(Options::REPLAY_PROGRESS, false))) {
+            return false;
+        }
+
+        [$allowUpdate, $minThreshold] = $this->getProgressThresholds();
+        if ($allowUpdate < $minThreshold) {
+            return false;
+        }
+
+        $newPlayProgress = (int) ag($new->getMetadata($new->via), iState::COLUMN_META_DATA_PROGRESS, 0);
+        $oldPlayProgress = (int) ag($old->getMetadata($new->via), iState::COLUMN_META_DATA_PROGRESS, 0);
+
+        if ($newPlayProgress < $this->getProgressMinimum() || $newPlayProgress <= ($oldPlayProgress + 10)) {
+            return false;
+        }
+
+        $receivedAt = ag($new->getExtra($new->via), iState::COLUMN_EXTRA_DATE, null);
+        $updated = null === $receivedAt ? time() : make_date($receivedAt)->getTimestamp();
+
+        $new->watched = 0;
+        $new->updated = max($old->updated + 1, $updated);
+        $new->setMeta(iState::COLUMN_WATCHED, '0', $new->via);
+        $new->setContext(Options::REPLAY_PROGRESS, true);
+
+        return true;
+    }
+
+    /**
      * Get default diff keys list.
      */
     private function getDefaultDiffKeys(): array
@@ -1448,6 +1532,15 @@ class DirectMapper implements ImportInterface
         }
 
         return [$this->progressThreshold, $this->progressMinThreshold];
+    }
+
+    private function getProgressMinimum(): int
+    {
+        if (null === $this->progressMinimum) {
+            $this->progressMinimum = (int) Config::get('progress.minimum', 60_000);
+        }
+
+        return $this->progressMinimum;
     }
 
     private function rethrowLock(Throwable $e, array $opts = []): bool

--- a/src/Libs/Options.php
+++ b/src/Libs/Options.php
@@ -65,6 +65,7 @@ final class Options
     public const string FAIL_FAST_ON_LOCK = 'FAIL_FAST_ON_LOCK';
     public const string CACHE_ONLY = 'CACHE_ONLY';
     public const string DATE_COLUMN = 'DATE_COLUMN';
+    public const string REPLAY_PROGRESS = 'REPLAY_PROGRESS';
 
     private function __construct() {}
 }

--- a/src/Listeners/ProcessProgressEvent.php
+++ b/src/Listeners/ProcessProgressEvent.php
@@ -77,7 +77,9 @@ final readonly class ProcessProgressEvent
             return $event;
         }
 
-        if ($item->isWatched()) {
+        $isReplayProgress = true === (bool) ag($options, Options::REPLAY_PROGRESS, false);
+
+        if ($item->isWatched() && false === $isReplayProgress) {
             $allowUpdate = (int) Config::get('progress.threshold', 0);
             $minThreshold = (int) Config::get('progress.minThreshold', 86_400);
             if (false === ($allowUpdate >= $minThreshold && time() > ($item->updated + $allowUpdate))) {
@@ -173,6 +175,10 @@ final readonly class ProcessProgressEvent
 
                 if (ag($options, Options::DEBUG_TRACE)) {
                     $opts[Options::DEBUG_TRACE] = true;
+                }
+
+                if ($isReplayProgress) {
+                    $opts[Options::REPLAY_PROGRESS] = true;
                 }
 
                 $backend['options'] = $opts;

--- a/src/Listeners/ProcessWebhookEvent.php
+++ b/src/Listeners/ProcessWebhookEvent.php
@@ -429,6 +429,10 @@ final class ProcessWebhookEvent
             Options::FAIL_FAST_ON_LOCK => true,
         ];
 
+        if (true === (bool) $entity->getContext(Options::REPLAY_PROGRESS, false)) {
+            $opts[Options::REPLAY_PROGRESS] = true;
+        }
+
         if (null === $this->event) {
             return;
         }
@@ -516,6 +520,7 @@ final class ProcessWebhookEvent
             Options::IMPORT_METADATA_ONLY => (bool) ag($options, Options::IMPORT_METADATA_ONLY),
             Options::DISABLE_MARK_UNPLAYED => (bool) ag($options, Options::DISABLE_MARK_UNPLAYED),
             Options::FAIL_FAST_ON_LOCK => (bool) ag($options, Options::FAIL_FAST_ON_LOCK, false),
+            Options::REPLAY_PROGRESS => (bool) ag($options, Options::REPLAY_PROGRESS, false),
             Options::STATE_UPDATE_EVENT => static fn(iState $state) => queue_push(
                 entity: $state,
                 userContext: $userContext,

--- a/tests/Backends/MediaBrowser/ProgressQueueTest.php
+++ b/tests/Backends/MediaBrowser/ProgressQueueTest.php
@@ -95,6 +95,88 @@ class ProgressQueueTest extends MediaBrowserTestCase
         }
     }
 
+    public function test_progress_unwatches_remote(): void
+    {
+        foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass, $metaClass, $sessionsClass]) {
+            $context = $this->makeContext($clientName, [Options::IGNORE_DATE => true, Options::REPLAY_PROGRESS => true]);
+            $cache = new Psr16Cache(new ArrayAdapter());
+
+            Container::add($sessionsClass, fn() => new class() {
+                public function __invoke(): Response
+                {
+                    return new Response(status: true, response: ['sessions' => []]);
+                }
+            });
+
+            $payload = $this->fixture('metadata');
+            $payload['UserData']['Played'] = true;
+            $payload['UserData']['PlayCount'] = 1;
+            $payload['UserData']['PlaybackPositionTicks'] = 0;
+            $payload['UserData']['LastPlayedDate'] = '2024-01-02T00:00:00Z';
+
+            $metaResponse = new MockResponse(json_encode($payload), ['http_code' => 200]);
+            $metaHttp = new HttpClient(new MockHttpClient($metaResponse));
+            Container::add($metaClass, fn() => new $metaClass($metaHttp, $this->logger, $cache));
+
+            $http = new HttpClient(new MockHttpClient(
+                fn(string $method, string $url, array $options) => new MockResponse('ok', [
+                    'http_code' => 200,
+                    'user_data' => $options['user_data'] ?? null,
+                ]),
+            ));
+
+            $entity = StateEntity::fromArray([
+                iState::COLUMN_ID => 10,
+                iState::COLUMN_TYPE => iState::TYPE_MOVIE,
+                iState::COLUMN_UPDATED => 2000,
+                iState::COLUMN_WATCHED => 0,
+                iState::COLUMN_VIA => 'Other',
+                iState::COLUMN_TITLE => 'Test Movie',
+                iState::COLUMN_META_DATA => [
+                    $context->backendName => [
+                        iState::COLUMN_ID => 'item-1',
+                        iState::COLUMN_TYPE => iState::TYPE_MOVIE,
+                        iState::COLUMN_WATCHED => '1',
+                        iState::COLUMN_META_DATA_PROGRESS => '70000',
+                        iState::COLUMN_TITLE => 'Test Movie',
+                    ],
+                    'Other' => [
+                        iState::COLUMN_META_DATA_PROGRESS => '70000',
+                        iState::COLUMN_WATCHED => '0',
+                    ],
+                ],
+                iState::COLUMN_EXTRA => [
+                    $context->backendName => [
+                        iState::COLUMN_EXTRA_DATE => '2024-01-02T00:00:00Z',
+                    ],
+                    'Other' => [
+                        iState::COLUMN_EXTRA_DATE => '2024-01-01T00:00:00Z',
+                    ],
+                ],
+            ]);
+
+            $queue = new QueueRequests();
+            $action = new $actionClass($http, $this->logger);
+            $guid = (new $guidClass($this->logger))->withContext($context);
+            $result = $action($context, $guid, [$entity], $queue);
+
+            $this->assertTrue($result->isSuccessful());
+            $this->assertSame(1, $queue->count());
+
+            $request = $queue->getQueue()[0];
+            $this->assertSame('DELETE', $request->method->value);
+            $this->assertStringContainsString('/Users/user-1/PlayedItems/item-1', (string) $request->url);
+
+            $followUps = ($request->success)(new MockResponse('', ['http_code' => 200]));
+            $this->assertCount(1, $followUps);
+            $this->assertContainsOnlyInstancesOf(Request::class, $followUps);
+            $this->assertSame('POST', $followUps[0]->method->value);
+            $this->assertStringContainsString('/Users/user-1/Items/item-1/UserData', (string) $followUps[0]->url);
+            $this->assertFalse($followUps[0]->options['json']['Played']);
+            $this->assertSame('700000000', $followUps[0]->options['json']['PlaybackPositionTicks']);
+        }
+    }
+
     private function provideBackends(): array
     {
         return [

--- a/tests/Backends/Plex/ProgressQueueTest.php
+++ b/tests/Backends/Plex/ProgressQueueTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Backends\Plex;
 
+use App\Backends\Common\Context;
 use App\Backends\Common\Response;
 use App\Backends\Common\Request;
 use App\Backends\Plex\Action\GetMetaData;
@@ -13,8 +14,11 @@ use App\Backends\Plex\PlexGuid;
 use App\Libs\Container;
 use App\Libs\Entity\StateEntity;
 use App\Libs\Entity\StateInterface as iState;
+use App\Libs\Extends\HttpClient;
+use App\Libs\Extends\MockHttpClient;
 use App\Libs\Options;
 use App\Libs\QueueRequests;
+use Symfony\Component\HttpClient\Response\MockResponse;
 
 class ProgressQueueTest extends PlexTestCase
 {
@@ -28,7 +32,7 @@ class ProgressQueueTest extends PlexTestCase
         });
 
         Container::add(GetMetaData::class, fn() => new class() {
-            public function __invoke(\App\Backends\Common\Context $context, string|int $id, array $opts = []): Response
+            public function __invoke(Context $context, string|int $id, array $opts = []): Response
             {
                 return new Response(status: true, response: [
                     'MediaContainer' => [
@@ -83,9 +87,9 @@ class ProgressQueueTest extends PlexTestCase
             ],
         ]);
 
-        $http = new \App\Libs\Extends\HttpClient(
-            new \App\Libs\Extends\MockHttpClient(
-                new \Symfony\Component\HttpClient\Response\MockResponse('ok', ['http_code' => 200]),
+        $http = new HttpClient(
+            new MockHttpClient(
+                new MockResponse('ok', ['http_code' => 200]),
             ),
         );
         $action = new Progress($http, $this->logger);
@@ -96,5 +100,96 @@ class ProgressQueueTest extends PlexTestCase
         $this->assertTrue($result->isSuccessful(), $message);
         $this->assertSame(1, $queue->count());
         $this->assertContainsOnlyInstancesOf(Request::class, $queue->getQueue());
+    }
+
+    public function test_progress_unwatches_remote(): void
+    {
+        Container::add(GetSessions::class, fn() => new class() {
+            public function __invoke(): Response
+            {
+                return new Response(status: true, response: ['sessions' => []]);
+            }
+        });
+
+        Container::add(GetMetaData::class, fn() => new class() {
+            public function __invoke(Context $context, string|int $id, array $opts = []): Response
+            {
+                return new Response(status: true, response: [
+                    'MediaContainer' => [
+                        'Metadata' => [
+                            [
+                                'ratingKey' => '1',
+                                'type' => 'movie',
+                                'title' => 'Test Movie',
+                                'duration' => 100000,
+                                'viewCount' => 1,
+                                'addedAt' => 1000,
+                                'lastViewedAt' => 2000,
+                                'Guid' => [
+                                    ['id' => 'imdb://tt123'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ]);
+            }
+        });
+
+        $context = $this->makeContext([Options::IGNORE_DATE => true, Options::REPLAY_PROGRESS => true]);
+        $queue = new QueueRequests();
+
+        $entity = StateEntity::fromArray([
+            iState::COLUMN_ID => 10,
+            iState::COLUMN_TYPE => iState::TYPE_MOVIE,
+            iState::COLUMN_UPDATED => 2000,
+            iState::COLUMN_WATCHED => 0,
+            iState::COLUMN_VIA => 'Other',
+            iState::COLUMN_TITLE => 'Test Movie',
+            iState::COLUMN_META_DATA => [
+                $context->backendName => [
+                    iState::COLUMN_ID => '1',
+                    iState::COLUMN_TYPE => iState::TYPE_MOVIE,
+                    iState::COLUMN_WATCHED => '1',
+                    iState::COLUMN_META_DATA_PROGRESS => '70000',
+                    iState::COLUMN_TITLE => 'Test Movie',
+                ],
+                'Other' => [
+                    iState::COLUMN_META_DATA_PROGRESS => '70000',
+                    iState::COLUMN_WATCHED => '0',
+                ],
+            ],
+            iState::COLUMN_EXTRA => [
+                $context->backendName => [
+                    iState::COLUMN_EXTRA_DATE => '2024-01-02T00:00:00Z',
+                ],
+                'Other' => [
+                    iState::COLUMN_EXTRA_DATE => '2024-01-01T00:00:00Z',
+                ],
+            ],
+        ]);
+
+        $http = new HttpClient(
+            new MockHttpClient(
+                new MockResponse('ok', ['http_code' => 200]),
+            ),
+        );
+        $action = new Progress($http, $this->logger);
+        $guid = (new PlexGuid($this->logger))->withContext($context);
+        $result = $action($context, $guid, [$entity], $queue);
+
+        $message = $result->error?->format() ?? '';
+        $this->assertTrue($result->isSuccessful(), $message);
+        $this->assertSame(1, $queue->count());
+
+        $request = $queue->getQueue()[0];
+        $this->assertSame('GET', $request->method->value);
+        $this->assertStringContainsString('/:/unscrobble', (string) $request->url);
+
+        $followUps = ($request->success)(new MockResponse('', ['http_code' => 200]));
+        $this->assertCount(1, $followUps);
+        $this->assertContainsOnlyInstancesOf(Request::class, $followUps);
+        $this->assertSame('POST', $followUps[0]->method->value);
+        $this->assertStringContainsString('/:/timeline/', (string) $followUps[0]->url);
+        $this->assertStringContainsString('time=70000', (string) $followUps[0]->url);
     }
 }

--- a/tests/Mappers/Import/DirectMapperTest.php
+++ b/tests/Mappers/Import/DirectMapperTest.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace Tests\Mappers\Import;
 
+use App\Libs\Config;
+use App\Libs\Container;
 use App\Libs\Entity\StateEntity;
 use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Mappers\Import\DirectMapper;
 use App\Libs\Mappers\ImportInterface;
 use App\Libs\Options;
+use App\Listeners\ProcessProgressEvent;
+use App\Model\Events\EventsRepository;
+use App\Model\Events\EventsTable;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Psr16Cache;
 
@@ -152,6 +157,83 @@ class DirectMapperTest extends MapperAbstract
             $storedMetadata,
             'PLAYED_AT should be set in metadata during SKIP_STATE scenario',
         );
+    }
+
+    public function test_watched_progress_replay(): void
+    {
+        $threshold = Config::get('progress.threshold');
+        $minThreshold = Config::get('progress.minThreshold');
+
+        Config::save('progress.threshold', 180);
+        Config::save('progress.minThreshold', 180);
+
+        try {
+            $now = time();
+            $this->testMovie[iState::COLUMN_WATCHED] = 1;
+            $this->testMovie[iState::COLUMN_UPDATED] = $now - 3600;
+            $this->testMovie[iState::COLUMN_META_DATA][$this->testMovie[iState::COLUMN_VIA]][iState::COLUMN_WATCHED] = 1;
+            $this->testMovie[iState::COLUMN_META_DATA][$this->testMovie[iState::COLUMN_VIA]][iState::COLUMN_META_DATA_PROGRESS] = 0;
+            $this->testMovie[iState::COLUMN_EXTRA][$this->testMovie[iState::COLUMN_VIA]][iState::COLUMN_EXTRA_DATE] = $now - 3600;
+
+            $testMovie = new StateEntity($this->testMovie);
+            $this->mapper->add($testMovie);
+            $this->mapper->commit();
+            $this->mapper->reset()->loadData();
+
+            $stored = $this->mapper->get($testMovie);
+            $this->assertNotNull($stored);
+
+            $progressCalls = 0;
+            $stateCalls = 0;
+            $progressEntity = null;
+
+            $updatedMovie = clone $stored;
+            $updatedMovie->watched = 1;
+            $updatedMovie->updated = $now - 3600;
+            $metadata = $updatedMovie->getMetadata();
+            $metadata[$updatedMovie->via][iState::COLUMN_WATCHED] = 1;
+            $metadata[$updatedMovie->via][iState::COLUMN_META_DATA_PROGRESS] = 120000;
+            $updatedMovie->metadata = $metadata;
+            $extra = $updatedMovie->getExtra();
+            $extra[$updatedMovie->via][iState::COLUMN_EXTRA_EVENT] = 'media.stop';
+            $extra[$updatedMovie->via][iState::COLUMN_EXTRA_DATE] = $now;
+            $updatedMovie->extra = $extra;
+            $updatedMovie->setIsTainted(true);
+
+            $this->mapper->add($updatedMovie, [
+                Options::REPLAY_PROGRESS => true,
+                Options::STATE_UPDATE_EVENT => static function () use (&$stateCalls): void {
+                    $stateCalls++;
+                },
+                Options::STATE_PROGRESS_EVENT => static function (iState $entity) use (&$progressCalls, &$progressEntity): void {
+                    $progressCalls++;
+                    $progressEntity = $entity;
+                },
+            ]);
+            $this->mapper->commit();
+
+            $this->mapper->reset()->loadData();
+            $result = $this->mapper->get($updatedMovie);
+
+            $this->assertNotNull($result);
+            $this->assertSame(0, $result->watched);
+            $this->assertSame('0', (string) ag($result->getMetadata($updatedMovie->via), iState::COLUMN_WATCHED));
+            $this->assertSame(120000, (int) ag($result->getMetadata($updatedMovie->via), iState::COLUMN_META_DATA_PROGRESS));
+            $this->assertSame(0, $stateCalls);
+            $this->assertSame(1, $progressCalls);
+            $this->assertInstanceOf(iState::class, $progressEntity);
+            $this->assertTrue($progressEntity->getContext(Options::REPLAY_PROGRESS, false));
+
+            $events = Container::get(EventsRepository::class)->findAll([
+                EventsTable::COLUMN_EVENT => ProcessProgressEvent::NAME,
+            ]);
+
+            $this->assertCount(1, $events);
+            $this->assertTrue((bool) ag($events[0]->options, Options::REPLAY_PROGRESS, false));
+        } finally {
+            Config::save('progress.threshold', $threshold);
+            Config::save('progress.minThreshold', $minThreshold);
+        }
     }
 
     /**


### PR DESCRIPTION
This pull request improves how playback progress updates are handled for Emby and Jellyfin backends, especially in scenarios where an item is already marked as watched but needs its progress updated (for example, when replaying or resuming). The changes ensure that progress updates are correctly applied by first marking an item as unwatched if necessary, then updating its progress. The logic for parsing webhook events and building progress requests has been updated to support this workflow.

**Progress Replay and Unwatch Workflow Enhancements:**

* Added logic in Emby and Jellyfin webhook parsers (`ParseWebhook.php`) to set a special context flag (`Options::REPLAY_PROGRESS`) when a progress update should be replayed for already-watched items, based on specific events and play state. [[1]](diffhunk://#diff-8a182e3e081cd0622eb96569045802ceb4654a8620cc327b06578ae3af4f1867R271-R287) [[2]](diffhunk://#diff-bca74bbcf204a0c0ae029b4710f9bbc2a91b9cf0e67d339793a4918702bb11dcR242-R245)
* Modified progress actions (`Progress.php`) for Emby and Jellyfin to check the new replay flag and, if set and the item is already watched, queue an additional request to mark the item as unwatched before sending the progress update. This ensures progress can be updated even on watched items. [[1]](diffhunk://#diff-54f4fad2b3793014495cbf5c7be86ef9ae2d23be6b64410ed8e83ebaa5ccc2d6R204-R206) [[2]](diffhunk://#diff-54f4fad2b3793014495cbf5c7be86ef9ae2d23be6b64410ed8e83ebaa5ccc2d6L263-R286) [[3]](diffhunk://#diff-54f4fad2b3793014495cbf5c7be86ef9ae2d23be6b64410ed8e83ebaa5ccc2d6R331-R398) [[4]](diffhunk://#diff-ade8e15b3bc6c8993d125495db1b1a72499f488c193b6723f8b2714f1044ae8bR227-R229) [[5]](diffhunk://#diff-ade8e15b3bc6c8993d125495db1b1a72499f488c193b6723f8b2714f1044ae8bL290-R313) [[6]](diffhunk://#diff-ade8e15b3bc6c8993d125495db1b1a72499f488c193b6723f8b2714f1044ae8bR358-R425)

**Request Flow and Context Handling:**

* Updated logic to skip the "already processed by this backend" check if replaying progress, allowing the update to proceed when appropriate. [[1]](diffhunk://#diff-54f4fad2b3793014495cbf5c7be86ef9ae2d23be6b64410ed8e83ebaa5ccc2d6L125-R126) [[2]](diffhunk://#diff-ade8e15b3bc6c8993d125495db1b1a72499f488c193b6723f8b2714f1044ae8bL152-R153)
* Introduced new variables (`$progress`, `$replayProgress`, `$unwatchFirst`) and ensured they are properly initialized and used throughout the workflow for clarity and correctness. [[1]](diffhunk://#diff-8a182e3e081cd0622eb96569045802ceb4654a8620cc327b06578ae3af4f1867R257) [[2]](diffhunk://#diff-54f4fad2b3793014495cbf5c7be86ef9ae2d23be6b64410ed8e83ebaa5ccc2d6R79) [[3]](diffhunk://#diff-54f4fad2b3793014495cbf5c7be86ef9ae2d23be6b64410ed8e83ebaa5ccc2d6R177-R178) [[4]](diffhunk://#diff-ade8e15b3bc6c8993d125495db1b1a72499f488c193b6723f8b2714f1044ae8bR106) [[5]](diffhunk://#diff-ade8e15b3bc6c8993d125495db1b1a72499f488c193b6723f8b2714f1044ae8bR204-R205)

**General Improvements:**

* Unified the way progress information is extracted and handled in all relevant webhook parsers, including Plex, for consistency.

These changes improve the robustness and accuracy of progress synchronization across backends, especially in edge cases involving replaying or resuming watched content.