### PR TITLE
feat: allow watch progress restore via backup file

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -203,7 +203,7 @@ No, webhooks are **not required** for the tool to function. You can use the buil
 
 > [!NOTE]
 > There are problems with jellyfin API, which are fixed by using webhooks, please check out
-> the [webhook guide](/guides/webhooks.md#media-backends-webhook-limitations) to learn more.
+> the [backend limitations guide](/guides/backend-limitations.md#jellyfin) to learn more.
 
 ---
 

--- a/config/config.php
+++ b/config/config.php
@@ -232,7 +232,7 @@ return (function () {
         'file' => [
             'type' => 'stream',
             'enabled' => (bool) env('WS_LOGGER_FILE_ENABLE', true),
-            'level' => env('WS_LOGGER_FILE_LEVEL', Level::Warning),
+            'level' => env('WS_LOGGER_FILE_LEVEL', Level::Error),
             'filename' => ag($config, 'tmpDir') . '/logs/app.' . $logDateFormat . '.log',
         ],
         'stderr' => [

--- a/frontend/app/components/BackendAdd.vue
+++ b/frontend/app/components/BackendAdd.vue
@@ -45,6 +45,17 @@
             </NuxtLink>
             to learn more.
           </li>
+          <li>
+            Each backend has specific requirements. Review the
+            <NuxtLink
+              to="/help/backend-limitations"
+              class="inline-flex items-center gap-1 text-primary"
+            >
+              <UIcon name="i-lucide-circle-help" class="size-4" />
+              <span>backend limitations</span>
+            </NuxtLink>
+            page before adding.
+          </li>
           <li v-if="api_user === 'main'">
             Do not add identity backends manually after finishing the main identity backend setup.
             Visit

--- a/frontend/app/pages/help/index.vue
+++ b/frontend/app/pages/help/index.vue
@@ -125,5 +125,11 @@ const choices: Array<{ number: number; title: string; text: string; url: string 
     text: 'How to enable path-based matching.',
     url: '/help/path-match',
   },
+  {
+    number: 11,
+    title: 'Backend limitations',
+    text: 'Requirements and known limitations for supported backends.',
+    url: '/help/backend-limitations',
+  },
 ];
 </script>

--- a/guides/backend-limitations.md
+++ b/guides/backend-limitations.md
@@ -1,0 +1,62 @@
+# Backend Limitations
+
+Each backend has specific requirements and limitations to be aware of before adding it to WatchState.
+
+## Plex
+
+### Requirements
+
+- **PlexPass** subscription is required for webhooks.
+- An **admin-level token** is required if you plan to [provision identities](/guides/identities.md).
+- Plex version **1.41.6.9606 or newer** is recommended. Older versions have a bug where marking an item as watched without prior progress does not show it in continue-watching [[reference](https://forums.plex.tv/t/continue-watching-is-buggy-unable-to-figure-out-why/869224/65)].
+
+### Limitations
+
+- **Limited tokens** cannot list or impersonate users. The users list will be empty, and you must enter the user UUID manually.
+- **.plex.direct URLs** often fail in Docker. Add your custom domain via **Plex Settings > Network > Custom server access URLs**.
+- Only **movie** and **show** libraries are imported for play state. Music, photos, and other library types are skipped.
+
+### Webhook Limitations
+
+- Plex does not send events for *marked as played/unplayed* actions.
+- Webhook events may be **skipped** when multiple items are added at once.
+- When items are marked as **unwatched**, Plex resets the date on the media object.
+- Plex does not send watch progress update events during playback. It only sends progress updates during `play`, `pause`, `stop`, and `resume` events, so progress data from Plex will not be reflected until one of those events triggers.
+
+### Plex via Tautulli
+
+- **Marking items as unplayed** is not reliable, as Tautulli's webhook payload lacks the data needed to detect this change.
+- Similarly to Plex, Tautulli does not send watch progress update events during playback.
+
+## Jellyfin
+
+### Requirements
+
+- **v10.9.x or higher** is required for watch progress sync.
+- The **Notifications > Webhook** plugin (free) must be installed from the plugin catalog for webhook support.
+- An **API key** is required if you plan to [provision identities](/guides/identities.md). The `username:password` format will not work for identity provisioning.
+
+### Limitations
+
+- Only **movie** and **show** libraries are imported for play state. Music, photos, and other library types are skipped.
+
+### Webhook Limitations
+
+- Even if a user ID is selected, Jellyfin may **still send events without user data**.
+- Items may be marked as **unplayed** if the setting *Libraries > Display > Date Added Behavior for New Content: Use Date Scanned into Library* is enabled. This can happen when media files are replaced or updated.
+
+### Known Issues
+
+- **Played without date bug**: Jellyfin marks items as played without updating the `LastPlayedDate`, causing export conflicts. The recommanded approch is to enable webhooks. However, if you prefer scheduled imports, you can enable the experimental `WS_CLIENTS_JELLYFIN_FIX_PLAYED` environment variable as a workaround, then run `state:import`.
+
+## Emby
+
+### Requirements
+
+- **Emby Premiere** subscription is required for webhooks.
+- An **API key** is required if you plan to [provision identities](/guides/identities.md). The `username:password` format will not work for identity provisioning.
+
+### Limitations
+
+- Only **movie** and **show** libraries are imported for play state. Music, photos, and other library types are skipped.
+- The **webhook test event** previously contained no data, but this issue appears to be fixed in version `4.9.0.37+`. To verify if your Emby webhook setup works, try playing or marking an item as played/unplayed and check if the changes appear in the database.

--- a/guides/webhooks.md
+++ b/guides/webhooks.md
@@ -232,38 +232,8 @@ Click *Save*.
 
 # Media Backends Webhook Limitations
 
-Here are some known limitations and issues when using webhooks with different media backends:
-
-### Plex
-
-- Plex doesn't send events for *marked as played/unplayed* actions.
-- Webhook events may be **skipped** when multiple items are added at once.
-- When items are marked as **unwatched**, Plex resets the date on the media object.
-- In old version of plex i.e. pre `1.41.6.9606` marking items as watched and if you didn't have progress on the show
-  will not show the item in continue watching, this is a limitation of the old plex version and not
-  watchstate. [reference](https://forums.plex.tv/t/continue-watching-is-buggy-unable-to-figure-out-why/869224/65)
-- Plex doesn't send watch progress update events during playback, it only sends the progress update during `play`,
-  `pause`, `stop`, `resume` events. So the progress update from plex will not be reflected until one of those events
-  kicks in.
-
-### Plex via Tautulli
-
-- **Marking items as unplayed** is not reliable, as Tautulli’s webhook payload lacks the data needed to detect this
-  change.
-- Similarly to plex, Tautulli doesn't send watch progress update events during playback.
-
-### Emby
-
-- The **webhook test event** previously contained no data, but this issue appears to be fixed in version `4.9.0.37+`.
-    - To verify if your Emby webhook setup works, try playing or marking an item as played/unplayed, and check if the
-      changes appear in the database.
-
-### Jellyfin
-
-- Even if a user ID is selected, Jellyfin may **still send events without user data**.
-- Items may be marked as **unplayed** if the setting *Libraries > Display > Date Added Behavior for New Content: Use
-  Date Scanned into Library* is enabled.
-    - This can happen when media files are replaced or updated.
+See the [backend limitations](/guides/backend-limitations.md) for a comprehensive list of per-backend requirements 
+and limitations, including webhook-specific event behaviour.
 
 # Sometimes Newly Added Content Does Not Show Up
 
@@ -272,7 +242,3 @@ complement webhook functionality.
 
 Simply go to the *Tasks* page and enable the *Import* and *Export* tasks. and set the schedule to `every 12 hours` or
 `every 24 hours` depending on your needs.
-
-# Troubleshooting
-
-TBA

--- a/src/Commands/Backend/RestoreCommand.php
+++ b/src/Commands/Backend/RestoreCommand.php
@@ -89,6 +89,7 @@ class RestoreCommand extends Command
                 InputOption::VALUE_NONE,
                 'Send one request at a time instead of all at once. note: Slower but more reliable.',
             )
+            ->addOption('restore-watch-progress', 'P', InputOption::VALUE_NONE, 'Restore the watch progress from backup as well.')
             ->addOption(
                 'async-requests',
                 null,
@@ -268,6 +269,7 @@ class RestoreCommand extends Command
 
         $opts = [
             Options::IGNORE_DATE => true,
+            Options::REPLAY_PROGRESS => true === $input->getOption('restore-watch-progress'),
             Options::DEBUG_TRACE => true === $input->getOption('trace'),
             Options::DRY_RUN => false === $input->getOption('execute'),
         ];
@@ -370,7 +372,55 @@ class RestoreCommand extends Command
                 );
             }
 
-            if ($stats['failed'] > 0 || $sendStats['failed'] > 0) {
+            $progressStats = ['sent' => 0, 'failed' => 0];
+
+            if (true === $input->getOption('restore-watch-progress')) {
+                $this->queue->reset();
+                $backend->progress($mapper->getObjects(), $this->queue, null);
+
+                $progressStats['sent'] = count($this->queue->getQueue());
+
+                if ($progressStats['sent'] >= 1) {
+                    $this->logger->notice("SYSTEM: Sending '{total}' watch progress requests for '{user}@{backend}'.", [
+                        'backend' => $name,
+                        'user' => $userContext->name,
+                        'total' => $progressStats['sent'],
+                    ]);
+                } else {
+                    $this->logger->notice("SYSTEM: No watch progress changes detected between backup file and '{user}@{backend}'.", [
+                        'backend' => $name,
+                        'user' => $userContext->name,
+                    ]);
+                }
+
+                if ($progressStats['sent'] >= 1 && false !== $input->getOption('execute')) {
+                    send_requests(
+                        requests: $this->queue->getQueue(),
+                        client: $this->http,
+                        sync: $syncRequests,
+                        logger: $this->logger,
+                        opts: [
+                            'error' => static function () use (&$progressStats): array {
+                                $progressStats['failed']++;
+                                return [];
+                            },
+                        ],
+                    );
+
+                    $this->logger->notice(
+                        "SYSTEM: Sent '{total}' watch progress requests to '{client}: {user}@{backend}' in '{duration}'s.",
+                        [
+                            'total' => $progressStats['sent'],
+                            'backend' => $name,
+                            'user' => $userContext->name,
+                            'client' => $backend->getContext()->clientName,
+                            'duration' => round(microtime(true) - $opStart, 4),
+                        ],
+                    );
+                }
+            }
+
+            if ($stats['failed'] > 0 || $sendStats['failed'] > 0 || $progressStats['failed'] > 0) {
                 $this->logger->warning(
                     "Restore completed with item-level request failures for '{user}@{backend}'.",
                     [
@@ -378,6 +428,7 @@ class RestoreCommand extends Command
                         'backend' => $name,
                         'comparison' => $stats,
                         'apply' => $sendStats,
+                        'progress' => $progressStats,
                     ],
                 );
             }

--- a/src/Commands/Backend/RestoreCommand.php
+++ b/src/Commands/Backend/RestoreCommand.php
@@ -132,6 +132,8 @@ class RestoreCommand extends Command
      */
     protected function process(iInput $input, iOutput $output): int
     {
+        $this->queue->reset();
+
         $userName = $input->getOption('user');
         if (empty($userName)) {
             $output->writeln(r('<error>ERROR: User not specified. Please use [-u, --user].</error>'));
@@ -292,64 +294,114 @@ class RestoreCommand extends Command
             $syncRequests = false;
         }
 
-        $requests = $backend->export($mapper, $this->queue, null);
+        try {
+            $requests = $backend->export($mapper, $this->queue, null);
 
-        $start = microtime(true);
-        $this->logger->notice("SYSTEM: Sending '{total}' play state comparison requests for '{user}@{backend}'.", [
-            'backend' => $name,
-            'total' => count($requests),
-            'user' => $userContext->name,
-        ]);
+            $stats = ['sent' => count($requests), 'failed' => 0];
 
-        send_requests(requests: $requests, client: $this->http, sync: $syncRequests, logger: $this->logger);
-
-        $this->logger->notice("SYSTEM: Completed '{total}' requests in '{duration}'s for '{user}@{backend}'.", [
-            'backend' => $name,
-            'total' => count($requests),
-            'user' => $userContext->name,
-            'duration' => round(microtime(true) - $start, 4),
-        ]);
-
-        $total = count($this->queue->getQueue());
-
-        if ($total >= 1) {
-            $this->logger->notice("SYSTEM: Sending '{total}' change state requests for '{user}@{backend}'.", [
+            $start = microtime(true);
+            $this->logger->notice("SYSTEM: Sending '{total}' play state comparison requests for '{user}@{backend}'.", [
                 'backend' => $name,
-                'user' => $userContext->name,
-                'total' => $total,
-            ]);
-        }
-
-        if ((int) Message::get("{$userContext->name}.{$name}.export", 0) < 1) {
-            $this->logger->notice("SYSTEM: No difference detected between backup file and '{user}@{backend}'.", [
-                'backend' => $name,
+                'total' => $stats['sent'],
                 'user' => $userContext->name,
             ]);
-        }
 
-        if ($total < 1 || false === $input->getOption('execute')) {
+            send_requests(
+                requests: $requests,
+                client: $this->http,
+                sync: $syncRequests,
+                logger: $this->logger,
+                opts: [
+                    'error' => static function () use (&$stats): array {
+                        $stats['failed']++;
+                        return [];
+                    },
+                ],
+            );
+
+            $this->logger->notice("SYSTEM: Completed '{total}' requests in '{duration}'s for '{user}@{backend}'.", [
+                'backend' => $name,
+                'total' => $stats['sent'],
+                'user' => $userContext->name,
+                'duration' => round(microtime(true) - $start, 4),
+            ]);
+
+            $total = count($this->queue->getQueue());
+            $sendStats = ['sent' => $total, 'failed' => 0];
+
+            if ($total >= 1) {
+                $this->logger->notice("SYSTEM: Sending '{total}' change state requests for '{user}@{backend}'.", [
+                    'backend' => $name,
+                    'user' => $userContext->name,
+                    'total' => $total,
+                ]);
+            }
+
+            if ((int) Message::get("{$userContext->name}.{$name}.export", 0) < 1) {
+                $this->logger->notice("SYSTEM: No difference detected between backup file and '{user}@{backend}'.", [
+                    'backend' => $name,
+                    'user' => $userContext->name,
+                ]);
+            }
+
+            if ($total >= 1 && false !== $input->getOption('execute')) {
+                send_requests(
+                    requests: $this->queue->getQueue(),
+                    client: $this->http,
+                    sync: $syncRequests,
+                    logger: $this->logger,
+                    opts: [
+                        'error' => static function () use (&$sendStats): array {
+                            $sendStats['failed']++;
+                            return [];
+                        },
+                    ],
+                );
+
+                $this->logger->notice(
+                    "SYSTEM: Sent '{total}' change play state requests to '{client}: {user}@{backend}' in '{duration}'s.",
+                    [
+                        'total' => $total,
+                        'backend' => $name,
+                        'user' => $userContext->name,
+                        'client' => $backend->getContext()->clientName,
+                        'duration' => round(microtime(true) - $opStart, 4),
+                    ],
+                );
+            }
+
+            if ($stats['failed'] > 0 || $sendStats['failed'] > 0) {
+                $this->logger->warning(
+                    "Restore completed with item-level request failures for '{user}@{backend}'.",
+                    [
+                        'user' => $userContext->name,
+                        'backend' => $name,
+                        'comparison' => $stats,
+                        'apply' => $sendStats,
+                    ],
+                );
+            }
+
             return self::SUCCESS;
+        } catch (Throwable $e) {
+            $this->logger->error(
+                "SYSTEM: Unhandled exception '{error.kind}' was thrown during '{user}@{backend}' restore operation. '{error.message}' at '{error.file}:{error.line}'.",
+                [
+                    'user' => $userContext->name,
+                    'backend' => $name,
+                    'error' => [
+                        'kind' => $e::class,
+                        'line' => $e->getLine(),
+                        'message' => $e->getMessage(),
+                        'file' => after($e->getFile(), ROOT_PATH),
+                    ],
+                ],
+            );
+
+            return self::FAILURE;
+        } finally {
+            $this->queue->reset();
         }
-
-        send_requests(
-            requests: $this->queue->getQueue(),
-            client: $this->http,
-            sync: $syncRequests,
-            logger: $this->logger,
-        );
-
-        $this->logger->notice(
-            "SYSTEM: Sent '{total}' change play state requests to '{client}: {user}@{backend}' in '{duration}'s.",
-            [
-                'total' => $total,
-                'backend' => $name,
-                'user' => $userContext->name,
-                'client' => $backend->getContext()->clientName,
-                'duration' => round(microtime(true) - $opStart, 4),
-            ],
-        );
-
-        return self::SUCCESS;
     }
 
     /**

--- a/src/Commands/State/BackupCommand.php
+++ b/src/Commands/State/BackupCommand.php
@@ -427,20 +427,34 @@ class BackupCommand extends Command
             assert($backend['fp'] instanceof iStream, 'Expected backup file stream.');
 
             if (false === $input->getOption('dry-run')) {
-                $backend['fp']->seek(-1, SEEK_END);
-                $backend['fp']->write(PHP_EOL . ']');
+                $file = (string) $backend['fp']->getMetadata('uri');
+
+                if (($backend['fp']->getSize() ?? 0) > 1) {
+                    $backend['fp']->seek(-1, SEEK_END);
+                    $backend['fp']->write(PHP_EOL . ']');
+                } else {
+                    $backend['fp']->close();
+                    if (true === file_exists($file)) {
+                        unlink($file);
+                    }
+
+                    $this->logger->warning("SYSTEM: No backup was generated for '{user}@{backend}'. No items were found.", [
+                        'user' => $userContext->name,
+                        'backend' => $b,
+                        'file' => $file,
+                    ]);
+
+                    continue;
+                }
 
                 if (false === $noCompression) {
-                    $file = $backend['fp']->getMetadata('uri');
                     $this->logger->notice("SYSTEM: Compressing '{user}@{backend}' backup file '{file}'.", [
                         'backend' => $b,
                         'file' => $file,
                         'user' => $userContext->name,
                     ]);
 
-                    $status = compress_files($file, [$file], ['affix' => 'zip']);
-
-                    if (true === $status) {
+                    if (true === compress_files($file, [$file], ['affix' => 'zip'])) {
                         unlink($file);
                     }
                 }

--- a/src/Commands/System/ReportCommand.php
+++ b/src/Commands/System/ReportCommand.php
@@ -14,6 +14,7 @@ use App\Libs\Entity\StateEntity;
 use App\Libs\Extends\ConsoleOutput;
 use App\Libs\Extends\Date;
 use App\Libs\Mappers\ImportInterface as iImport;
+use App\Libs\Options;
 use App\Libs\UserContext;
 use Cron\CronExpression;
 use LimitIterator;

--- a/src/Libs/Mappers/Import/RestoreMapper.php
+++ b/src/Libs/Mappers/Import/RestoreMapper.php
@@ -174,6 +174,20 @@ final class RestoreMapper implements iImport
                 $entity[iState::COLUMN_PARENT] = Guid::fromArray($entity[iState::COLUMN_PARENT])->getAll();
             }
 
+            if (null !== ($progress = $entity[iState::COLUMN_META_DATA_PROGRESS] ?? null)) {
+                $entity[iState::COLUMN_META_DATA] = [
+                    $entity[iState::COLUMN_VIA] => [
+                        iState::COLUMN_META_DATA_PROGRESS => (string) $progress,
+                    ],
+                ];
+                $entity[iState::COLUMN_EXTRA] = [
+                    $entity[iState::COLUMN_VIA] => [
+                        iState::COLUMN_EXTRA_EVENT => 'task.backup',
+                        iState::COLUMN_EXTRA_DATE => time(),
+                    ],
+                ];
+            }
+
             $item = $state::fromArray($entity);
 
             $this->add($item);

--- a/src/Listeners/ProcessProfileEvent.php
+++ b/src/Listeners/ProcessProfileEvent.php
@@ -82,14 +82,14 @@ final readonly class ProcessProfileEvent
                 $statusCode = $response->getStatusCode();
 
                 if (Status::OK !== Status::tryFrom($statusCode)) {
-                    $this->logger->error("Failed to process profile '{id}'. Status: '{status}'.", [
+                    $writer(Level::Error, "Failed to process profile '{id}'. Status: '{status}'.", [
                         'id' => ag($e->getData(), 'meta.id', '??'),
                         'status' => $statusCode,
                     ]);
                     return $e;
                 }
 
-                $this->logger->notice("Successfully Processed '{id}'.", [
+                $writer(Level::Notice, "Successfully Processed '{id}'.", [
                     'id' => ag($e->getData(), 'meta.id', '??'),
                 ]);
             } catch (TransportExceptionInterface $e) {

--- a/tests/Commands/Backend/RestoreCommandTest.php
+++ b/tests/Commands/Backend/RestoreCommandTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands\Backend;
+
+use App\Commands\Backend\RestoreCommand;
+use App\Libs\Extends\HttpClient;
+use App\Libs\LogSuppressor;
+use App\Libs\QueueRequests;
+use App\Libs\TestCase;
+use App\Libs\Extends\MockHttpClient;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Contracts\HttpClient\HttpClientInterface as iHttp;
+use Tests\Support\FakeBackendClient;
+use Tests\Support\StateCommandTestSupport;
+
+final class RestoreCommandTest extends TestCase
+{
+    use StateCommandTestSupport;
+
+    public function test_fatal_resets_queue(): void
+    {
+        $logger = $this->initFakeBackendApp($this->fakeBackendConfig('fake_restore'));
+        FakeBackendClient::setExportError('main', 'fake_restore', new \RuntimeException('restore export failed'));
+
+        $backupFile = self::$tmpPath . '/backup.json';
+        file_put_contents($backupFile, json_encode([
+            [
+                'type' => 'movie',
+                'watched' => 1,
+                'updated' => 1_700_000_000,
+                'title' => 'Fake Movie',
+                'year' => 2024,
+                'guids' => [
+                    'guid_imdb' => 'tt-fake-fake_restore',
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+        $queue = new QueueRequests();
+        FakeBackendClient::setQueuedExportRequests('main', 'fake_restore', 1);
+
+        $command = new RestoreCommand(
+            $queue,
+            $logger,
+            new LogSuppressor([]),
+            $this->createStub(iHttp::class),
+        );
+
+        $status = $this->makeTester($command)->execute([
+            '--assume-yes' => true,
+            '--user' => 'main',
+            '--select-backend' => 'fake_restore',
+            'file' => $backupFile,
+        ]);
+
+        self::assertSame(RestoreCommand::FAILURE, $status);
+        self::assertCount(1, FakeBackendClient::getCalls('export'));
+        self::assertCount(0, $queue->getQueue());
+    }
+
+    public function test_item_failures_keep_success(): void
+    {
+        $logger = $this->initFakeBackendApp($this->fakeBackendConfig('fake_restore'));
+
+        $backupFile = self::$tmpPath . '/backup.json';
+        file_put_contents($backupFile, json_encode([
+            [
+                'type' => 'movie',
+                'watched' => 1,
+                'updated' => 1_700_000_000,
+                'title' => 'Fake Movie',
+                'year' => 2024,
+                'guids' => [
+                    'guid_imdb' => 'tt-fake-fake_restore',
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+        $queue = new QueueRequests();
+        FakeBackendClient::setQueuedExportRequests('main', 'fake_restore', 1);
+
+        $http = new HttpClient(new MockHttpClient(
+            static fn(string $method, string $url, array $options) => throw new \RuntimeException('removed item'),
+        ));
+
+        $command = new RestoreCommand(
+            $queue,
+            $logger,
+            new LogSuppressor([]),
+            $http,
+        );
+
+        $status = $this->makeTester($command)->execute([
+            '--assume-yes' => true,
+            '--user' => 'main',
+            '--select-backend' => 'fake_restore',
+            '--execute' => true,
+            'file' => $backupFile,
+        ]);
+
+        self::assertSame(RestoreCommand::SUCCESS, $status);
+        self::assertCount(1, FakeBackendClient::getCalls('export'));
+        self::assertCount(0, $queue->getQueue());
+    }
+
+    private function makeTester(RestoreCommand $command): CommandTester
+    {
+        $application = new Application();
+        $application->getDefinition()->addOption(new InputOption('trace', null, InputOption::VALUE_NONE));
+        $application->addCommand($command);
+
+        return new CommandTester($application->find(RestoreCommand::ROUTE));
+    }
+}

--- a/tests/Commands/Backend/RestoreCommandTest.php
+++ b/tests/Commands/Backend/RestoreCommandTest.php
@@ -35,7 +35,7 @@ final class RestoreCommandTest extends TestCase
                 'title' => 'Fake Movie',
                 'year' => 2024,
                 'guids' => [
-                    'guid_imdb' => 'tt-fake-fake_restore',
+                    'guid_imdb' => 'tt1234567',
                 ],
             ],
         ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
@@ -75,7 +75,7 @@ final class RestoreCommandTest extends TestCase
                 'title' => 'Fake Movie',
                 'year' => 2024,
                 'guids' => [
-                    'guid_imdb' => 'tt-fake-fake_restore',
+                    'guid_imdb' => 'tt1234567',
                 ],
             ],
         ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
@@ -105,6 +105,54 @@ final class RestoreCommandTest extends TestCase
         self::assertSame(RestoreCommand::SUCCESS, $status);
         self::assertCount(1, FakeBackendClient::getCalls('export'));
         self::assertCount(0, $queue->getQueue());
+    }
+
+    public function test_progress_flag_calls_progress(): void
+    {
+        $logger = $this->initFakeBackendApp($this->fakeBackendConfig('fake_restore'));
+
+        $backupFile = self::$tmpPath . '/backup.json';
+        file_put_contents($backupFile, json_encode([
+            [
+                'type' => 'movie',
+                'watched' => 0,
+                'updated' => 1_700_000_000,
+                'title' => 'Fake Movie',
+                'year' => 2024,
+                'progress' => 90000,
+                'guids' => [
+                    'guid_imdb' => 'tt1234567',
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+        $queue = new QueueRequests();
+
+        $command = new RestoreCommand(
+            $queue,
+            $logger,
+            new LogSuppressor([]),
+            $this->createStub(iHttp::class),
+        );
+
+        $status = $this->makeTester($command)->execute([
+            '--assume-yes' => true,
+            '--restore-watch-progress' => true,
+            '--user' => 'main',
+            '--select-backend' => 'fake_restore',
+            'file' => $backupFile,
+        ]);
+
+        self::assertSame(RestoreCommand::SUCCESS, $status);
+        self::assertCount(1, FakeBackendClient::getCalls('export'));
+        self::assertSame([
+            [
+                'backend' => 'fake_restore',
+                'user' => 'main',
+                'count' => 1,
+                'after' => null,
+            ],
+        ], FakeBackendClient::getCalls('progress'));
     }
 
     private function makeTester(RestoreCommand $command): CommandTester

--- a/tests/Commands/State/BackupCommandTest.php
+++ b/tests/Commands/State/BackupCommandTest.php
@@ -135,6 +135,29 @@ final class BackupCommandTest extends TestCase
         ], FakeBackendClient::getCalls('backup'));
     }
 
+    public function test_empty_backup_removes_file(): void
+    {
+        $logger = $this->initFakeBackendApp($this->fakeBackendConfig('fake_backup'));
+        mkdir(self::$tmpPath . '/backup', 0o755, true);
+        FakeBackendClient::setSkipBackupWrite('main', 'fake_backup');
+
+        $command = new BackupCommand(
+            $this->createRuntimeMapper($logger),
+            $logger,
+            new LogSuppressor([]),
+            $this->createStub(iHttp::class),
+        );
+
+        $status = $this->makeTester($command)->execute([
+            '--keep' => true,
+            '--no-enhance' => true,
+            '--no-compress' => true,
+        ]);
+
+        self::assertSame(BackupCommand::SUCCESS, $status);
+        self::assertFileDoesNotExist(self::$tmpPath . '/backup/main.fake_backup.json');
+    }
+
     private function makeTester(BackupCommand $command): CommandTester
     {
         $application = new Application();

--- a/tests/Support/FakeBackendClient.php
+++ b/tests/Support/FakeBackendClient.php
@@ -46,6 +46,15 @@ class FakeBackendClient implements ClientInterface
     /** @var array<string,array<string,mixed>|Throwable> */
     private static array $metadataResponses = [];
 
+    /** @var array<string,Throwable> */
+    private static array $exportErrors = [];
+
+    /** @var array<string,bool> */
+    private static array $skipBackupWrites = [];
+
+    /** @var array<string,int> */
+    private static array $queuedExportRequests = [];
+
     public function __construct()
     {
         $this->guid = new FakeGuid();
@@ -63,6 +72,9 @@ class FakeBackendClient implements ClientInterface
             'update_state' => [],
         ];
         self::$metadataResponses = [];
+        self::$exportErrors = [];
+        self::$skipBackupWrites = [];
+        self::$queuedExportRequests = [];
     }
 
     /**
@@ -80,6 +92,21 @@ class FakeBackendClient implements ClientInterface
         array|Throwable $response,
     ): void {
         self::$metadataResponses[self::metadataKey($user, $backend, $id)] = $response;
+    }
+
+    public static function setExportError(string $user, string $backend, Throwable $error): void
+    {
+        self::$exportErrors[self::exportKey($user, $backend)] = $error;
+    }
+
+    public static function setSkipBackupWrite(string $user, string $backend, bool $skip = true): void
+    {
+        self::$skipBackupWrites[self::exportKey($user, $backend)] = $skip;
+    }
+
+    public static function setQueuedExportRequests(string $user, string $backend, int $count): void
+    {
+        self::$queuedExportRequests[self::exportKey($user, $backend)] = $count;
     }
 
     public function withContext(Context $context): ClientInterface
@@ -157,7 +184,11 @@ class FakeBackendClient implements ClientInterface
             'no_enhance' => (bool) ag($opts, 'no_enhance', false),
         ]);
 
-        if (null !== $writer && false === (bool) ag($opts, Options::DRY_RUN, false)) {
+        if (
+            null !== $writer
+            && false === (bool) ag($opts, Options::DRY_RUN, false)
+            && true !== (self::$skipBackupWrites[self::exportKey($context->userContext->name, $context->backendName)] ?? false)
+        ) {
             $payload = json_encode([
                 'backend' => $context->backendName,
                 'user' => $context->userContext->name,
@@ -178,6 +209,22 @@ class FakeBackendClient implements ClientInterface
             'user' => $context->userContext->name,
             'after' => null === $after ? null : $after->getTimestamp(),
         ]);
+
+        if (null !== ($error = self::$exportErrors[self::exportKey($context->userContext->name, $context->backendName)] ?? null)) {
+            throw $error;
+        }
+
+        $count = self::$queuedExportRequests[self::exportKey($context->userContext->name, $context->backendName)] ?? 0;
+
+        for ($i = 0; $i < $count; $i++) {
+            $queue->add(new Request(
+                method: Method::GET,
+                url: new Uri(r('https://restore-{backend}-{i}.example.invalid', [
+                    'backend' => $context->backendName,
+                    'i' => $i,
+                ])),
+            ));
+        }
 
         return [];
     }
@@ -394,6 +441,14 @@ class FakeBackendClient implements ClientInterface
             'user' => $user,
             'backend' => $backend,
             'id' => $id,
+        ]);
+    }
+
+    private static function exportKey(string $user, string $backend): string
+    {
+        return r('{user}:{backend}', [
+            'user' => $user,
+            'backend' => $backend,
         ]);
     }
 


### PR DESCRIPTION
This pull request introduces several documentation improvements, backend-specific guidance, and enhancements to the backend restore process. The most significant changes include the creation of a comprehensive backend limitations guide, updates to documentation and UI to reference this new guide, and new features and reliability improvements for the backend restore command.

**Documentation and User Guidance Updates:**

* Added a new `guides/backend-limitations.md` file that details requirements and known limitations for each supported backend (Plex, Jellyfin, Emby), including webhook behaviors and troubleshooting tips.
* Updated references in documentation and frontend UI to point to the new backend limitations guide instead of duplicating or scattering backend-specific advice:
  - Changed FAQ and webhook docs to reference the backend limitations guide. [[1]](diffhunk://#diff-c7bd425fd98aad1f9fef20099637bcbdcfadeb566ba1f83bb40ce484f195b8cfL206-R206) [[2]](diffhunk://#diff-74ff68dd347e2af185f52cce9ac42945a6df402530a437004e93362e0b133ea2L235-R236)
  - Added a "Backend limitations" entry to the help menu and a prominent link in the backend add UI. [[1]](diffhunk://#diff-260b58b8c06866b20affe8237ddcabac87425f5ddf13fdd25098d874fac9110bR48-R58) [[2]](diffhunk://#diff-f4083e2134250dde67a0557b2b10247480cf354e2cf8c9fc84a0041504771667R128-R133)
  - Removed duplicated webhook backend limitations from `webhooks.md` in favor of the new guide. [[1]](diffhunk://#diff-74ff68dd347e2af185f52cce9ac42945a6df402530a437004e93362e0b133ea2L235-R236) [[2]](diffhunk://#diff-74ff68dd347e2af185f52cce9ac42945a6df402530a437004e93362e0b133ea2L275-L278)

**Backend Restore Command Enhancements:**

* Added a `--restore-watch-progress` option to the backend restore command, enabling restoration of watch progress in addition to play state. The process now separately tracks and logs stats for play state, change state, and progress requests, and provides improved error handling and reporting. [[1]](diffhunk://#diff-1b57055445f1ad991edc5c5b5fa317fc4102a9a48b0b699cbf5aedc9b550667eR92) [[2]](diffhunk://#diff-1b57055445f1ad991edc5c5b5fa317fc4102a9a48b0b699cbf5aedc9b550667eR272) [[3]](diffhunk://#diff-1b57055445f1ad991edc5c5b5fa317fc4102a9a48b0b699cbf5aedc9b550667eR299-R332) [[4]](diffhunk://#diff-1b57055445f1ad991edc5c5b5fa317fc4102a9a48b0b699cbf5aedc9b550667eL330-R360) [[5]](diffhunk://#diff-1b57055445f1ad991edc5c5b5fa317fc4102a9a48b0b699cbf5aedc9b550667eR373-R455)
* Improved reliability by resetting the request queue at appropriate stages and adding a try/catch/finally block to ensure cleanup and error logging on failure. [[1]](diffhunk://#diff-1b57055445f1ad991edc5c5b5fa317fc4102a9a48b0b699cbf5aedc9b550667eR136-R137) [[2]](diffhunk://#diff-1b57055445f1ad991edc5c5b5fa317fc4102a9a48b0b699cbf5aedc9b550667eR373-R455)

**Other Improvements:**

* Updated the default file logger level in `config.php` from `Warning` to `Error` for less noisy logging.
* Enhanced backup command to handle empty backups more gracefully, deleting empty files and logging a warning.
* Fixed logging in `ProcessProfileEvent` listener to use the correct writer function for error and notice messages.
* Updated import restore mapper to handle progress metadata correctly when loading data.