### PR TITLE
fix: stale backend metadata after deletion. Closes #845

### DIFF
--- a/src/Libs/Prune/BackendMetadataPruner.php
+++ b/src/Libs/Prune/BackendMetadataPruner.php
@@ -1,0 +1,361 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Libs\Prune;
+
+use App\Libs\Attributes\Cli\Prune;
+use App\Libs\Database\DBLayer;
+use App\Libs\Entity\StateInterface as iState;
+use App\Libs\Mappers\ImportInterface as iImport;
+use App\Libs\UserContext;
+use PDO;
+use Psr\Log\LoggerInterface as iLogger;
+use Throwable;
+
+#[Prune(name: 'Backend Metadata', cron: '35 */12 * * *', desc: 'Remove metadata for deleted backends.')]
+final class BackendMetadataPruner
+{
+    public function __construct(
+        private readonly iLogger $logger,
+        private readonly iImport $mapper,
+    ) {}
+
+    public function __invoke(bool $execute): void
+    {
+        foreach (get_users_context($this->mapper, $this->logger) as $userContext) {
+            $this->logger->debug("Scanning deleted backend metadata for user '{user}'.", [
+                'event_name' => 'state.metadata_prune.scan_started',
+                'subsystem' => 'state',
+                'operation' => 'prune_deleted_backend_metadata',
+                'outcome' => 'started',
+                'user' => $userContext->name,
+                'execute' => $execute,
+            ]);
+
+            try {
+                $stats = $this->pruneContext($userContext, $execute);
+            } catch (Throwable $e) {
+                $this->logger->error("Failed to prune deleted backend metadata for user '{user}'.", [
+                    'event_name' => 'state.metadata_prune.failed',
+                    'subsystem' => 'state',
+                    'operation' => 'prune_deleted_backend_metadata',
+                    'outcome' => 'failed',
+                    'reason' => 'exception',
+                    'user' => $userContext->name,
+                    ...exception_log($e),
+                ]);
+                continue;
+            }
+
+            if (1 > $stats['references'] && 1 > $stats['records']) {
+                $this->logger->debug("No deleted backend metadata found for user '{user}'.", [
+                    'event_name' => 'state.metadata_prune.skipped',
+                    'subsystem' => 'state',
+                    'operation' => 'prune_deleted_backend_metadata',
+                    'outcome' => 'skipped',
+                    'reason' => 'nothing_to_prune',
+                    'user' => $userContext->name,
+                    'backends' => $stats['backends'],
+                ]);
+                continue;
+            }
+
+            $this->logger->info(
+                true === $execute
+                    ? "Pruned '{references}' deleted backend metadata references and '{records}' empty state records for user '{user}'."
+                    : "Found '{references}' deleted backend metadata references and '{records}' empty state records for user '{user}'.",
+                [
+                    'event_name' => 'state.metadata_prune.completed',
+                    'subsystem' => 'state',
+                    'operation' => 'prune_deleted_backend_metadata',
+                    'outcome' => true === $execute ? 'completed' : 'dry_run',
+                    'user' => $userContext->name,
+                    'references' => $stats['references'],
+                    'records' => $stats['records'],
+                    'backends' => $stats['backends'],
+                ],
+            );
+        }
+    }
+
+    /**
+     * @return array{backends:array<string>,references:int,records:int}
+     */
+    private function pruneContext(UserContext $userContext, bool $execute): array
+    {
+        $db = $userContext->db->getDBLayer();
+        $backends = $this->findStaleBackends($userContext);
+        $references = 0;
+
+        if ([] === $backends) {
+            $this->logger->debug("No stale backend metadata keys found for user '{user}'.", [
+                'event_name' => 'state.metadata_prune.backends_skipped',
+                'subsystem' => 'state',
+                'operation' => 'find_deleted_backend_metadata',
+                'outcome' => 'skipped',
+                'reason' => 'no_stale_backends',
+                'user' => $userContext->name,
+                'active_backends' => array_keys($userContext->config->getAll()),
+            ]);
+        } else {
+            $this->logger->debug("Found stale backend metadata keys for user '{user}'.", [
+                'event_name' => 'state.metadata_prune.backends_found',
+                'subsystem' => 'state',
+                'operation' => 'find_deleted_backend_metadata',
+                'outcome' => 'found',
+                'user' => $userContext->name,
+                'backends' => $backends,
+            ]);
+        }
+
+        foreach ($backends as $backend) {
+            $references += $this->pruneBackend($db, $backend, $execute);
+        }
+
+        $records = true === $execute
+            ? $this->deleteEmptyRecords($db)
+            : $this->countEmptyRecords($db);
+
+        return [
+            'backends' => $backends,
+            'references' => $references,
+            'records' => $records,
+        ];
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function findStaleBackends(UserContext $userContext): array
+    {
+        $active = array_fill_keys(array_keys($userContext->config->getAll()), true);
+        $db = $userContext->db->getDBLayer();
+        $stmt = $db->query(
+            'SELECT DISTINCT backend
+             FROM
+             (
+                 SELECT metadata_entries.key AS backend
+                 FROM state, json_each(
+                     CASE WHEN json_valid(state.'
+            . iState::COLUMN_META_DATA
+            . ') THEN state.'
+            . iState::COLUMN_META_DATA
+            . " ELSE '{}' END
+                 ) AS metadata_entries
+                 UNION
+                 SELECT extra_entries.key AS backend
+                 FROM state, json_each(
+                     CASE WHEN json_valid(state."
+            . iState::COLUMN_EXTRA
+            . ') THEN state.'
+            . iState::COLUMN_EXTRA
+            . " ELSE '{}' END
+                 ) AS extra_entries
+             )
+             WHERE backend IS NOT NULL
+             ORDER BY backend ASC",
+        );
+
+        $backends = [];
+        foreach ($stmt->fetchAll(PDO::FETCH_COLUMN) as $backend) {
+            $backend = (string) $backend;
+            if ('' === $backend || true === isset($active[$backend])) {
+                continue;
+            }
+
+            $backends[$backend] = $backend;
+        }
+
+        return array_values($backends);
+    }
+
+    private function pruneBackend(DBLayer $db, string $backend, bool $execute): int
+    {
+        $path = $this->jsonPath($backend);
+        $matches = $this->countBackendRows($db, $path);
+
+        $this->logger->debug("Found '{count}' state records with deleted backend metadata for '{backend}'.", [
+            'event_name' => 'state.metadata_prune.backend_checked',
+            'subsystem' => 'state',
+            'operation' => 'prune_deleted_backend_metadata',
+            'outcome' => 0 < $matches ? 'found' : 'skipped',
+            'reason' => 0 < $matches ? null : 'no_matching_records',
+            'backend' => $backend,
+            'count' => $matches,
+            'execute' => $execute,
+        ]);
+
+        if (true !== $execute || 1 > $matches) {
+            return $matches;
+        }
+
+        $stmt = $db->query(
+            'UPDATE state
+             SET
+                 '
+            . iState::COLUMN_META_DATA
+            . ' = CASE
+                     WHEN json_valid('
+            . iState::COLUMN_META_DATA
+            . ') THEN json_remove('
+            . iState::COLUMN_META_DATA
+            . ', :metadata_path)
+                     ELSE '
+            . iState::COLUMN_META_DATA
+            . '
+                 END,
+                 '
+            . iState::COLUMN_EXTRA
+            . ' = CASE
+                     WHEN json_valid('
+            . iState::COLUMN_EXTRA
+            . ') THEN json_remove('
+            . iState::COLUMN_EXTRA
+            . ', :extra_path)
+                     ELSE '
+            . iState::COLUMN_EXTRA
+            . '
+                 END
+             WHERE
+                 json_type(
+                     CASE WHEN json_valid('
+            . iState::COLUMN_META_DATA
+            . ') THEN '
+            . iState::COLUMN_META_DATA
+            . " ELSE '{}' END,
+                     :metadata_where_path
+                 ) IS NOT NULL
+             OR
+                 json_type(
+                     CASE WHEN json_valid("
+            . iState::COLUMN_EXTRA
+            . ') THEN '
+            . iState::COLUMN_EXTRA
+            . " ELSE '{}' END,
+                     :extra_where_path
+                 ) IS NOT NULL",
+            [
+                'metadata_path' => $path,
+                'extra_path' => $path,
+                'metadata_where_path' => $path,
+                'extra_where_path' => $path,
+            ],
+        );
+
+        $removed = $stmt->rowCount();
+
+        $this->logger->debug("Removed deleted backend metadata for '{backend}' from '{count}' state records.", [
+            'event_name' => 'state.metadata_prune.backend_completed',
+            'subsystem' => 'state',
+            'operation' => 'prune_deleted_backend_metadata',
+            'outcome' => 'completed',
+            'backend' => $backend,
+            'count' => $removed,
+        ]);
+
+        return $removed;
+    }
+
+    private function countBackendRows(DBLayer $db, string $path): int
+    {
+        $stmt = $db->query(
+            'SELECT COUNT(*)
+             FROM state
+             WHERE
+                 json_type(
+                     CASE WHEN json_valid('
+            . iState::COLUMN_META_DATA
+            . ') THEN '
+            . iState::COLUMN_META_DATA
+            . " ELSE '{}' END,
+                     :metadata_path
+                 ) IS NOT NULL
+             OR
+                 json_type(
+                     CASE WHEN json_valid("
+            . iState::COLUMN_EXTRA
+            . ') THEN '
+            . iState::COLUMN_EXTRA
+            . " ELSE '{}' END,
+                     :extra_path
+                 ) IS NOT NULL",
+            [
+                'metadata_path' => $path,
+                'extra_path' => $path,
+            ],
+        );
+
+        $count = $stmt->fetchColumn();
+
+        return false === $count ? 0 : (int) $count;
+    }
+
+    private function deleteEmptyRecords(DBLayer $db): int
+    {
+        $stmt = $db->query(
+            'DELETE FROM state
+             WHERE
+                 '
+            . iState::COLUMN_META_DATA
+            . ' IS NULL
+             OR
+                 (
+                     json_valid('
+            . iState::COLUMN_META_DATA
+            . ')
+                 AND
+                     NOT EXISTS (
+                         SELECT 1
+                         FROM json_each(
+                             CASE WHEN json_valid(state.'
+            . iState::COLUMN_META_DATA
+            . ') THEN state.'
+            . iState::COLUMN_META_DATA
+            . " ELSE '{}' END
+                         )
+                     )
+                 )",
+        );
+
+        return $stmt->rowCount();
+    }
+
+    private function countEmptyRecords(DBLayer $db): int
+    {
+        $stmt = $db->query(
+            'SELECT COUNT(*)
+             FROM state
+             WHERE
+                 '
+            . iState::COLUMN_META_DATA
+            . ' IS NULL
+             OR
+                 (
+                     json_valid('
+            . iState::COLUMN_META_DATA
+            . ')
+                 AND
+                     NOT EXISTS (
+                         SELECT 1
+                         FROM json_each(
+                             CASE WHEN json_valid(state.'
+            . iState::COLUMN_META_DATA
+            . ') THEN state.'
+            . iState::COLUMN_META_DATA
+            . " ELSE '{}' END
+                         )
+                     )
+                 )",
+        );
+
+        $count = $stmt->fetchColumn();
+
+        return false === $count ? 0 : (int) $count;
+    }
+
+    private function jsonPath(string $backend): string
+    {
+        return '$.' . json_encode($backend, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+    }
+}

--- a/tests/Commands/Prune/BackendMetadataPrunerTest.php
+++ b/tests/Commands/Prune/BackendMetadataPrunerTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands\Prune;
+
+use App\Libs\Config;
+use App\Libs\ConfigFile;
+use App\Libs\Container;
+use App\Libs\Database\DatabaseInterface as iDB;
+use App\Libs\Database\PackageMigrationFactory;
+use App\Libs\Entity\StateInterface as iState;
+use App\Libs\Mappers\ImportInterface as iImport;
+use App\Libs\Prune\BackendMetadataPruner;
+use App\Libs\TestCase;
+use Monolog\Logger;
+use PDO;
+
+final class BackendMetadataPrunerTest extends TestCase
+{
+    private iDB $db;
+    private iImport $mapper;
+    private Logger $logger;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->initTempApp();
+        $this->logger = new Logger('test');
+        $this->writeBackends([
+            'kept' => [
+                'type' => 'plex',
+                'url' => 'http://localhost:32400',
+                'token' => 'token',
+            ],
+        ]);
+
+        $this->db = Container::get(iDB::class);
+        $pdo = $this->db->getDBLayer()->getBackend();
+        $migrations = new PackageMigrationFactory();
+        if (false === $migrations->isMigrated($pdo)) {
+            $migrations->migrate($pdo, dryRun: false);
+        }
+
+        $this->mapper = $this->createStub(iImport::class);
+        $this->mapper->method('withUserContext')->willReturnSelf();
+    }
+
+    public function test_exec(): void
+    {
+        $keptMixed = $this->insertState(
+            'kept',
+            [
+                'deleted' => [
+                    'via' => 'other',
+                ],
+                'kept' => [
+                    iState::COLUMN_ID => '1',
+                ],
+            ],
+            [
+                'deleted' => [
+                    iState::COLUMN_EXTRA_DATE => 20,
+                ],
+                'kept' => [
+                    iState::COLUMN_EXTRA_DATE => 10,
+                ],
+            ],
+        );
+        $this->insertState(
+            'deleted',
+            [
+                'deleted' => [
+                    iState::COLUMN_ID => '2',
+                ],
+            ],
+            [
+                'deleted' => [
+                    iState::COLUMN_EXTRA_DATE => 30,
+                ],
+            ],
+        );
+        $keptOnly = $this->insertState('kept', [
+            'kept' => [
+                iState::COLUMN_ID => '3',
+            ],
+        ]);
+
+        new BackendMetadataPruner($this->logger, $this->mapper)->__invoke(true);
+
+        $rows = $this->fetchRows();
+
+        self::assertSame([$keptMixed, $keptOnly], array_column($rows, 'id'));
+        self::assertSame(['kept'], array_keys($rows[0][iState::COLUMN_META_DATA]));
+        self::assertSame(['kept'], array_keys($rows[0][iState::COLUMN_EXTRA]));
+        self::assertSame(['kept'], array_keys($rows[1][iState::COLUMN_META_DATA]));
+    }
+
+    public function test_dry(): void
+    {
+        $this->insertState('kept', [
+            'deleted' => [
+                'via' => 'other',
+            ],
+            'kept' => [
+                iState::COLUMN_ID => '1',
+            ],
+        ]);
+
+        new BackendMetadataPruner($this->logger, $this->mapper)->__invoke(false);
+
+        $rows = $this->fetchRows();
+
+        self::assertSame(['deleted', 'kept'], array_keys($rows[0][iState::COLUMN_META_DATA]));
+    }
+
+    public function test_discover(): void
+    {
+        Config::save('prune.paths', [ROOT_PATH . '/src/Libs/Prune']);
+        Config::save('prune.cache.time', 0);
+
+        $pruners = discover_pruners();
+
+        self::assertArrayHasKey('backend_metadata', $pruners);
+        self::assertSame('Remove metadata for deleted backends.', $pruners['backend_metadata']['desc']);
+    }
+
+    private function insertState(string $via, array $metadata, array $extra = []): int
+    {
+        $this->db->getDBLayer()->query(
+            'INSERT INTO state
+                (type, updated, watched, via, title, year, season, episode, parent, guids, metadata, extra, created_at, updated_at)
+             VALUES
+                (:type, :updated, :watched, :via, :title, :year, :season, :episode, :parent, :guids, :metadata, :extra, :created_at, :updated_at)',
+            [
+                'type' => iState::TYPE_MOVIE,
+                'updated' => 1,
+                'watched' => 0,
+                'via' => $via,
+                'title' => 'Movie',
+                'year' => 2024,
+                'season' => null,
+                'episode' => null,
+                'parent' => null,
+                'guids' => '{}',
+                'metadata' => json_encode($metadata, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES),
+                'extra' => json_encode($extra, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES),
+                'created_at' => 1,
+                'updated_at' => 1,
+            ],
+        );
+
+        return (int) $this->db->getDBLayer()->lastInsertId();
+    }
+
+    /**
+     * @return Array<array{id:int,via:string,metadata:array,extra:array}>
+     */
+    private function fetchRows(): array
+    {
+        $rows = $this->db
+            ->getDBLayer()
+            ->query('SELECT id, via, metadata, extra FROM state ORDER BY id ASC')
+            ->fetchAll(PDO::FETCH_ASSOC);
+
+        foreach ($rows as &$row) {
+            $row['id'] = (int) $row['id'];
+            $row[iState::COLUMN_META_DATA] = json_decode(
+                (string) $row[iState::COLUMN_META_DATA],
+                true,
+                512,
+                JSON_THROW_ON_ERROR,
+            );
+            $row[iState::COLUMN_EXTRA] = json_decode(
+                (string) $row[iState::COLUMN_EXTRA],
+                true,
+                512,
+                JSON_THROW_ON_ERROR,
+            );
+        }
+
+        return $rows;
+    }
+
+    private function writeBackends(array $backends): void
+    {
+        ConfigFile::open((string) Config::get('backends_file'), 'yaml', autoCreate: true, autoBackup: false)
+            ->replaceAll($backends)
+            ->persist(true);
+    }
+}


### PR DESCRIPTION
**New Backend Metadata Pruner:**

* Added `BackendMetadataPruner`  to identify and remove metadata for backends that have been deleted.
* The pruner also deletes empty state records after metadata removal, ensuring no orphaned data remains.
