### PR TITLE
Feat: add proper queue system.

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -21,7 +21,7 @@ use Monolog\Level;
 return (function () {
     $inContainer = in_container();
     $progressTimeCheck = fn(int $v, int $d): int => 0 === $v || $v >= 180 ? $v : $d;
-    $progressToMS = fn(int $v): int => $v < 60 ? $v * 1000 : 60000;
+    $progressToMS = fn(int $v): int => $v < 60 ? $v * 1_000 : 60_000;
     $tokenExpiry = max(1, (int) env('WS_AUTH_TOKEN_EXPIRY', 2 * 24 * 60 * 60));
     $defaultRefreshWindow = max(60, min(24 * 60 * 60, max(60, intdiv($tokenExpiry, 4))));
     $logsPruneAfter = (string) env('WS_LOGS_PRUNE_AFTER', '-7 DAYS');
@@ -298,7 +298,7 @@ return (function () {
             'opcache.enable' => 1,
             'opcache.memory_consumption' => 128,
             'opcache.interned_strings_buffer' => 16,
-            'opcache.max_accelerated_files' => 10000,
+            'opcache.max_accelerated_files' => 10_000,
             'opcache.max_wasted_percentage' => 5,
             'opcache.validate_timestamps' => $inContainer ? 0 : 1,
             'expose_php' => 0,
@@ -416,6 +416,19 @@ return (function () {
 
     $config['events'] = [
         'logfile' => ag($config, 'tmpDir') . '/logs/events.' . $logDateFormat . '.log',
+        'queue' => [
+            'driver' => env('WS_EVENTS_QUEUE_DRIVER', 'auto'),
+            'path' => env('WS_EVENTS_QUEUE_PATH', fn() => ag($config, 'tmpDir') . '/queue/events'),
+            'file' => [
+                'claim_after_seconds' => (int) env('WS_EVENTS_QUEUE_FILE_CLAIM_AFTER_SECONDS', 300),
+            ],
+            'redis' => [
+                'stream' => env('WS_EVENTS_QUEUE_REDIS_STREAM', 'watchstate:events'),
+                'group' => env('WS_EVENTS_QUEUE_REDIS_GROUP', 'watchstate'),
+                'consumer' => env('WS_EVENTS_QUEUE_REDIS_CONSUMER', 'ws-worker'),
+                'claim_after_ms' => (int) env('WS_EVENTS_QUEUE_REDIS_CLAIM_AFTER_MS', 300_000),
+            ],
+        ],
         'listeners' => [
             'cache' => new DateInterval(env('WS_EVENTS_LISTENERS_CACHE', 'PT1M')),
             'file' => env('APP_EVENTS_FILE', function () use ($config): ?string {

--- a/config/directories.php
+++ b/config/directories.php
@@ -9,6 +9,7 @@ return [
     '{path}/users',
     '{tmp_dir}/logs',
     '{tmp_dir}/cache',
+    '{tmp_dir}/queue/events',
     '{tmp_dir}/profiler',
     '{tmp_dir}/webhooks',
     '{tmp_dir}/debug',

--- a/config/env.spec.php
+++ b/config/env.spec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Last update: 2025-07-13
  *
@@ -194,6 +196,48 @@ return (function () {
             'config' => 'cache.path',
             'description' => 'Where to store cache data. This is usually used if the cache server is not available and/or experiencing issues.',
             'type' => 'string',
+        ],
+        [
+            'key' => 'WS_EVENTS_QUEUE_DRIVER',
+            'config' => 'events.queue.driver',
+            'description' => 'The event queue transport driver. Supported values are auto, redis, file.',
+            'type' => 'string',
+        ],
+        [
+            'key' => 'WS_EVENTS_QUEUE_PATH',
+            'config' => 'events.queue.path',
+            'description' => 'Where to store filesystem event queue payloads.',
+            'type' => 'string',
+        ],
+        [
+            'key' => 'WS_EVENTS_QUEUE_REDIS_STREAM',
+            'config' => 'events.queue.redis.stream',
+            'description' => 'Redis stream key used for queued events.',
+            'type' => 'string',
+        ],
+        [
+            'key' => 'WS_EVENTS_QUEUE_FILE_CLAIM_AFTER_SECONDS',
+            'config' => 'events.queue.file.claim_after_seconds',
+            'description' => 'How old a claimed filesystem queued event must be before another dispatcher can reclaim it.',
+            'type' => 'int',
+        ],
+        [
+            'key' => 'WS_EVENTS_QUEUE_REDIS_GROUP',
+            'config' => 'events.queue.redis.group',
+            'description' => 'Redis consumer group used for queued events.',
+            'type' => 'string',
+        ],
+        [
+            'key' => 'WS_EVENTS_QUEUE_REDIS_CONSUMER',
+            'config' => 'events.queue.redis.consumer',
+            'description' => 'Redis consumer name used by this WatchState instance.',
+            'type' => 'string',
+        ],
+        [
+            'key' => 'WS_EVENTS_QUEUE_REDIS_CLAIM_AFTER_MS',
+            'config' => 'events.queue.redis.claim_after_ms',
+            'description' => 'How old a pending Redis stream event must be before another dispatcher can reclaim it.',
+            'type' => 'int',
         ],
         [
             'key' => 'WS_LOGGER_SYSLOG_FACILITY',

--- a/config/services.php
+++ b/config/services.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Libs\Config;
 use App\Libs\ConfigFile;
+use App\Libs\Container;
 use App\Libs\Database\DatabaseInterface as iDB;
 use App\Libs\Database\DBLayer;
 use App\Libs\Database\PDO\PDOAdapter;
@@ -11,6 +12,11 @@ use App\Libs\Database\PdoFactory;
 use App\Libs\Entity\StateEntity;
 use App\Libs\Entity\StateInterface;
 use App\Libs\Events\EventQueue;
+use App\Libs\Events\Queue\ArrayEventTransport;
+use App\Libs\Events\Queue\EventTransportInterface;
+use App\Libs\Events\Queue\FilesystemEventTransport;
+use App\Libs\Events\Queue\NullEventTransport;
+use App\Libs\Events\Queue\RedisStreamEventTransport;
 use App\Libs\Exceptions\RuntimeException;
 use App\Libs\Extends\ConsoleOutput;
 use App\Libs\Extends\HttpClient;
@@ -105,10 +111,50 @@ return (function (): array {
             'class' => fn() => new QueueRequests(),
         ],
 
+        EventTransportInterface::class => [
+            'class' => function (): EventTransportInterface {
+                $driver = strtolower((string) Config::get('events.queue.driver', 'auto'));
+
+                if ('null' === $driver) {
+                    return new NullEventTransport();
+                }
+
+                if ('array' === $driver || true === (defined('IN_TEST_MODE') && true === IN_TEST_MODE) && 'auto' === $driver) {
+                    return new ArrayEventTransport();
+                }
+
+                if ('file' === $driver) {
+                    return new FilesystemEventTransport(
+                        path: (string) Config::get('events.queue.path'),
+                        claimAfterSeconds: (int) Config::get('events.queue.file.claim_after_seconds', 300),
+                    );
+                }
+
+                try {
+                    return new RedisStreamEventTransport(
+                        redis: Container::get(Redis::class),
+                        stream: (string) Config::get('events.queue.redis.stream'),
+                        group: (string) Config::get('events.queue.redis.group'),
+                        consumer: (string) Config::get('events.queue.redis.consumer'),
+                        claimAfterMs: (int) Config::get('events.queue.redis.claim_after_ms', 300_000),
+                    );
+                } catch (Throwable $e) {
+                    if ('redis' === $driver) {
+                        throw $e;
+                    }
+
+                    return new FilesystemEventTransport(
+                        path: (string) Config::get('events.queue.path'),
+                        claimAfterSeconds: (int) Config::get('events.queue.file.claim_after_seconds', 300),
+                    );
+                }
+            },
+        ],
+
         EventQueue::class => [
-            'class' => fn(iCache $cache, EventsRepository $repo): EventQueue => new EventQueue($cache, $repo),
+            'class' => fn(EventTransportInterface $transport, EventsRepository $repo): EventQueue => new EventQueue($transport, $repo),
             'args' => [
-                iCache::class,
+                EventTransportInterface::class,
                 EventsRepository::class,
             ],
         ],

--- a/container/files/redis.conf
+++ b/container/files/redis.conf
@@ -11,14 +11,15 @@ loglevel nothing
 # Persistence
 dbfilename redis.rdb
 dir /config/cache/
-appendonly no
+appendonly yes
 appendfilename appendonly.aof
+appendfsync everysec
 save 900 1
 save 300 10
 save 60 10000
 
 # Arbitrary Parameters
-maxmemory-policy allkeys-lru
+maxmemory-policy noeviction
 slowlog-log-slower-than 10000
 slowlog-max-len 128
 notify-keyspace-events ""

--- a/src/API/System/Command.php
+++ b/src/API/System/Command.php
@@ -8,6 +8,7 @@ use App\Libs\Attributes\Route\Delete;
 use App\Libs\Attributes\Route\Get;
 use App\Libs\Attributes\Route\Post;
 use App\Libs\Config;
+use App\Libs\Container;
 use App\Libs\DataUtil;
 use App\Libs\Enums\Http\Status;
 use App\Libs\Extends\Date;
@@ -18,6 +19,7 @@ use DateInterval;
 use DirectoryIterator;
 use Psr\Http\Message\ResponseInterface as iResponse;
 use Psr\Http\Message\ServerRequestInterface as iRequest;
+use Psr\SimpleCache\CacheInterface as iCache;
 use Random\RandomException;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
@@ -26,6 +28,8 @@ use Throwable;
 final class Command
 {
     public const string URL = '%{api.prefix}/system/command';
+
+    public const string CACHE_NAME = 'system.command.running';
 
     private const int TIMES_BEFORE_PING = 6;
     private const int PING_INTERVAL = 200_000;
@@ -232,6 +236,9 @@ final class Command
             timeout: ag($params, 'timeout', 7200),
         );
 
+        $cache = Container::get(iCache::class);
+        $cache->set(self::CACHE_NAME, true, new DateInterval('PT6H'));
+
         try {
             if (true === $pty) {
                 $process->setPty(true);
@@ -287,6 +294,8 @@ final class Command
             $this->failSession($sessionPath, $e->getMessage(), 124, $clientConnected && $isActiveConnection());
         } catch (Throwable $e) {
             $this->failSession($sessionPath, $e->getMessage(), 1, $clientConnected && $isActiveConnection());
+        } finally {
+            $cache->delete(self::CACHE_NAME);
         }
     }
 

--- a/src/API/System/Command.php
+++ b/src/API/System/Command.php
@@ -8,7 +8,6 @@ use App\Libs\Attributes\Route\Delete;
 use App\Libs\Attributes\Route\Get;
 use App\Libs\Attributes\Route\Post;
 use App\Libs\Config;
-use App\Libs\Container;
 use App\Libs\DataUtil;
 use App\Libs\Enums\Http\Status;
 use App\Libs\Extends\Date;
@@ -19,7 +18,6 @@ use DateInterval;
 use DirectoryIterator;
 use Psr\Http\Message\ResponseInterface as iResponse;
 use Psr\Http\Message\ServerRequestInterface as iRequest;
-use Psr\SimpleCache\CacheInterface as iCache;
 use Random\RandomException;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
@@ -28,8 +26,6 @@ use Throwable;
 final class Command
 {
     public const string URL = '%{api.prefix}/system/command';
-
-    public const string CACHE_NAME = 'system.command.running';
 
     private const int TIMES_BEFORE_PING = 6;
     private const int PING_INTERVAL = 200_000;
@@ -236,9 +232,6 @@ final class Command
             timeout: ag($params, 'timeout', 7200),
         );
 
-        $cache = Container::get(iCache::class);
-        $cache->set(self::CACHE_NAME, true, new DateInterval('PT6H'));
-
         try {
             if (true === $pty) {
                 $process->setPty(true);
@@ -294,8 +287,6 @@ final class Command
             $this->failSession($sessionPath, $e->getMessage(), 124, $clientConnected && $isActiveConnection());
         } catch (Throwable $e) {
             $this->failSession($sessionPath, $e->getMessage(), 1, $clientConnected && $isActiveConnection());
-        } finally {
-            $cache->delete(self::CACHE_NAME);
         }
     }
 

--- a/src/API/WebHook.php
+++ b/src/API/WebHook.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\API;
 
-use App\API\System\Command as SystemCommand;
-use App\Commands\System\TasksCommand;
 use App\Libs\Attributes\Route\Route;
 use App\Libs\Config;
 use App\Libs\Enums\Http\Status;
@@ -13,18 +11,15 @@ use App\Libs\Middlewares\AuthorizationMiddleware;
 use App\Libs\Options;
 use App\Libs\Uri;
 use App\Listeners\ProcessWebhookEvent;
-use DateInterval;
 use Psr\Http\Message\ResponseInterface as iResponse;
 use Psr\Http\Message\ServerRequestInterface as iRequest;
-use Psr\SimpleCache\CacheInterface as iCache;
 
 final class WebHook
 {
     public const string URL = '%{api.prefix}/webhook';
 
-    public function __construct(
-        private readonly iCache $cache,
-    ) {
+    public function __construct()
+    {
         set_time_limit(0);
     }
 
@@ -53,15 +48,8 @@ final class WebHook
 
         $opts = [
             Options::FAIL_FAST_ON_LOCK => true,
+            Options::QUEUE_ONLY => true,
         ];
-
-        $isTaskRunning = true === (bool) $this->cache->get(TasksCommand::CACHE_NAME, false);
-        $isCommandRunning = true === (bool) $this->cache->get(SystemCommand::CACHE_NAME, false);
-
-        if ($isTaskRunning || $isCommandRunning) {
-            $opts[Options::CACHE_ONLY] = true;
-            $opts[Options::CACHE_TTL] = new DateInterval('PT6H');
-        }
 
         $post = $request->getParsedBody();
         $data = [

--- a/src/API/WebHook.php
+++ b/src/API/WebHook.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\API;
 
+use App\API\System\Command as SystemCommand;
 use App\Commands\System\TasksCommand;
 use App\Libs\Attributes\Route\Route;
 use App\Libs\Config;
@@ -23,7 +24,9 @@ final class WebHook
 
     public function __construct(
         private readonly iCache $cache,
-    ) {}
+    ) {
+        set_time_limit(0);
+    }
 
     /**
      * Receive a webhook request from a backend.
@@ -48,9 +51,14 @@ final class WebHook
             array_flip([AuthorizationMiddleware::KEY_NAME, AuthorizationMiddleware::TOKEN_NAME]),
         );
 
-        $opts = [];
+        $opts = [
+            Options::FAIL_FAST_ON_LOCK => true,
+        ];
 
-        if (true === (bool) $this->cache->get(TasksCommand::CACHE_NAME, false)) {
+        $isTaskRunning = true === (bool) $this->cache->get(TasksCommand::CACHE_NAME, false);
+        $isCommandRunning = true === (bool) $this->cache->get(SystemCommand::CACHE_NAME, false);
+
+        if ($isTaskRunning || $isCommandRunning) {
             $opts[Options::CACHE_ONLY] = true;
             $opts[Options::CACHE_TTL] = new DateInterval('PT6H');
         }

--- a/src/Commands/Events/DispatchCommand.php
+++ b/src/Commands/Events/DispatchCommand.php
@@ -8,6 +8,9 @@ use App\Command;
 use App\Libs\Attributes\Route\Cli;
 use App\Libs\Config;
 use App\Libs\Events\DataEvent;
+use App\Libs\Events\EventQueue;
+use App\Libs\Events\Queue\EventEnvelope;
+use App\Libs\Events\Queue\EventTransportInterface as iEventTransport;
 use App\Libs\Extends\ProxyHandler;
 use App\Libs\Options;
 use App\Model\Events\Event;
@@ -49,6 +52,8 @@ final class DispatchCommand extends Command
     public function __construct(
         private readonly iDispatcher $dispatcher,
         private readonly EventsRepository $repo,
+        private readonly EventQueue $queue,
+        private readonly iEventTransport $transport,
         private readonly iCache $cache,
         private iLogger $logger,
     ) {
@@ -67,6 +72,7 @@ final class DispatchCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $this->drainTransport((int) $input->getOption('limit'));
         $this->unloadEvents();
 
         register_events();
@@ -90,6 +96,53 @@ final class DispatchCommand extends Command
         }
 
         return $this->runEvents(visibleLevel: $visibleLevel, limit: (int) $input->getOption('limit'), debug: $debug);
+    }
+
+    private function drainTransport(int $limit): void
+    {
+        foreach ($this->transport->dequeue($limit) as $envelope) {
+            try {
+                $item = $this->queue->materialize($envelope);
+                $this->transport->ack($envelope);
+                $this->logger->info("Materialized queued event '{event}'.", [
+                    'event_name' => 'event.queue.materialized',
+                    'subsystem' => 'events',
+                    'operation' => 'queue.materialize',
+                    'outcome' => 'success',
+                    'event' => $envelope->event,
+                    'queue_id' => $envelope->id,
+                    'item_id' => $item->id,
+                ]);
+            } catch (Throwable $e) {
+                $this->handleDrainFailure($envelope, $e);
+            }
+        }
+    }
+
+    private function handleDrainFailure(EventEnvelope $envelope, Throwable $e): void
+    {
+        $isLock = false !== stripos($e->getMessage(), 'database is locked');
+
+        if (true === $isLock) {
+            $this->transport->release($envelope);
+            $outcome = 'retry';
+            $reason = 'database_locked';
+        } else {
+            $this->transport->fail($envelope);
+            $outcome = 'failed';
+            $reason = 'materialize_failed';
+        }
+
+        $this->logger->error("Failed to materialize queued event '{event}'.", [
+            'event_name' => 'event.queue.materialize_failed',
+            'subsystem' => 'events',
+            'operation' => 'queue.materialize',
+            'outcome' => $outcome,
+            'reason' => $reason,
+            'event' => $envelope->event,
+            'queue_id' => $envelope->id,
+            ...exception_log($e),
+        ]);
     }
 
     protected function runEvents(Level $visibleLevel, int $limit, bool $debug = false): int

--- a/src/Libs/Events/EventQueue.php
+++ b/src/Libs/Events/EventQueue.php
@@ -4,19 +4,20 @@ declare(strict_types=1);
 
 namespace App\Libs\Events;
 
+use App\Libs\Events\Queue\EventEnvelope;
+use App\Libs\Events\Queue\EventTransportInterface as iEventTransport;
 use App\Libs\Options;
 use App\Model\Events\Event as EventInfo;
 use App\Model\Events\EventsRepository;
 use App\Model\Events\EventsTable;
 use App\Model\Events\EventStatus;
-use DateInterval;
+use DateTimeInterface;
 use PDOException;
-use Psr\SimpleCache\CacheInterface as iCache;
 
 final class EventQueue
 {
     public function __construct(
-        private readonly iCache $cache,
+        private readonly iEventTransport $transport,
         private readonly EventsRepository $repo,
     ) {}
 
@@ -28,14 +29,26 @@ final class EventQueue
      * @param array $opts Options.
      *
      * @return EventInfo
-     * @throws \Psr\SimpleCache\InvalidArgumentException May throw this exception if saving to db fails and fallback also fail.
      */
     public function queue(string $event, array $data = [], array $opts = []): EventInfo
     {
-        if (true === (bool) ag($opts, Options::CACHE_ONLY, false)) {
-            return $this->cacheItem($event, $data, $opts);
+        if (true === (bool) ag($opts, Options::QUEUE_ONLY, false) || true === (bool) ag($opts, Options::CACHE_ONLY, false)) {
+            return $this->transportItem($event, $data, $opts);
         }
 
+        return $this->persist($event, $data, $opts);
+    }
+
+    /**
+     * Materialize a transported event envelope into the database event journal.
+     */
+    public function materialize(EventEnvelope $envelope): EventInfo
+    {
+        return $this->persist($envelope->event, $envelope->data, $envelope->opts);
+    }
+
+    private function persist(string $event, array $data, array $opts = []): EventInfo
+    {
         $repo = ag($opts, EventsRepository::class, $this->repo);
         if (!$repo instanceof EventsRepository) {
             $repo = $this->repo;
@@ -66,7 +79,7 @@ final class EventQueue
             $item->id = $id;
         } catch (PDOException $e) {
             if (false === ag_exists($opts, 'cached') && false !== stripos($e->getMessage(), 'database is locked')) {
-                return $this->cacheItem($event, $data, $opts);
+                return $this->transportItem($event, $data, $opts);
             }
             throw $e;
         }
@@ -109,40 +122,19 @@ final class EventQueue
         return $item;
     }
 
-    private function cacheItem(string $event, array $data, array $opts): EventInfo
+    private function transportItem(string $event, array $data, array $opts): EventInfo
     {
         $item = $this->createEntity(new EventInfo(['id' => generate_uuid()]), $event, $data, $opts);
 
-        $events = $this->cache->get('events', []);
-        $reference = ag($opts, EventsTable::COLUMN_REFERENCE);
-        $isUnique = true === (bool) ag($opts, 'unique', false);
-        $ttl = ag($opts, Options::CACHE_TTL, new DateInterval('PT1H'));
+        unset($opts[EventsRepository::class], $opts[Options::CACHE_ONLY], $opts[Options::CACHE_TTL], $opts[Options::QUEUE_ONLY]);
+        $createdAt = $item->created_at instanceof DateTimeInterface
+            ? $item->created_at->format(DateTimeInterface::ATOM)
+            : (string) $item->created_at;
 
-        unset($opts[EventsRepository::class], $opts[Options::CACHE_ONLY], $opts[Options::CACHE_TTL]);
-        $opts[EventsTable::COLUMN_CREATED_AT] = $item->created_at;
+        $opts[EventsTable::COLUMN_CREATED_AT] = $createdAt;
         $opts['cached'] = true;
 
-        $cachedEvent = [
-            'event' => $event,
-            'data' => $data,
-            'opts' => $opts,
-        ];
-
-        if (true === $isUnique && null !== $reference) {
-            foreach ($events as $index => $queued) {
-                if ($reference !== ag($queued, 'opts.' . EventsTable::COLUMN_REFERENCE)) {
-                    continue;
-                }
-
-                $events[$index] = $cachedEvent;
-                $this->cache->set('events', $events, $ttl);
-
-                return $item;
-            }
-        }
-
-        $events[] = $cachedEvent;
-        $this->cache->set('events', $events, $ttl);
+        $this->transport->enqueue(EventEnvelope::create($event, $data, $opts));
 
         return $item;
     }

--- a/src/Libs/Events/Queue/ArrayEventTransport.php
+++ b/src/Libs/Events/Queue/ArrayEventTransport.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Libs\Events\Queue;
+
+final class ArrayEventTransport implements EventTransportInterface
+{
+    /** @var array<EventEnvelope> */
+    private array $items = [];
+
+    /**
+     * @inheritdoc
+     */
+    public function enqueue(EventEnvelope $envelope): EventEnvelope
+    {
+        $this->items[] = $envelope;
+
+        return $envelope;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function dequeue(int $limit): array
+    {
+        $limit = max(1, $limit);
+        $claimed = [];
+
+        foreach ($this->items as $i => $envelope) {
+            if (count($claimed) >= $limit) {
+                break;
+            }
+
+            unset($this->items[$i]);
+            $claimed[] = $envelope;
+        }
+
+        $this->items = array_values($this->items);
+
+        return $claimed;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function ack(EventEnvelope $envelope): void {}
+
+    /**
+     * @inheritdoc
+     */
+    public function release(EventEnvelope $envelope): void
+    {
+        $this->items[] = $envelope;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function fail(EventEnvelope $envelope): void {}
+
+    /**
+     * @inheritdoc
+     */
+    public function count(): int
+    {
+        return count($this->items);
+    }
+}

--- a/src/Libs/Events/Queue/EventEnvelope.php
+++ b/src/Libs/Events/Queue/EventEnvelope.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Libs\Events\Queue;
+
+use DateTimeInterface;
+use InvalidArgumentException;
+
+final class EventEnvelope
+{
+    /**
+     * @param array<string, mixed> $data Event payload.
+     * @param array<string, mixed> $opts Event queue options.
+     */
+    public function __construct(
+        public readonly string $id,
+        public readonly string $event,
+        public readonly array $data,
+        public readonly array $opts,
+        public readonly string $createdAt,
+        public readonly mixed $ack = null,
+    ) {}
+
+    /**
+     * Create an event envelope for transport enqueueing.
+     *
+     * @param array<string, mixed> $data Event payload.
+     * @param array<string, mixed> $opts Event queue options.
+     */
+    public static function create(string $event, array $data = [], array $opts = []): self
+    {
+        return new self(
+            id: generate_uuid(),
+            event: $event,
+            data: $data,
+            opts: $opts,
+            createdAt: (string) make_date(),
+        );
+    }
+
+    /**
+     * Recreate an event envelope from transport payload data.
+     *
+     * @param array<string, mixed> $payload Transport payload.
+     */
+    public static function fromArray(array $payload, mixed $ack = null): self
+    {
+        $id = (string) ($payload['id'] ?? '');
+        $event = (string) ($payload['event'] ?? '');
+
+        if ('' === trim($id)) {
+            throw new InvalidArgumentException('Queue envelope id is missing.');
+        }
+
+        if ('' === trim($event)) {
+            throw new InvalidArgumentException('Queue envelope event name is missing.');
+        }
+
+        $data = $payload['data'] ?? [];
+        $opts = $payload['opts'] ?? [];
+
+        return new self(
+            id: $id,
+            event: $event,
+            data: is_array($data) ? $data : [],
+            opts: is_array($opts) ? $opts : [],
+            createdAt: (string) ($payload['created_at'] ?? make_date()->format(DateTimeInterface::ATOM)),
+            ack: $ack,
+        );
+    }
+
+    /**
+     * Return this envelope with transport acknowledgement metadata.
+     */
+    public function withAck(mixed $ack): self
+    {
+        return new self(
+            id: $this->id,
+            event: $this->event,
+            data: $this->data,
+            opts: $this->opts,
+            createdAt: $this->createdAt,
+            ack: $ack,
+        );
+    }
+
+    /**
+     * Convert envelope to transport payload data.
+     *
+     * @return array{id:string,event:string,data:array<string,mixed>,opts:array<string,mixed>,created_at:string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'event' => $this->event,
+            'data' => $this->data,
+            'opts' => $this->opts,
+            'created_at' => $this->createdAt,
+        ];
+    }
+}

--- a/src/Libs/Events/Queue/EventTransportInterface.php
+++ b/src/Libs/Events/Queue/EventTransportInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Libs\Events\Queue;
+
+interface EventTransportInterface
+{
+    /**
+     * Push a new event envelope into the transport.
+     */
+    public function enqueue(EventEnvelope $envelope): EventEnvelope;
+
+    /**
+     * Claim up to the requested number of queued event envelopes.
+     *
+     * @return array<EventEnvelope>
+     */
+    public function dequeue(int $limit): array;
+
+    /**
+     * Acknowledge successful processing and remove the envelope from the transport.
+     */
+    public function ack(EventEnvelope $envelope): void;
+
+    /**
+     * Release a claimed envelope back to the transport for a later retry.
+     */
+    public function release(EventEnvelope $envelope): void;
+
+    /**
+     * Reject a malformed or permanently failed envelope.
+     */
+    public function fail(EventEnvelope $envelope): void;
+
+    /**
+     * Count currently queued envelopes when supported by the transport.
+     */
+    public function count(): int;
+}

--- a/src/Libs/Events/Queue/FilesystemEventTransport.php
+++ b/src/Libs/Events/Queue/FilesystemEventTransport.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Libs\Events\Queue;
+
+use DirectoryIterator;
+use JsonException;
+use RuntimeException;
+use Throwable;
+
+final class FilesystemEventTransport implements EventTransportInterface
+{
+    private const string EXTENSION = '.json';
+    private const string PROCESSING_SUFFIX = '.processing';
+
+    public function __construct(
+        private readonly string $path,
+        private readonly int $claimAfterSeconds = 300,
+    ) {
+        $this->ensureDirectories();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function enqueue(EventEnvelope $envelope): EventEnvelope
+    {
+        try {
+            $payload = json_encode($envelope->toArray(), flags: JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new RuntimeException(r('Unable to encode queue envelope: {error}', ['error' => $e->getMessage()]), previous: $e);
+        }
+
+        $filename = $this->filename($envelope);
+        $tmp = $this->dir('tmp') . '/' . $filename . '.tmp.' . getmypid();
+        $target = $this->dir('pending') . '/' . $filename;
+
+        if (false === @file_put_contents($tmp, $payload, LOCK_EX)) {
+            throw new RuntimeException(r("Unable to write event queue payload '{file}'.", ['file' => $tmp]));
+        }
+
+        if (false === @rename($tmp, $target)) {
+            if (true === file_exists($tmp)) {
+                @unlink($tmp);
+            }
+            throw new RuntimeException(r("Unable to queue event payload '{file}'.", ['file' => $target]));
+        }
+
+        return $envelope->withAck($target);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function dequeue(int $limit): array
+    {
+        $limit = max(1, $limit);
+        $this->reclaimStale();
+
+        $items = $this->pendingFiles();
+        $claimed = [];
+
+        foreach ($items as $file) {
+            if (count($claimed) >= $limit) {
+                break;
+            }
+
+            $source = $this->dir('pending') . '/' . $file;
+            $target = $this->dir('processing') . '/' . $file . '.' . getmypid() . self::PROCESSING_SUFFIX;
+
+            if (false === @rename($source, $target)) {
+                continue;
+            }
+
+            try {
+                $payload = $this->readPayload($target);
+                $claimed[] = EventEnvelope::fromArray($payload, $target);
+            } catch (Throwable) {
+                $this->moveFailed($target);
+            }
+        }
+
+        return $claimed;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function ack(EventEnvelope $envelope): void
+    {
+        if (false === is_string($envelope->ack) || '' === $envelope->ack) {
+            return;
+        }
+
+        @unlink($envelope->ack);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function release(EventEnvelope $envelope): void
+    {
+        if (false === is_string($envelope->ack) || '' === $envelope->ack || false === file_exists($envelope->ack)) {
+            return;
+        }
+
+        @rename($envelope->ack, $this->dir('pending') . '/' . $this->pendingName($envelope->ack));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function fail(EventEnvelope $envelope): void
+    {
+        if (false === is_string($envelope->ack) || '' === $envelope->ack || false === file_exists($envelope->ack)) {
+            return;
+        }
+
+        $this->moveFailed($envelope->ack);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function count(): int
+    {
+        return count($this->pendingFiles());
+    }
+
+    private function ensureDirectories(): void
+    {
+        foreach (['pending', 'processing', 'failed', 'tmp'] as $dir) {
+            $path = $this->dir($dir);
+            if (true === is_dir($path)) {
+                continue;
+            }
+
+            if (false === mkdir($path, 0o755, true) && false === is_dir($path)) {
+                throw new RuntimeException(r("Unable to create event queue directory '{path}'.", ['path' => $path]));
+            }
+        }
+    }
+
+    private function dir(string $name): string
+    {
+        return rtrim(fix_path($this->path), '/') . '/' . $name;
+    }
+
+    private function filename(EventEnvelope $envelope): string
+    {
+        $id = preg_replace('/[^A-Za-z0-9_.-]/', '_', $envelope->id);
+        if (false === is_string($id) || '' === $id) {
+            $id = generate_uuid();
+        }
+
+        return sprintf('%020d.%s%s', (int) (microtime(true) * 1_000_000), $id, self::EXTENSION);
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function pendingFiles(): array
+    {
+        $files = [];
+
+        foreach (new DirectoryIterator($this->dir('pending')) as $file) {
+            if ($file->isDot() || false === $file->isFile()) {
+                continue;
+            }
+
+            $name = $file->getFilename();
+            if (false === str_ends_with($name, self::EXTENSION)) {
+                continue;
+            }
+
+            $files[] = $name;
+        }
+
+        sort($files, SORT_STRING);
+
+        return $files;
+    }
+
+    private function reclaimStale(): void
+    {
+        $threshold = time() - max(1, $this->claimAfterSeconds);
+
+        foreach (new DirectoryIterator($this->dir('processing')) as $file) {
+            if ($file->isDot() || false === $file->isFile()) {
+                continue;
+            }
+
+            $path = $file->getPathname();
+            $modifiedAt = $file->getMTime();
+            if ($modifiedAt > $threshold) {
+                continue;
+            }
+
+            @rename($path, $this->dir('pending') . '/' . $this->pendingName($path));
+        }
+    }
+
+    private function pendingName(string $path): string
+    {
+        $basename = basename($path);
+        $name = preg_replace('/\.\d+' . preg_quote(self::PROCESSING_SUFFIX, '/') . '$/', '', $basename);
+
+        return is_string($name) && '' !== $name ? $name : $basename;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readPayload(string $path): array
+    {
+        if (false === ($content = @file_get_contents($path))) {
+            throw new RuntimeException(r("Unable to read event queue payload '{file}'.", ['file' => $path]));
+        }
+
+        try {
+            $payload = json_decode($content, true, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new RuntimeException(r("Invalid JSON in event queue payload '{file}': {error}", [
+                'file' => $path,
+                'error' => $e->getMessage(),
+            ]), previous: $e);
+        }
+
+        return $payload;
+    }
+
+    private function moveFailed(string $path): void
+    {
+        @rename($path, $this->dir('failed') . '/' . basename($path));
+    }
+}

--- a/src/Libs/Events/Queue/NullEventTransport.php
+++ b/src/Libs/Events/Queue/NullEventTransport.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Libs\Events\Queue;
+
+final class NullEventTransport implements EventTransportInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function enqueue(EventEnvelope $envelope): EventEnvelope
+    {
+        return $envelope;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function dequeue(int $limit): array
+    {
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function ack(EventEnvelope $envelope): void {}
+
+    /**
+     * @inheritdoc
+     */
+    public function release(EventEnvelope $envelope): void {}
+
+    /**
+     * @inheritdoc
+     */
+    public function fail(EventEnvelope $envelope): void {}
+
+    /**
+     * @inheritdoc
+     */
+    public function count(): int
+    {
+        return 0;
+    }
+}

--- a/src/Libs/Events/Queue/RedisStreamEventTransport.php
+++ b/src/Libs/Events/Queue/RedisStreamEventTransport.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Libs\Events\Queue;
+
+use JsonException;
+use Redis;
+use RuntimeException;
+use Throwable;
+
+final class RedisStreamEventTransport implements EventTransportInterface
+{
+    private bool $groupReady = false;
+
+    public function __construct(
+        private readonly Redis $redis,
+        private readonly string $stream,
+        private readonly string $group,
+        private readonly string $consumer,
+        private readonly int $claimAfterMs = 300_000,
+    ) {}
+
+    /**
+     * @inheritdoc
+     */
+    public function enqueue(EventEnvelope $envelope): EventEnvelope
+    {
+        $this->createGroup();
+
+        try {
+            $payload = json_encode($envelope->toArray(), flags: JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new RuntimeException(r('Unable to encode queue envelope: {error}', ['error' => $e->getMessage()]), previous: $e);
+        }
+
+        $id = $this->redis->xAdd($this->stream, '*', ['payload' => $payload]);
+        if (false === is_string($id) || '' === $id) {
+            throw new RuntimeException(r("Unable to append event to Redis stream '{stream}'.", ['stream' => $this->stream]));
+        }
+
+        return $envelope->withAck($id);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function dequeue(int $limit): array
+    {
+        $this->createGroup();
+
+        $limit = max(1, $limit);
+        $items = $this->claimStale($limit);
+        $remaining = $limit - count($items);
+
+        if ($remaining < 1) {
+            return $items;
+        }
+
+        return [...$items, ...$this->readNew($remaining)];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function ack(EventEnvelope $envelope): void
+    {
+        if (!is_string($envelope->ack) || '' === $envelope->ack) {
+            return;
+        }
+
+        $this->redis->xAck($this->stream, $this->group, [$envelope->ack]);
+        $this->redis->xDel($this->stream, [$envelope->ack]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function release(EventEnvelope $envelope): void
+    {
+        // Redis Streams keep unacked messages in the pending list. They will be reclaimed later.
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function fail(EventEnvelope $envelope): void
+    {
+        $this->ack($envelope);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function count(): int
+    {
+        $count = $this->redis->xLen($this->stream);
+
+        return is_int($count) ? $count : 0;
+    }
+
+    private function createGroup(): void
+    {
+        if (true === $this->groupReady) {
+            return;
+        }
+
+        try {
+            $this->redis->xGroup('CREATE', $this->stream, $this->group, '0', true);
+        } catch (Throwable $e) {
+            if (false === str_contains($e->getMessage(), 'BUSYGROUP')) {
+                throw $e;
+            }
+        }
+
+        $this->groupReady = true;
+    }
+
+    /**
+     * @return array<EventEnvelope>
+     */
+    private function readNew(int $limit): array
+    {
+        try {
+            $records = $this->redis->xReadGroup($this->group, $this->consumer, [$this->stream => '>'], $limit);
+        } catch (Throwable) {
+            return [];
+        }
+
+        return $this->parseReadRecords(is_array($records) ? $records : []);
+    }
+
+    /**
+     * @return array<EventEnvelope>
+     */
+    private function claimStale(int $limit): array
+    {
+        try {
+            $records = $this->redis->rawCommand(
+                'XAUTOCLAIM',
+                $this->stream,
+                $this->group,
+                $this->consumer,
+                (string) $this->claimAfterMs,
+                '0-0',
+                'COUNT',
+                (string) $limit,
+            );
+        } catch (Throwable) {
+            return [];
+        }
+
+        if (false === is_array($records) || false === isset($records[1]) || false === is_array($records[1])) {
+            return [];
+        }
+
+        return $this->parseStreamEntries($records[1]);
+    }
+
+    /**
+     * @param array<mixed> $records
+     * @return array<EventEnvelope>
+     */
+    private function parseReadRecords(array $records): array
+    {
+        $streamRecords = $records[$this->stream] ?? [];
+        if (false === is_array($streamRecords)) {
+            return [];
+        }
+
+        return $this->parseStreamEntries($streamRecords);
+    }
+
+    /**
+     * @param array<mixed> $entries
+     * @return array<EventEnvelope>
+     */
+    private function parseStreamEntries(array $entries): array
+    {
+        $items = [];
+
+        foreach ($entries as $id => $fields) {
+            if (is_array($fields) && array_key_exists(0, $fields) && is_string($fields[0] ?? null)) {
+                $id = $fields[0];
+                $fields = $fields[1] ?? [];
+            }
+
+            if (false === is_string($id) || false === is_array($fields)) {
+                continue;
+            }
+
+            $payload = $fields['payload'] ?? null;
+            if (false === is_string($payload)) {
+                continue;
+            }
+
+            $data = json_decode($payload, true);
+            if (false === is_array($data)) {
+                $this->redis->xAck($this->stream, $this->group, [$id]);
+                $this->redis->xDel($this->stream, [$id]);
+                continue;
+            }
+
+            try {
+                $items[] = EventEnvelope::fromArray($data, $id);
+            } catch (Throwable) {
+                $this->redis->xAck($this->stream, $this->group, [$id]);
+                $this->redis->xDel($this->stream, [$id]);
+            }
+        }
+
+        return $items;
+    }
+}

--- a/src/Libs/Options.php
+++ b/src/Libs/Options.php
@@ -64,6 +64,7 @@ final class Options
     public const string ON_SKIP_STATE = 'ON_SKIP_STATE';
     public const string FAIL_FAST_ON_LOCK = 'FAIL_FAST_ON_LOCK';
     public const string CACHE_ONLY = 'CACHE_ONLY';
+    public const string QUEUE_ONLY = 'QUEUE_ONLY';
     public const string DATE_COLUMN = 'DATE_COLUMN';
     public const string REPLAY_PROGRESS = 'REPLAY_PROGRESS';
 

--- a/tests/API/System/CommandTest.php
+++ b/tests/API/System/CommandTest.php
@@ -7,8 +7,11 @@ namespace Tests\API\System;
 use App\API\System\Command;
 use App\Libs\Attributes\Route\Post;
 use App\Libs\Config;
+use App\Libs\Container;
 use App\Libs\Enums\Http\Status;
 use App\Libs\TestCase;
+use DateInterval;
+use Psr\SimpleCache\CacheInterface as iCache;
 use Tests\Support\RequestResponseTrait;
 
 final class CommandTest extends TestCase
@@ -131,6 +134,62 @@ final class CommandTest extends TestCase
 
         $this->assertSame(Status::OK->value, $streamResponse->getStatusCode());
         $this->assertTrue(is_dir($sessionPath));
+    }
+
+    public function test_stream_marks_command(): void
+    {
+        Config::save('console.enable.all', true);
+
+        $cache = $this->createMock(iCache::class);
+        $cache
+            ->expects($this->once())
+            ->method('set')
+            ->with(
+                Command::CACHE_NAME,
+                true,
+                $this->callback(static fn(mixed $ttl): bool => $ttl instanceof DateInterval && 6 === $ttl->h),
+            )
+            ->willReturn(true);
+        $cache
+            ->expects($this->once())
+            ->method('delete')
+            ->with(Command::CACHE_NAME)
+            ->willReturn(true);
+
+        Container::init();
+        Container::add(iCache::class, $cache);
+
+        $handler = new Command();
+        $response = $handler->queue($this->getRequest(post: [
+            'command' => '$ printf api-marker',
+            'cwd' => $this->tmpDir,
+            'pty' => false,
+            'timeout' => 5,
+        ]));
+
+        $payload = json_decode((string) $response->getBody(), true);
+        $token = (string) ag($payload, 'token');
+        $sessionPath = $this->tmpDir . '/console/' . $token;
+        $streamResponse = $handler->stream($this->getRequest(), $token);
+
+        $bufferLevel = ob_get_level();
+        ob_start(static fn(string $_buffer, int $_phase): string => '');
+
+        try {
+            $body = (string) $streamResponse->getBody();
+        } finally {
+            while (ob_get_level() > $bufferLevel) {
+                ob_end_clean();
+            }
+        }
+
+        $state = json_decode((string) file_get_contents($sessionPath . '/state.json'), true);
+        $transcript = (string) file_get_contents($sessionPath . '/stream.log');
+
+        $this->assertSame('', $body);
+        $this->assertStringContainsString('api-marker', $transcript);
+        $this->assertSame('completed', ag($state, 'status'));
+        $this->assertSame(0, ag($state, 'exit_code'));
     }
 
     public function test_list(): void

--- a/tests/API/System/CommandTest.php
+++ b/tests/API/System/CommandTest.php
@@ -7,11 +7,8 @@ namespace Tests\API\System;
 use App\API\System\Command;
 use App\Libs\Attributes\Route\Post;
 use App\Libs\Config;
-use App\Libs\Container;
 use App\Libs\Enums\Http\Status;
 use App\Libs\TestCase;
-use DateInterval;
-use Psr\SimpleCache\CacheInterface as iCache;
 use Tests\Support\RequestResponseTrait;
 
 final class CommandTest extends TestCase
@@ -134,62 +131,6 @@ final class CommandTest extends TestCase
 
         $this->assertSame(Status::OK->value, $streamResponse->getStatusCode());
         $this->assertTrue(is_dir($sessionPath));
-    }
-
-    public function test_stream_marks_command(): void
-    {
-        Config::save('console.enable.all', true);
-
-        $cache = $this->createMock(iCache::class);
-        $cache
-            ->expects($this->once())
-            ->method('set')
-            ->with(
-                Command::CACHE_NAME,
-                true,
-                $this->callback(static fn(mixed $ttl): bool => $ttl instanceof DateInterval && 6 === $ttl->h),
-            )
-            ->willReturn(true);
-        $cache
-            ->expects($this->once())
-            ->method('delete')
-            ->with(Command::CACHE_NAME)
-            ->willReturn(true);
-
-        Container::init();
-        Container::add(iCache::class, $cache);
-
-        $handler = new Command();
-        $response = $handler->queue($this->getRequest(post: [
-            'command' => '$ printf api-marker',
-            'cwd' => $this->tmpDir,
-            'pty' => false,
-            'timeout' => 5,
-        ]));
-
-        $payload = json_decode((string) $response->getBody(), true);
-        $token = (string) ag($payload, 'token');
-        $sessionPath = $this->tmpDir . '/console/' . $token;
-        $streamResponse = $handler->stream($this->getRequest(), $token);
-
-        $bufferLevel = ob_get_level();
-        ob_start(static fn(string $_buffer, int $_phase): string => '');
-
-        try {
-            $body = (string) $streamResponse->getBody();
-        } finally {
-            while (ob_get_level() > $bufferLevel) {
-                ob_end_clean();
-            }
-        }
-
-        $state = json_decode((string) file_get_contents($sessionPath . '/state.json'), true);
-        $transcript = (string) file_get_contents($sessionPath . '/stream.log');
-
-        $this->assertSame('', $body);
-        $this->assertStringContainsString('api-marker', $transcript);
-        $this->assertSame('completed', ag($state, 'status'));
-        $this->assertSame(0, ag($state, 'exit_code'));
     }
 
     public function test_list(): void

--- a/tests/API/Webhook/IndexTest.php
+++ b/tests/API/Webhook/IndexTest.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Tests\API\Webhook;
 
-use App\API\System\Command as SystemCommand;
 use App\API\WebHook;
-use App\Commands\System\TasksCommand;
+use App\Libs\Config;
 use App\Libs\Container;
 use App\Libs\Database\DatabaseInterface as iDB;
 use App\Libs\Enums\Http\Method;
 use App\Libs\Events\EventQueue;
+use App\Libs\Events\Queue\EventEnvelope;
+use App\Libs\Events\Queue\EventTransportInterface;
+use App\Libs\Events\Queue\FilesystemEventTransport;
 use App\Libs\Options;
 use App\Libs\TestCase;
 use App\Listeners\ProcessWebhookEvent;
@@ -18,7 +20,6 @@ use App\Model\Events\EventsRepository;
 use App\Model\Events\EventsTable;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Message\ServerRequestInterface as iRequest;
-use Psr\SimpleCache\CacheInterface;
 use Tests\Support\RequestResponseTrait;
 
 final class IndexTest extends TestCase
@@ -26,108 +27,75 @@ final class IndexTest extends TestCase
     use RequestResponseTrait;
 
     private EventsRepository $repo;
+    private FilesystemEventTransport $transport;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->initTempApp();
-        $cache = Container::get(CacheInterface::class);
         $db = $this->createDb();
+        Config::save('events.queue.driver', 'file');
+        Config::save('events.queue.path', self::$tmpPath . '/queue/events');
+        $this->transport = new FilesystemEventTransport(self::$tmpPath . '/queue/events');
 
         Container::add(iDB::class, $db);
         Container::add(EventsRepository::class, $this->repo = new EventsRepository($db->getDBLayer()));
-        Container::add(EventQueue::class, new EventQueue($cache, $this->repo));
+        Container::add(EventTransportInterface::class, $this->transport);
+        Container::add(EventQueue::class, new EventQueue($this->transport, $this->repo));
     }
 
     public function test_ready(): void
     {
-        $cache = Container::get(CacheInterface::class);
-        $response = (new WebHook($cache))($this->getRequest(method: Method::GET, uri: '/v1/api/webhook'));
+        $response = (new WebHook())($this->getRequest(method: Method::GET, uri: '/v1/api/webhook'));
 
         self::assertSame(200, $response->getStatusCode());
     }
 
     public function test_queue(): void
     {
-        $cache = Container::get(CacheInterface::class);
-
-        $response = (new Webhook($cache))($this->getWebhookRequest('req-1'));
+        $response = (new WebHook())($this->getWebhookRequest('req-1'));
 
         self::assertSame(200, $response->getStatusCode());
 
-        $events = $this->repo->findAll([EventsTable::COLUMN_EVENT => ProcessWebhookEvent::NAME]);
+        $event = $this->queuedEnvelope();
 
-        self::assertCount(1, $events);
-        self::assertSame(['keep' => '1'], $events[0]->event_data['get']);
-        self::assertSame(['payload' => 'ok'], $events[0]->event_data['post']);
-        self::assertSame('', $events[0]->event_data['body']);
-        self::assertSame('req-1', $events[0]->event_data['server']['X_REQUEST_ID']);
-        self::assertArrayNotHasKey('HTTP_AUTHORIZATION', $events[0]->event_data['server']);
-        self::assertArrayNotHasKey('WS_API_KEY', $events[0]->event_data['server']);
-        self::assertArrayNotHasKey('WS_BACKENDS_FILE', $events[0]->event_data['server']);
-        self::assertStringNotContainsString('apikey', $events[0]->event_data['server']['REQUEST_URI']);
-        self::assertStringNotContainsString('ws_token', $events[0]->event_data['server']['REQUEST_URI']);
-        self::assertSame('keep=1', $events[0]->event_data['server']['QUERY_STRING']);
-        self::assertTrue($events[0]->options[Options::FAIL_FAST_ON_LOCK]);
-        self::assertSame([], $cache->get('events', []));
+        self::assertSame(ProcessWebhookEvent::NAME, $event->event);
+        self::assertSame(['keep' => '1'], $event->data['get']);
+        self::assertSame(['payload' => 'ok'], $event->data['post']);
+        self::assertSame('', $event->data['body']);
+        self::assertSame('req-1', $event->data['server']['X_REQUEST_ID']);
+        self::assertArrayNotHasKey('HTTP_AUTHORIZATION', $event->data['server']);
+        self::assertArrayNotHasKey('WS_API_KEY', $event->data['server']);
+        self::assertArrayNotHasKey('WS_BACKENDS_FILE', $event->data['server']);
+        self::assertStringNotContainsString('apikey', $event->data['server']['REQUEST_URI']);
+        self::assertStringNotContainsString('ws_token', $event->data['server']['REQUEST_URI']);
+        self::assertSame('keep=1', $event->data['server']['QUERY_STRING']);
+        self::assertTrue($event->opts[Options::FAIL_FAST_ON_LOCK]);
+        self::assertTrue($event->opts['cached']);
+        self::assertArrayNotHasKey(Options::QUEUE_ONLY, $event->opts);
+        self::assertSame([], $this->repo->findAll([EventsTable::COLUMN_EVENT => ProcessWebhookEvent::NAME]));
     }
 
     public function test_raw_queue(): void
     {
-        $cache = Container::get(CacheInterface::class);
-
-        $response = (new WebHook($cache))($this->getWebhookRequest('req-1')->withParsedBody(null));
+        $response = (new WebHook())($this->getWebhookRequest('req-1')->withParsedBody(null));
 
         self::assertSame(200, $response->getStatusCode());
 
-        $events = $this->repo->findAll([EventsTable::COLUMN_EVENT => ProcessWebhookEvent::NAME]);
+        $event = $this->queuedEnvelope();
 
-        self::assertCount(1, $events);
-        self::assertArrayNotHasKey('post', $events[0]->event_data);
-        self::assertSame('raw-body', $events[0]->event_data['body']);
+        self::assertArrayNotHasKey('post', $event->data);
+        self::assertSame('raw-body', $event->data['body']);
     }
 
-    public function test_cache_during_tasks(): void
+    private function queuedEnvelope(): EventEnvelope
     {
-        $cache = Container::get(CacheInterface::class);
-        $cache->set(TasksCommand::CACHE_NAME, true, new \DateInterval('PT6H'));
-
-        $response = (new WebHook($cache))($this->getWebhookRequest('req-1'));
-
-        self::assertSame(200, $response->getStatusCode());
-
-        $events = $cache->get('events', []);
+        $events = $this->transport->dequeue(10);
 
         self::assertCount(1, $events);
-        self::assertSame(ProcessWebhookEvent::NAME, $events[0]['event']);
-        self::assertSame(['payload' => 'ok'], $events[0]['data']['post']);
-        self::assertSame('', $events[0]['data']['body']);
-        self::assertArrayNotHasKey('WS_API_KEY', $events[0]['data']['server']);
-        self::assertTrue($events[0]['opts']['cached']);
-        self::assertTrue($events[0]['opts'][Options::FAIL_FAST_ON_LOCK]);
-        self::assertArrayNotHasKey(Options::CACHE_ONLY, $events[0]['opts']);
-        self::assertSame([], $this->repo->findAll([EventsTable::COLUMN_EVENT => ProcessWebhookEvent::NAME]));
-    }
 
-    public function test_cache_during_command(): void
-    {
-        $cache = Container::get(CacheInterface::class);
-        $cache->set(SystemCommand::CACHE_NAME, true, new \DateInterval('PT6H'));
-
-        $response = (new WebHook($cache))($this->getWebhookRequest('req-1'));
-
-        self::assertSame(200, $response->getStatusCode());
-
-        $events = $cache->get('events', []);
-
-        self::assertCount(1, $events);
-        self::assertSame(ProcessWebhookEvent::NAME, $events[0]['event']);
-        self::assertSame(['payload' => 'ok'], $events[0]['data']['post']);
-        self::assertTrue($events[0]['opts']['cached']);
-        self::assertTrue($events[0]['opts'][Options::FAIL_FAST_ON_LOCK]);
-        self::assertArrayNotHasKey(Options::CACHE_ONLY, $events[0]['opts']);
-        self::assertSame([], $this->repo->findAll([EventsTable::COLUMN_EVENT => ProcessWebhookEvent::NAME]));
+        return $events[0];
     }
 
     private function getWebhookRequest(string $requestId): iRequest

--- a/tests/API/Webhook/IndexTest.php
+++ b/tests/API/Webhook/IndexTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\API\Webhook;
 
+use App\API\System\Command as SystemCommand;
 use App\API\WebHook;
 use App\Commands\System\TasksCommand;
 use App\Libs\Container;
@@ -68,6 +69,7 @@ final class IndexTest extends TestCase
         self::assertStringNotContainsString('apikey', $events[0]->event_data['server']['REQUEST_URI']);
         self::assertStringNotContainsString('ws_token', $events[0]->event_data['server']['REQUEST_URI']);
         self::assertSame('keep=1', $events[0]->event_data['server']['QUERY_STRING']);
+        self::assertTrue($events[0]->options[Options::FAIL_FAST_ON_LOCK]);
         self::assertSame([], $cache->get('events', []));
     }
 
@@ -103,6 +105,27 @@ final class IndexTest extends TestCase
         self::assertSame('', $events[0]['data']['body']);
         self::assertArrayNotHasKey('WS_API_KEY', $events[0]['data']['server']);
         self::assertTrue($events[0]['opts']['cached']);
+        self::assertTrue($events[0]['opts'][Options::FAIL_FAST_ON_LOCK]);
+        self::assertArrayNotHasKey(Options::CACHE_ONLY, $events[0]['opts']);
+        self::assertSame([], $this->repo->findAll([EventsTable::COLUMN_EVENT => ProcessWebhookEvent::NAME]));
+    }
+
+    public function test_cache_during_command(): void
+    {
+        $cache = Container::get(CacheInterface::class);
+        $cache->set(SystemCommand::CACHE_NAME, true, new \DateInterval('PT6H'));
+
+        $response = (new WebHook($cache))($this->getWebhookRequest('req-1'));
+
+        self::assertSame(200, $response->getStatusCode());
+
+        $events = $cache->get('events', []);
+
+        self::assertCount(1, $events);
+        self::assertSame(ProcessWebhookEvent::NAME, $events[0]['event']);
+        self::assertSame(['payload' => 'ok'], $events[0]['data']['post']);
+        self::assertTrue($events[0]['opts']['cached']);
+        self::assertTrue($events[0]['opts'][Options::FAIL_FAST_ON_LOCK]);
         self::assertArrayNotHasKey(Options::CACHE_ONLY, $events[0]['opts']);
         self::assertSame([], $this->repo->findAll([EventsTable::COLUMN_EVENT => ProcessWebhookEvent::NAME]));
     }

--- a/tests/Commands/Events/DispatchCommandTest.php
+++ b/tests/Commands/Events/DispatchCommandTest.php
@@ -5,11 +5,17 @@ declare(strict_types=1);
 namespace Tests\Commands\Events;
 
 use App\Commands\Events\DispatchCommand;
+use App\Libs\Container;
 use App\Libs\Events\DataEvent;
+use App\Libs\Events\EventQueue;
+use App\Libs\Events\Queue\EventEnvelope;
+use App\Libs\Events\Queue\EventTransportInterface;
+use App\Libs\Events\Queue\FilesystemEventTransport;
 use App\Libs\Extends\LogMessageProcessor;
 use App\Libs\TestCase;
 use App\Model\Events\Event;
 use App\Model\Events\EventsRepository;
+use App\Model\Events\EventsTable;
 use Monolog\Handler\TestHandler;
 use Monolog\Level;
 use Monolog\Logger;
@@ -28,10 +34,14 @@ final class DispatchCommandTest extends TestCase
             $event->addRawLog('listener raw output');
             $logger->notice('Listener raw output.');
         });
+        $repo = $this->repo();
+        $transport = $this->transport();
 
         $command = new DispatchCommand(
             $dispatcher,
-            $this->repo(),
+            $repo,
+            new EventQueue($transport, $repo),
+            $transport,
             $this->createStub(iCache::class),
             $logger,
         );
@@ -53,10 +63,14 @@ final class DispatchCommandTest extends TestCase
             $event->addLog(Level::Notice, 'listener visible');
             $logger->notice('Listener visible.');
         });
+        $repo = $this->repo();
+        $transport = $this->transport();
 
         $command = new DispatchCommand(
             $dispatcher,
-            $this->repo(),
+            $repo,
+            new EventQueue($transport, $repo),
+            $transport,
             $this->createStub(iCache::class),
             $logger,
         );
@@ -79,10 +93,14 @@ final class DispatchCommandTest extends TestCase
         $dispatcher->addListener('on_push', static function (DataEvent $event): void {
             $event->addLog(Level::Debug, 'listener debug');
         });
+        $repo = $this->repo();
+        $transport = $this->transport();
 
         $command = new DispatchCommand(
             $dispatcher,
-            $this->repo(),
+            $repo,
+            new EventQueue($transport, $repo),
+            $transport,
             $this->createStub(iCache::class),
             $logger,
         );
@@ -104,6 +122,44 @@ final class DispatchCommandTest extends TestCase
         );
     }
 
+    public function test_drain_transport(): void
+    {
+        $this->initTempDir();
+        Container::init();
+
+        $logger = new Logger('test');
+        $repo = new EventsRepository($this->createDb($logger)->getDBLayer());
+        $transport = new FilesystemEventTransport(self::$tmpPath . '/queue/events');
+        $queue = new EventQueue($transport, $repo);
+
+        $transport->enqueue(EventEnvelope::create(
+            'on_push',
+            ['ok' => true],
+            [
+                EventsTable::COLUMN_REFERENCE => 'push://1',
+            ],
+        ));
+
+        $command = new DispatchCommand(
+            new EventDispatcher(),
+            $repo,
+            $queue,
+            $transport,
+            $this->createStub(iCache::class),
+            $logger,
+        );
+
+        $method = new ReflectionMethod(DispatchCommand::class, 'drainTransport');
+        $method->invoke($command, 10);
+
+        $events = $repo->findAll([EventsTable::COLUMN_EVENT => 'on_push']);
+
+        self::assertCount(1, $events);
+        self::assertSame(['ok' => true], $events[0]->event_data);
+        self::assertSame('push://1', $events[0]->reference);
+        self::assertSame(0, $transport->count());
+    }
+
     private function event(): Event
     {
         $event = new Event([]);
@@ -120,6 +176,11 @@ final class DispatchCommandTest extends TestCase
         $repo->expects(self::exactly(2))->method('save')->willReturn('event-id');
 
         return $repo;
+    }
+
+    private function transport(): EventTransportInterface
+    {
+        return $this->createStub(EventTransportInterface::class);
     }
 
     private function runEvent(DispatchCommand $command, Event $event, Level $level, bool $debug = false): void

--- a/tests/Libs/Events/ArrayAndNullEventTransportTest.php
+++ b/tests/Libs/Events/ArrayAndNullEventTransportTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Libs\Events;
+
+use App\Libs\Events\Queue\ArrayEventTransport;
+use App\Libs\Events\Queue\EventEnvelope;
+use App\Libs\Events\Queue\NullEventTransport;
+use App\Libs\TestCase;
+
+final class ArrayAndNullEventTransportTest extends TestCase
+{
+    public function test_null_enqueue(): void
+    {
+        $transport = new NullEventTransport();
+        $envelope = EventEnvelope::create('on_push', ['ok' => true]);
+
+        self::assertSame($envelope, $transport->enqueue($envelope));
+    }
+
+    public function test_null_dequeue(): void
+    {
+        $transport = new NullEventTransport();
+        $transport->enqueue(EventEnvelope::create('on_push', ['ok' => true]));
+
+        self::assertSame([], $transport->dequeue(10));
+        self::assertSame(0, $transport->count());
+    }
+
+    public function test_array_enqueue(): void
+    {
+        $transport = new ArrayEventTransport();
+        $envelope = EventEnvelope::create('on_push', ['ok' => true]);
+
+        self::assertSame($envelope, $transport->enqueue($envelope));
+        self::assertSame(1, $transport->count());
+    }
+
+    public function test_array_dequeue(): void
+    {
+        $transport = new ArrayEventTransport();
+        $transport->enqueue(EventEnvelope::create('on_push', ['ok' => true]));
+        $transport->enqueue(EventEnvelope::create('on_progress', ['progress' => 50]));
+
+        $events = $transport->dequeue(10);
+
+        self::assertCount(2, $events);
+        self::assertSame('on_push', $events[0]->event);
+        self::assertSame('on_progress', $events[1]->event);
+        self::assertSame(0, $transport->count());
+    }
+
+    public function test_array_release(): void
+    {
+        $transport = new ArrayEventTransport();
+        $transport->enqueue(EventEnvelope::create('on_push', ['ok' => true]));
+
+        $events = $transport->dequeue(10);
+        self::assertCount(1, $events);
+        self::assertSame(0, $transport->count());
+
+        $transport->release($events[0]);
+
+        self::assertSame(1, $transport->count());
+
+        $reclaimed = $transport->dequeue(10);
+        self::assertCount(1, $reclaimed);
+        self::assertSame($events[0]->id, $reclaimed[0]->id);
+    }
+}

--- a/tests/Libs/Events/EventQueueTest.php
+++ b/tests/Libs/Events/EventQueueTest.php
@@ -6,6 +6,8 @@ namespace Tests\Libs\Events;
 
 use App\Libs\Events\DataEvent;
 use App\Libs\Events\EventQueue;
+use App\Libs\Events\Queue\EventEnvelope;
+use App\Libs\Events\Queue\EventTransportInterface;
 use App\Libs\Options;
 use App\Libs\TestCase;
 use App\Model\Events\Event as EventInfo;
@@ -13,14 +15,12 @@ use App\Model\Events\EventsRepository;
 use App\Model\Events\EventsTable;
 use App\Model\Events\EventStatus;
 use PDOException;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Component\Cache\Psr16Cache;
 
 final class EventQueueTest extends TestCase
 {
     public function test_cache_only(): void
     {
-        $cache = new Psr16Cache(new ArrayAdapter());
+        $transport = $this->createMock(EventTransportInterface::class);
         $repo = $this
             ->getMockBuilder(EventsRepository::class)
             ->disableOriginalConstructor()
@@ -32,7 +32,24 @@ final class EventQueueTest extends TestCase
         $repo->expects($this->never())->method('remove');
         $repo->expects($this->never())->method('save');
 
-        $queued = new EventQueue($cache, $repo)->queue(
+        $transport
+            ->expects($this->once())
+            ->method('enqueue')
+            ->with($this->callback(static function (EventEnvelope $event): bool {
+                return (
+                    'on_request' === $event->event
+                    && ['ok' => true] === $event->data
+                    && 'request://1' === $event->opts[EventsTable::COLUMN_REFERENCE]
+                    && true === $event->opts['cached']
+                    && 'alice' === $event->opts[Options::CONTEXT_USER]
+                    && false === array_key_exists(Options::CACHE_ONLY, $event->opts)
+                    && false === array_key_exists(Options::CACHE_TTL, $event->opts)
+                    && false === array_key_exists(EventsRepository::class, $event->opts)
+                );
+            }))
+            ->willReturnCallback(static fn(EventEnvelope $event): EventEnvelope => $event);
+
+        $queued = new EventQueue($transport, $repo)->queue(
             'on_request',
             ['ok' => true],
             [
@@ -50,23 +67,21 @@ final class EventQueueTest extends TestCase
         self::assertSame(['ok' => true], $queued->event_data);
         self::assertSame(DataEvent::class, $queued->options['class']);
         self::assertSame('alice', $queued->options[Options::CONTEXT_USER]);
-
-        $events = $cache->get('events', []);
-
-        self::assertCount(1, $events);
-        self::assertSame('on_request', $events[0]['event']);
-        self::assertSame(['ok' => true], $events[0]['data']);
-        self::assertSame('request://1', $events[0]['opts'][EventsTable::COLUMN_REFERENCE]);
-        self::assertTrue($events[0]['opts']['cached']);
-        self::assertArrayNotHasKey(Options::CACHE_ONLY, $events[0]['opts']);
-        self::assertArrayNotHasKey(Options::CACHE_TTL, $events[0]['opts']);
-        self::assertArrayNotHasKey(EventsRepository::class, $events[0]['opts']);
     }
 
     public function test_lock_fallback(): void
     {
-        $cache = new Psr16Cache(new ArrayAdapter());
         $modes = ['find', 'remove', 'save'];
+        $queuedEvents = [];
+        $transport = $this->createMock(EventTransportInterface::class);
+        $transport
+            ->expects($this->exactly(3))
+            ->method('enqueue')
+            ->willReturnCallback(static function (EventEnvelope $event) use (&$queuedEvents): EventEnvelope {
+                $queuedEvents[] = $event;
+
+                return $event;
+            });
 
         foreach ($modes as $mode) {
             $reference = 'ref://' . $mode;
@@ -148,7 +163,7 @@ final class EventQueueTest extends TestCase
                     ->willThrowException(new PDOException('database is locked'));
             }
 
-            $queued = new EventQueue($cache, $repo)->queue(
+            $queued = new EventQueue($transport, $repo)->queue(
                 'process_request',
                 ['ok' => true],
                 [
@@ -168,18 +183,16 @@ final class EventQueueTest extends TestCase
             self::assertTrue($queued->options[Options::FAIL_FAST_ON_LOCK]);
         }
 
-        $events = $cache->get('events', []);
+        self::assertCount(3, $queuedEvents);
 
-        self::assertCount(3, $events);
-
-        foreach ($events as $index => $event) {
-            self::assertSame('process_request', $event['event']);
-            self::assertSame(['ok' => true], $event['data']);
-            self::assertTrue($event['opts']['cached']);
-            self::assertTrue($event['opts'][Options::FAIL_FAST_ON_LOCK]);
-            self::assertSame('alice', $event['opts'][Options::CONTEXT_USER]);
-            self::assertSame('ref://' . $modes[$index], $event['opts'][EventsTable::COLUMN_REFERENCE]);
-            self::assertArrayNotHasKey(EventsRepository::class, $event['opts']);
+        foreach ($queuedEvents as $index => $event) {
+            self::assertSame('process_request', $event->event);
+            self::assertSame(['ok' => true], $event->data);
+            self::assertTrue($event->opts['cached']);
+            self::assertTrue($event->opts[Options::FAIL_FAST_ON_LOCK]);
+            self::assertSame('alice', $event->opts[Options::CONTEXT_USER]);
+            self::assertSame('ref://' . $modes[$index], $event->opts[EventsTable::COLUMN_REFERENCE]);
+            self::assertArrayNotHasKey(EventsRepository::class, $event->opts);
         }
     }
 }

--- a/tests/Libs/Events/FilesystemEventTransportTest.php
+++ b/tests/Libs/Events/FilesystemEventTransportTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Libs\Events;
+
+use App\Libs\Events\Queue\EventEnvelope;
+use App\Libs\Events\Queue\FilesystemEventTransport;
+use App\Libs\TestCase;
+
+final class FilesystemEventTransportTest extends TestCase
+{
+    public function test_ack(): void
+    {
+        $transport = $this->transport();
+        $transport->enqueue(EventEnvelope::create('on_push', ['ok' => true]));
+
+        $events = $transport->dequeue(10);
+
+        self::assertCount(1, $events);
+        self::assertSame('on_push', $events[0]->event);
+        self::assertSame(['ok' => true], $events[0]->data);
+
+        $transport->ack($events[0]);
+
+        self::assertSame(0, $transport->count());
+        self::assertSame([], $transport->dequeue(10));
+    }
+
+    public function test_reclaims_stale(): void
+    {
+        $transport = $this->transport(claimAfterSeconds: 1);
+        $transport->enqueue(EventEnvelope::create('on_webhook', ['ok' => true]));
+
+        $events = $transport->dequeue(10);
+        self::assertCount(1, $events);
+        self::assertIsString($events[0]->ack);
+        touch($events[0]->ack, time() - 10);
+
+        $reclaimed = $transport->dequeue(10);
+
+        self::assertCount(1, $reclaimed);
+        self::assertSame($events[0]->id, $reclaimed[0]->id);
+        self::assertSame($events[0]->event, $reclaimed[0]->event);
+        self::assertSame($events[0]->data, $reclaimed[0]->data);
+    }
+
+    private function transport(int $claimAfterSeconds = 300): FilesystemEventTransport
+    {
+        $this->initTempDir();
+
+        return new FilesystemEventTransport(self::$tmpPath . '/queue/events', $claimAfterSeconds);
+    }
+}

--- a/tests/Mappers/Import/MapperAbstract.php
+++ b/tests/Mappers/Import/MapperAbstract.php
@@ -10,6 +10,8 @@ use App\Libs\Database\DatabaseInterface as iDB;
 use App\Libs\Entity\StateEntity;
 use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Events\EventQueue;
+use App\Libs\Events\Queue\EventTransportInterface;
+use App\Libs\Events\Queue\FilesystemEventTransport;
 use App\Libs\Exceptions\DBAdapterException;
 use App\Libs\Extends\LogMessageProcessor;
 use App\Libs\Guid;
@@ -58,14 +60,16 @@ abstract class MapperAbstract extends TestCase
         $this->logger = new Logger('logger', processors: [new LogMessageProcessor()]);
         $this->logger->pushHandler($this->handler);
         Guid::setLogger($this->logger);
+        $this->initTempDir();
 
         $this->db = $this->createDb($this->logger);
         Container::reset();
         Container::init();
         Container::add(CacheInterface::class, new Psr16Cache(new NullAdapter()));
         Container::add(EventsRepository::class, new EventsRepository($this->db->getDBLayer()));
+        Container::add(EventTransportInterface::class, new FilesystemEventTransport(self::$tmpPath . '/queue/events'));
         Container::add(EventQueue::class, new EventQueue(
-            Container::get(CacheInterface::class),
+            Container::get(EventTransportInterface::class),
             Container::get(EventsRepository::class),
         ));
 


### PR DESCRIPTION
This pull request introduces a mechanism to track and prevent concurrent execution of long-running system commands and tasks via a shared cache flag. It ensures that webhook processing can detect when a command or task is running and adjusts its behavior accordingly. The changes also include new and updated tests to verify this locking and detection logic.

- Added a cache flag that is set when a system command starts and cleared when it finishes.
- Updated webhook logic to check both the task and command running cache flags before processing, and to set options to fail fast if a lock is detected. 
