### PR TITLE
refactor: logger for import/playlist instead stdout

### DIFF
--- a/src/Commands/State/ImportCommand.php
+++ b/src/Commands/State/ImportCommand.php
@@ -24,8 +24,6 @@ use App\Libs\UserContext;
 use Monolog\Level;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface as iLogger;
-use Symfony\Component\Console\Helper\Table;
-use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -453,22 +451,6 @@ class ImportCommand extends Command
 
             $operations = $userContext->mapper->commit();
 
-            $a = [
-                [
-                    'Type' => ucfirst(iState::TYPE_MOVIE),
-                    'Added' => $operations[iState::TYPE_MOVIE]['added'] ?? '-',
-                    'Updated' => $operations[iState::TYPE_MOVIE]['updated'] ?? '-',
-                    'Failed' => $operations[iState::TYPE_MOVIE]['failed'] ?? '-',
-                ],
-                new TableSeparator(),
-                [
-                    'Type' => ucfirst(iState::TYPE_EPISODE),
-                    'Added' => $operations[iState::TYPE_EPISODE]['added'] ?? '-',
-                    'Updated' => $operations[iState::TYPE_EPISODE]['updated'] ?? '-',
-                    'Failed' => $operations[iState::TYPE_EPISODE]['failed'] ?? '-',
-                ],
-            ];
-
             Message::reset();
             $userContext->mapper->reset();
 
@@ -485,13 +467,22 @@ class ImportCommand extends Command
                 ],
             );
 
-            $output->writeln('');
-            new Table($output)
-                ->setHeaders(array_keys($a[0]))
-                ->setStyle('box')
-                ->setRows(array_values($a))
-                ->render();
-            $output->writeln('');
+            $this->logger->notice(
+                "SYSTEM: Imported '{user}' play states: {movie.added} added, {movie.updated} updated, {movie.failed} failed (movies); {episode.added} added, {episode.updated} updated, {episode.failed} failed (episodes).",
+                [
+                    'user' => $userContext->name,
+                    'movie' => [
+                        'added' => $operations[iState::TYPE_MOVIE]['added'] ?? 0,
+                        'updated' => $operations[iState::TYPE_MOVIE]['updated'] ?? 0,
+                        'failed' => $operations[iState::TYPE_MOVIE]['failed'] ?? 0,
+                    ],
+                    'episode' => [
+                        'added' => $operations[iState::TYPE_EPISODE]['added'] ?? 0,
+                        'updated' => $operations[iState::TYPE_EPISODE]['updated'] ?? 0,
+                        'failed' => $operations[iState::TYPE_EPISODE]['failed'] ?? 0,
+                    ],
+                ],
+            );
 
             if (false === $input->getOption('dry-run')) {
                 $userContext->config->persist();

--- a/src/Commands/State/PlaylistCommand.php
+++ b/src/Commands/State/PlaylistCommand.php
@@ -21,7 +21,6 @@ use App\Libs\UserContext;
 use Monolog\Level;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface as iLogger;
-use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -214,15 +213,19 @@ class PlaylistCommand extends Command
             }
 
             foreach ($results as $backend => $stats) {
-                $rows[] = [
-                    'User' => $userContext->name,
-                    'Backend' => $backend,
-                    'Playlists' => $stats['playlists'],
-                    'Items' => $stats['items'],
-                    'Added' => true === $dryRun ? '-' : $stats['added'],
-                    'Updated' => true === $dryRun ? '-' : $stats['updated'],
-                    'Removed' => true === $dryRun ? '-' : $stats['removed'],
-                ];
+                $rows[] = $backend;
+                $this->logger->notice(
+                    "SYSTEM: Synced '{user}@{backend}' playlists: {playlists} playlists, {items} items, {added} added, {updated} updated, {removed} removed.",
+                    [
+                        'user' => $userContext->name,
+                        'backend' => $backend,
+                        'playlists' => $stats['playlists'],
+                        'items' => $stats['items'],
+                        'added' => true === $dryRun ? 0 : $stats['added'],
+                        'updated' => true === $dryRun ? 0 : $stats['updated'],
+                        'removed' => true === $dryRun ? 0 : $stats['removed'],
+                    ],
+                );
             }
 
             if (false === $dryRun) {
@@ -254,15 +257,9 @@ class PlaylistCommand extends Command
             $this->logger->notice('SYSTEM: Using WatchState {full_version}', [
                 'full_version' => get_full_version(),
             ]);
-            $output->writeln('<comment>No matching backends produced syncable playlists.</comment>');
+            $this->logger->notice('SYSTEM: No matching backends produced syncable playlists.');
             return self::SUCCESS;
         }
-
-        new Table($output)
-            ->setStyle('box')
-            ->setHeaders(array_keys($rows[0]))
-            ->setRows($rows)
-            ->render();
 
         $this->logger->notice("SYSTEM: Playlist sync process completed in '{duration}'s for all users.", [
             'duration' => round(microtime(true) - $totalStart, 4),

--- a/tests/Commands/State/PlaylistCommandTest.php
+++ b/tests/Commands/State/PlaylistCommandTest.php
@@ -24,6 +24,8 @@ final class PlaylistCommandTest extends TestCase
 {
     public function test_summary(): void
     {
+        $this->initTempDir();
+
         $service = $this->makeServiceMock();
         $service
             ->expects(self::once())
@@ -57,16 +59,21 @@ final class PlaylistCommandTest extends TestCase
         $client->method('getName')->willReturn('test_plex');
         $client->method('getType')->willReturn('plex');
 
+        $logfile = self::$tmpPath . '/playlist-summary.txt';
+        touch($logfile);
+
         $tester = $this->makeTester($service, $client);
-        $status = $tester->execute([]);
+        $status = $tester->execute(['--logfile' => $logfile], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE]);
 
         self::assertSame(PlaylistCommand::SUCCESS, $status);
-        self::assertStringContainsString('test_plex', $tester->getDisplay());
-        self::assertStringContainsString('Playlists', $tester->getDisplay());
+        self::assertStringContainsString('Synced', file_get_contents($logfile));
+        self::assertStringContainsString('playlists,', file_get_contents($logfile));
     }
 
     public function test_skips_disabled_backend(): void
     {
+        $this->initTempDir();
+
         $service = $this->makeServiceMock();
         $service
             ->expects(self::once())
@@ -87,11 +94,14 @@ final class PlaylistCommandTest extends TestCase
             )
             ->willReturn([]);
 
+        $logfile = self::$tmpPath . '/playlist-skip.txt';
+        touch($logfile);
+
         $tester = $this->makeTester($service, $this->createStub(iClient::class), 'test_disabled');
-        $status = $tester->execute([]);
+        $status = $tester->execute(['--logfile' => $logfile], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE]);
 
         self::assertSame(PlaylistCommand::SUCCESS, $status);
-        self::assertStringContainsString('No matching backends produced syncable playlists.', $tester->getDisplay());
+        self::assertStringContainsString('No matching backends produced syncable playlists.', file_get_contents($logfile));
     }
 
     public function test_disabled_passed_empty(): void


### PR DESCRIPTION
* Removed usage of tables in both `ImportCommand` and `PlaylistCommand`.
