### PR TITLE
Refactor progress handling, session management, and logging

### DIFF
--- a/frontend/app/components/BackendEditForm.vue
+++ b/frontend/app/components/BackendEditForm.vue
@@ -941,7 +941,7 @@ const loadContent = async (): Promise<void> => {
       return;
     }
 
-    if (!json?.options || 'object' !== typeof json.options) {
+    if (!json?.options || 'object' !== typeof json.options || Array.isArray(json.options)) {
       json.options = {};
     }
 

--- a/src/Backends/Emby/Action/Progress.php
+++ b/src/Backends/Emby/Action/Progress.php
@@ -297,7 +297,7 @@ class Progress
                             $statusCode = $response->getStatusCode();
 
                             if (false === in_array(Status::tryFrom($statusCode), [Status::OK, Status::NO_CONTENT], true)) {
-                                $this->logger->error(
+                                $this->logger->warning(
                                     message: "Request to change '{identity.user}@{identity.backend}' {history.type} '{history.title}' watch progress returned HTTP {response.status_code}.",
                                     context: [
                                         ...$requestContext,

--- a/src/Backends/Emby/Action/Progress.php
+++ b/src/Backends/Emby/Action/Progress.php
@@ -17,7 +17,6 @@ use App\Libs\Enums\Http\Method;
 use App\Libs\Enums\Http\Status;
 use App\Libs\Exceptions\Backends\InvalidArgumentException;
 use App\Libs\Exceptions\Backends\RuntimeException;
-use App\Libs\Extends\Date;
 use App\Libs\Options;
 use App\Libs\QueueRequests;
 use DateTimeInterface;
@@ -199,10 +198,11 @@ class Progress
             $unwatchFirst = false;
 
             try {
+                $remoteData = $this->getItemDetails($context, $logContext['remote']['id'], [Options::NO_CACHE => true]);
                 $remoteItem = $this->createEntity(
                     $context,
                     $guid,
-                    $this->getItemDetails($context, $logContext['remote']['id'], [Options::NO_CACHE => true]),
+                    $remoteData,
                     ['latest_date' => true],
                 );
 
@@ -257,12 +257,19 @@ class Progress
             }
 
             try {
-                $url = $context->backendUrl->withPath(
-                    r('/Users/{user_id}/Items/{item_id}/UserData', [
+                $positionTicks = (string) floor($entity->getPlayProgress() * 1_00_00);
+                $url = $context
+                    ->backendUrl
+                    ->withPath(r('/Users/{user_id}/PlayingItems/{item_id}/Progress', [
                         'user_id' => $context->backendUser,
                         'item_id' => $logContext['remote']['id'],
-                    ]),
-                );
+                    ]))
+                    ->withQuery(http_build_query([
+                        'MediaSourceId' => ag($remoteData, ['MediaSources.0.Id', 'MediaSourceId', 'Id']),
+                        'PositionTicks' => $positionTicks,
+                        'IsPaused' => 'true',
+                        'PlayMethod' => 'DirectPlay',
+                    ]));
 
                 $logContext['request']['url'] = (string) $url;
 
@@ -271,8 +278,8 @@ class Progress
                     context: [
                         ...$logContext,
                         'progress' => format_duration($entity->getPlayProgress()),
-                        // -- convert secs to ms for emby to understand it.
-                        'time' => floor($entity->getPlayProgress() * 1_00_00),
+                        // -- convert milliseconds to ticks for Emby to understand it.
+                        'time' => $positionTicks,
                     ],
                 );
 
@@ -282,24 +289,10 @@ class Progress
                         'progress' => format_duration($entity->getPlayProgress()),
                     ];
 
-                    $json = [
-                        'PlaybackPositionTicks' => (string) floor($entity->getPlayProgress() * 1_00_00),
-                        'LastPlayedDate' => make_date($senderDate)->format(Date::ATOM),
-                    ];
-
-                    if (true === $unwatchFirst) {
-                        $json['Played'] = false;
-                    }
-
                     $progressRequest = new Request(
                         method: Method::POST,
                         url: $url,
-                        options: array_replace_recursive($context->getHttpOptions(), [
-                            'headers' => [
-                                'Content-Type' => 'application/json',
-                            ],
-                            'json' => $json,
-                        ]),
+                        options: $context->getHttpOptions(),
                         success: function (ResponseInterface $response) use ($requestContext): array {
                             $statusCode = $response->getStatusCode();
 

--- a/src/Backends/Emby/Action/Progress.php
+++ b/src/Backends/Emby/Action/Progress.php
@@ -17,6 +17,7 @@ use App\Libs\Enums\Http\Method;
 use App\Libs\Enums\Http\Status;
 use App\Libs\Exceptions\Backends\InvalidArgumentException;
 use App\Libs\Exceptions\Backends\RuntimeException;
+use App\Libs\Extends\Date;
 use App\Libs\Options;
 use App\Libs\QueueRequests;
 use DateTimeInterface;
@@ -257,19 +258,12 @@ class Progress
             }
 
             try {
-                $positionTicks = (string) floor($entity->getPlayProgress() * 1_00_00);
-                $url = $context
-                    ->backendUrl
-                    ->withPath(r('/Users/{user_id}/PlayingItems/{item_id}/Progress', [
+                $url = $context->backendUrl->withPath(
+                    r('/Users/{user_id}/Items/{item_id}/UserData', [
                         'user_id' => $context->backendUser,
                         'item_id' => $logContext['remote']['id'],
-                    ]))
-                    ->withQuery(http_build_query([
-                        'MediaSourceId' => ag($remoteData, ['MediaSources.0.Id', 'MediaSourceId', 'Id']),
-                        'PositionTicks' => $positionTicks,
-                        'IsPaused' => 'true',
-                        'PlayMethod' => 'DirectPlay',
-                    ]));
+                    ]),
+                );
 
                 $logContext['request']['url'] = (string) $url;
 
@@ -279,7 +273,7 @@ class Progress
                         ...$logContext,
                         'progress' => format_duration($entity->getPlayProgress()),
                         // -- convert milliseconds to ticks for Emby to understand it.
-                        'time' => $positionTicks,
+                        'time' => floor($entity->getPlayProgress() * 1_00_00),
                     ],
                 );
 
@@ -289,10 +283,24 @@ class Progress
                         'progress' => format_duration($entity->getPlayProgress()),
                     ];
 
+                    $json = [
+                        'PlaybackPositionTicks' => (string) floor($entity->getPlayProgress() * 1_00_00),
+                        'LastPlayedDate' => make_date($senderDate)->format(Date::ATOM),
+                    ];
+
+                    if (true === $unwatchFirst) {
+                        $json['Played'] = false;
+                    }
+
                     $progressRequest = new Request(
                         method: Method::POST,
                         url: $url,
-                        options: $context->getHttpOptions(),
+                        options: array_replace_recursive($context->getHttpOptions(), [
+                            'headers' => [
+                                'Content-Type' => 'application/json',
+                            ],
+                            'json' => $json,
+                        ]),
                         success: function (ResponseInterface $response) use ($requestContext): array {
                             $statusCode = $response->getStatusCode();
 

--- a/src/Backends/Jellyfin/Action/Export.php
+++ b/src/Backends/Jellyfin/Action/Export.php
@@ -7,6 +7,8 @@ namespace App\Backends\Jellyfin\Action;
 use App\Backends\Common\Context;
 use App\Backends\Common\GuidInterface as iGuid;
 use App\Backends\Common\Request;
+use App\Backends\Emby\Action\GetSessions as EmbyGetSessions;
+use App\Backends\Emby\EmbyClient;
 use App\Backends\Jellyfin\JellyfinClient;
 use App\Backends\Jellyfin\JellyfinClient as JFC;
 use App\Libs\Container;
@@ -75,6 +77,7 @@ class Export extends Import
 
             $queue = ag($opts, 'queue', static fn() => Container::get(QueueRequests::class));
             $after = ag($opts, 'after', null);
+            $sessions = $this->getActiveSessions($context);
 
             Message::increment("{$context->backendName}.{$mappedType}.total");
 
@@ -185,6 +188,41 @@ class Export extends Import
             }
 
             if ($rItem->watched === $entity->watched) {
+                $remoteProgress = (int) ag($item, 'UserData.PlaybackPositionTicks', 0);
+                if (true === $entity->isWatched() && true === $rItem->isWatched() && $remoteProgress > 0) {
+                    if (true === array_key_exists((string) ag($item, 'Id'), $sessions)) {
+                        $this->logger->notice(
+                            message: "Not clearing '{identity.user}@{identity.backend}' {item.type} '{item.title}' watched item progress. The item is playing right now.",
+                            context: [
+                                ...$logContext,
+                                'operation' => 'export.skip',
+                                'error' => 'currently_playing',
+                            ],
+                        );
+
+                        return;
+                    }
+
+                    $lastPlayed = make_date($entity->updated)->format(Date::ATOM);
+                    $playState = 'Played';
+                    $requestContext = $logContext + ['play_state' => $playState];
+
+                    if (true === (bool) ag($context->options, Options::DRY_RUN, false)) {
+                        $this->logger->notice(
+                            message: "Queuing request to clear '{identity.user}@{identity.backend}' {item.type} '{item.title}' watched item progress.",
+                            context: [
+                                ...$requestContext,
+                                'progress' => format_duration((int) floor($remoteProgress / 1_00_00)),
+                            ],
+                        );
+                        return;
+                    }
+
+                    Message::increment("{$context->userContext->name}.{$context->backendName}.export");
+                    $queue->add($this->createProgressResetRequest($context, $item, $lastPlayed));
+                    return;
+                }
+
                 if (true === (bool) ag($context->options, Options::DEBUG_TRACE)) {
                     $this->logger->debug(
                         message: "Ignoring '{identity.user}@{identity.backend}' - '{item.title}'. {item.type} play state is identical.",
@@ -228,6 +266,11 @@ class Export extends Import
             if ($context->clientName === JellyfinClient::CLIENT_NAME) {
                 $url = $url->withQuery(http_build_query(['DatePlayed' => $lastPlayed]));
             }
+            if ($context->clientName === EmbyClient::CLIENT_NAME) {
+                $url = $url->withQuery(http_build_query([
+                    'DatePlayed' => make_date($entity->updated)->format('YmdHis'),
+                ]));
+            }
 
             $logContext['item']['url'] = $url;
 
@@ -249,7 +292,7 @@ class Export extends Import
                     method: $entity->isWatched() ? Method::POST : Method::DELETE,
                     url: $url,
                     options: $context->getHttpOptions(),
-                    success: function (iResponse $response) use ($context, $entity, $item, $lastPlayed, $requestContext): array {
+                    success: function (iResponse $response) use ($context, $entity, $item, $lastPlayed, $requestContext, $sessions): array {
                         $statusCode = $response->getStatusCode();
 
                         if (Status::OK !== Status::tryFrom($statusCode)) {
@@ -273,24 +316,12 @@ class Export extends Import
                             return [];
                         }
 
+                        if (true === array_key_exists((string) ag($item, 'Id'), $sessions)) {
+                            return [];
+                        }
+
                         return [
-                            new Request(
-                                method: Method::POST,
-                                url: $context->backendUrl->withPath(r('/Users/{user}/Items/{id}/UserData', [
-                                    'user' => $context->backendUser,
-                                    'id' => ag($item, 'Id'),
-                                ])),
-                                options: $context->getHttpOptions()
-                                + [
-                                    'json' => [
-                                        'Played' => true,
-                                        'PlaybackPositionTicks' => 0,
-                                        'LastPlayedDate' => $lastPlayed,
-                                    ],
-                                    'user_data' => [Options::NO_LOGGING => true],
-                                ],
-                                extras: [iHttp::class => $this->http],
-                            ),
+                            $this->createProgressResetRequest($context, $item, $lastPlayed),
                         ];
                     },
                     error: function (Throwable $e) use ($requestContext): array {
@@ -325,5 +356,76 @@ class Export extends Import
                 ),
             );
         }
+    }
+
+    private function getActiveSessions(Context $context): array
+    {
+        $sessions = [];
+
+        try {
+            $action = EmbyClient::CLIENT_NAME === $context->clientName ? EmbyGetSessions::class : GetSessions::class;
+            $remoteSessions = Container::get($action)($context);
+            if (true !== $remoteSessions->status) {
+                return [];
+            }
+
+            foreach (ag($remoteSessions->response, 'sessions', []) as $session) {
+                $userId = ag($session, 'user_id', null);
+                if (!$userId || $context->backendUser !== $userId) {
+                    continue;
+                }
+
+                $sessions[(string) ag($session, 'item_id')] = ag($session, 'item_offset_at', 0);
+            }
+        } catch (Throwable) {
+            return [];
+        }
+
+        return $sessions;
+    }
+
+    private function createProgressResetRequest(Context $context, array $item, string $lastPlayed): Request
+    {
+        if (EmbyClient::CLIENT_NAME === $context->clientName) {
+            $url = $context
+                ->backendUrl
+                ->withPath(r('/Users/{user}/PlayingItems/{id}/Progress', [
+                    'user' => $context->backendUser,
+                    'id' => ag($item, 'Id'),
+                ]))
+                ->withQuery(http_build_query([
+                    'MediaSourceId' => ag($item, ['MediaSources.0.Id', 'MediaSourceId', 'Id']),
+                    'PositionTicks' => 0,
+                    'IsPaused' => 'true',
+                    'PlayMethod' => 'DirectPlay',
+                ]));
+
+            return new Request(
+                method: Method::POST,
+                url: $url,
+                options: array_replace_recursive($context->getHttpOptions(), [
+                    'user_data' => [Options::NO_LOGGING => true],
+                ]),
+                extras: [iHttp::class => $this->http],
+            );
+        }
+
+        return new Request(
+            method: Method::POST,
+            url: $context->backendUrl->withPath(r('/Users/{user}/Items/{id}/UserData', [
+                'user' => $context->backendUser,
+                'id' => ag($item, 'Id'),
+            ])),
+            options: $context->getHttpOptions()
+            + [
+                'json' => [
+                    'Played' => true,
+                    'PlaybackPositionTicks' => 0,
+                    'LastPlayedDate' => $lastPlayed,
+                ],
+                'user_data' => [Options::NO_LOGGING => true],
+            ],
+            extras: [iHttp::class => $this->http],
+        );
     }
 }

--- a/src/Backends/Jellyfin/Action/Export.php
+++ b/src/Backends/Jellyfin/Action/Export.php
@@ -296,7 +296,7 @@ class Export extends Import
                         $statusCode = $response->getStatusCode();
 
                         if (Status::OK !== Status::tryFrom($statusCode)) {
-                            $this->logger->error(
+                            $this->logger->warning(
                                 message: "Request to change '{identity.user}@{identity.backend}' {item.type} '{item.title}' play state returned HTTP {response.status_code}.",
                                 context: [
                                     ...$requestContext,

--- a/src/Backends/Jellyfin/Action/Push.php
+++ b/src/Backends/Jellyfin/Action/Push.php
@@ -8,7 +8,10 @@ use App\Backends\Common\CommonTrait;
 use App\Backends\Common\Context;
 use App\Backends\Common\Request;
 use App\Backends\Common\Response;
+use App\Backends\Emby\Action\GetSessions as EmbyGetSessions;
+use App\Backends\Emby\EmbyClient;
 use App\Backends\Jellyfin\JellyfinClient as JFC;
+use App\Libs\Container;
 use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Enums\Http\Method;
 use App\Libs\Enums\Http\Status;
@@ -83,6 +86,7 @@ class Push
         ?DateTimeInterface $after = null,
     ): Response {
         $requests = [];
+        $sessions = $this->getActiveSessions($context);
 
         foreach ($entities as $key => $entity) {
             if (true !== $entity instanceof iState) {
@@ -220,6 +224,39 @@ class Push
                 $isWatched = (int) (bool) ag($json, 'UserData.Played', false);
 
                 if ($entity->watched === $isWatched) {
+                    $remoteProgress = (int) ag($json, 'UserData.PlaybackPositionTicks', 0);
+                    if (true === $entity->isWatched() && $remoteProgress > 0) {
+                        if (true === array_key_exists((string) ag($json, 'Id'), $sessions)) {
+                            $this->logger->notice(
+                                message: "Not clearing '{identity.user}@{identity.backend}' {history.type} '#{history.id}: {history.title}' watched item progress. The item is playing right now.",
+                                context: [
+                                    ...$logContext,
+                                    'operation' => 'push.skip',
+                                    'error' => 'currently_playing',
+                                ],
+                            );
+
+                            continue;
+                        }
+
+                        $lastPlayed = make_date($entity->updated)->format(Date::ATOM);
+                        $requestContext = $logContext + ['play_state' => 'Played'];
+
+                        $this->logger->debug(
+                            message: "Queuing request to clear '{identity.user}@{identity.backend}' {history.type} '#{history.id}: {history.title}' watched item progress.",
+                            context: [
+                                ...$requestContext,
+                                'progress' => format_duration((int) floor($remoteProgress / 1_00_00)),
+                            ],
+                        );
+
+                        if (false === (bool) ag($context->options, Options::DRY_RUN, false)) {
+                            $queue->add($this->createProgressResetRequest($context, $json, $lastPlayed));
+                        }
+
+                        continue;
+                    }
+
                     $this->logger->info(
                         message: "Ignoring '{identity.user}@{identity.backend}' {history.type} '#{history.id}: {history.title}'. Play state is identical.",
                         context: [
@@ -281,6 +318,11 @@ class Push
                 if ($context->clientName === JFC::CLIENT_NAME) {
                     $url = $url->withQuery(http_build_query(['DatePlayed' => $lastPlayed]));
                 }
+                if ($context->clientName === EmbyClient::CLIENT_NAME) {
+                    $url = $url->withQuery(http_build_query([
+                        'DatePlayed' => make_date($entity->updated)->format('YmdHis'),
+                    ]));
+                }
 
                 $logContext['request']['url'] = (string) $url;
                 $playState = $entity->isWatched() ? 'Played' : 'Unplayed';
@@ -297,7 +339,7 @@ class Push
                             method: $entity->isWatched() ? Method::POST : Method::DELETE,
                             url: $url,
                             options: $context->getHttpOptions(),
-                            success: function (ResponseInterface $response) use ($context, $entity, $json, $lastPlayed): array {
+                            success: function (ResponseInterface $response) use ($context, $entity, $json, $lastPlayed, $sessions): array {
                                 if (Status::OK !== Status::tryFrom($response->getStatusCode())) {
                                     return [];
                                 }
@@ -306,24 +348,12 @@ class Push
                                     return [];
                                 }
 
+                                if (true === array_key_exists((string) ag($json, 'Id'), $sessions)) {
+                                    return [];
+                                }
+
                                 return [
-                                    new Request(
-                                        method: Method::POST,
-                                        url: $context->backendUrl->withPath(r('/Users/{user}/Items/{id}/UserData', [
-                                            'user' => $context->backendUser,
-                                            'id' => ag($json, 'Id'),
-                                        ])),
-                                        options: $context->getHttpOptions()
-                                        + [
-                                            'json' => [
-                                                'Played' => true,
-                                                'PlaybackPositionTicks' => 0,
-                                                'LastPlayedDate' => $lastPlayed,
-                                            ],
-                                            'user_data' => [Options::NO_LOGGING => true],
-                                        ],
-                                        extras: [iHttp::class => $this->http],
-                                    ),
+                                    $this->createProgressResetRequest($context, $json, $lastPlayed),
                                 ];
                             },
                             extras: [
@@ -348,5 +378,76 @@ class Push
         }
 
         return new Response(status: true, response: $queue);
+    }
+
+    private function getActiveSessions(Context $context): array
+    {
+        $sessions = [];
+
+        try {
+            $action = EmbyClient::CLIENT_NAME === $context->clientName ? EmbyGetSessions::class : GetSessions::class;
+            $remoteSessions = Container::get($action)($context);
+            if (true !== $remoteSessions->status) {
+                return [];
+            }
+
+            foreach (ag($remoteSessions->response, 'sessions', []) as $session) {
+                $userId = ag($session, 'user_id', null);
+                if (!$userId || $context->backendUser !== $userId) {
+                    continue;
+                }
+
+                $sessions[(string) ag($session, 'item_id')] = ag($session, 'item_offset_at', 0);
+            }
+        } catch (Throwable) {
+            return [];
+        }
+
+        return $sessions;
+    }
+
+    private function createProgressResetRequest(Context $context, array $item, string $lastPlayed): Request
+    {
+        if (EmbyClient::CLIENT_NAME === $context->clientName) {
+            $url = $context
+                ->backendUrl
+                ->withPath(r('/Users/{user}/PlayingItems/{id}/Progress', [
+                    'user' => $context->backendUser,
+                    'id' => ag($item, 'Id'),
+                ]))
+                ->withQuery(http_build_query([
+                    'MediaSourceId' => ag($item, ['MediaSources.0.Id', 'MediaSourceId', 'Id']),
+                    'PositionTicks' => 0,
+                    'IsPaused' => 'true',
+                    'PlayMethod' => 'DirectPlay',
+                ]));
+
+            return new Request(
+                method: Method::POST,
+                url: $url,
+                options: array_replace_recursive($context->getHttpOptions(), [
+                    'user_data' => [Options::NO_LOGGING => true],
+                ]),
+                extras: [iHttp::class => $this->http],
+            );
+        }
+
+        return new Request(
+            method: Method::POST,
+            url: $context->backendUrl->withPath(r('/Users/{user}/Items/{id}/UserData', [
+                'user' => $context->backendUser,
+                'id' => ag($item, 'Id'),
+            ])),
+            options: $context->getHttpOptions()
+            + [
+                'json' => [
+                    'Played' => true,
+                    'PlaybackPositionTicks' => 0,
+                    'LastPlayedDate' => $lastPlayed,
+                ],
+                'user_data' => [Options::NO_LOGGING => true],
+            ],
+            extras: [iHttp::class => $this->http],
+        );
     }
 }

--- a/src/Backends/Jellyfin/Action/UpdateState.php
+++ b/src/Backends/Jellyfin/Action/UpdateState.php
@@ -8,6 +8,7 @@ use App\Backends\Common\CommonTrait;
 use App\Backends\Common\Context;
 use App\Backends\Common\Request;
 use App\Backends\Common\Response;
+use App\Backends\Emby\EmbyClient;
 use App\Backends\Jellyfin\JellyfinClient;
 use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Enums\Http\Method;
@@ -80,6 +81,13 @@ class UpdateState
                         $url = $url->withQuery(
                             http_build_query([
                                 'DatePlayed' => make_date($entity->updated)->format(Date::ATOM),
+                            ]),
+                        );
+                    }
+                    if ($context->clientName === EmbyClient::CLIENT_NAME) {
+                        $url = $url->withQuery(
+                            http_build_query([
+                                'DatePlayed' => make_date($entity->updated)->format('YmdHis'),
                             ]),
                         );
                     }

--- a/src/Backends/Plex/Action/Export.php
+++ b/src/Backends/Plex/Action/Export.php
@@ -168,6 +168,7 @@ final class Export extends Import
             }
 
             if ($rItem->watched === $entity->watched) {
+                // NOTE: If Plex ever keeps a non-zero viewOffset on watched items, this skip path is where to add cleanup.
                 if (true === (bool) ag($context->options, Options::DEBUG_TRACE)) {
                     $this->logger->debug(
                         message: "Ignoring '{identity.client}: {identity.backend}' - '{item.title}'. {item.type} play state is identical.",

--- a/src/Backends/Plex/Action/Export.php
+++ b/src/Backends/Plex/Action/Export.php
@@ -222,7 +222,7 @@ final class Export extends Import
                         $statusCode = $response->getStatusCode();
 
                         if (Status::OK !== Status::tryFrom($statusCode)) {
-                            $this->logger->error(
+                            $this->logger->warning(
                                 message: "Request to change '{identity.user}@{identity.backend}' {item.type} '{item.title}' play state returned HTTP {response.status_code}.",
                                 context: [
                                     ...$requestContext,

--- a/src/Backends/Plex/Action/Push.php
+++ b/src/Backends/Plex/Action/Push.php
@@ -199,6 +199,7 @@ final class Push
                 $isWatched = 0 === (int) ag($json, 'viewCount', 0) ? 0 : 1;
 
                 if ($entity->watched === $isWatched) {
+                    // NOTE: If Plex ever keeps a non-zero viewOffset on watched items, this skip path is where to add cleanup.
                     $this->logger->info(
                         message: "Ignoring '{identity.user}@{identity.backend}' {history.type} '#{history.id}: {history.title}'. Play state is identical.",
                         context: [

--- a/src/Commands/State/ExportCommand.php
+++ b/src/Commands/State/ExportCommand.php
@@ -554,7 +554,7 @@ class ExportCommand extends Command
                                 $context['response']['status_code'] = $response->getStatusCode();
 
                                 if (Status::OK !== Status::tryFrom($context['response']['status_code'])) {
-                                    $logger->error(
+                                    $logger->warning(
                                         "Request to change '{identity.user}@{identity.backend}' - '#{history.id}: {history.title}' play state returned HTTP {response.status_code}.",
                                         $context,
                                     );

--- a/src/Listeners/ProcessProgressEvent.php
+++ b/src/Listeners/ProcessProgressEvent.php
@@ -288,7 +288,7 @@ final readonly class ProcessProgressEvent
 
                     if (false === in_array(Status::tryFrom($statusCode), [Status::OK, Status::NO_CONTENT], true)) {
                         $writer(
-                            Level::Error,
+                            Level::Warning,
                             "Request to change '{identity.user}@{identity.backend}' - '#{id}: {history.title}' watch progress returned HTTP {response.status_code}.",
                             [
                                 ...$context,

--- a/src/Listeners/ProcessPushEvent.php
+++ b/src/Listeners/ProcessPushEvent.php
@@ -222,7 +222,7 @@ final readonly class ProcessPushEvent
 
                     if (Status::OK !== Status::tryFrom($context['response']['status_code'])) {
                         $writer(
-                            Level::Error,
+                            Level::Warning,
                             "Request to change '{identity.user}@{identity.backend}' - '#{history.id}: {history.title}' play state returned HTTP {response.status_code}.",
                             $context,
                         );

--- a/tests/Backends/MediaBrowser/ExportFlowTest.php
+++ b/tests/Backends/MediaBrowser/ExportFlowTest.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace Tests\Backends\MediaBrowser;
 
 use App\Backends\Common\Request;
+use App\Backends\Common\Response;
 use App\Backends\Emby\Action\Export as EmbyExport;
+use App\Backends\Emby\Action\GetSessions as EmbyGetSessions;
 use App\Backends\Emby\EmbyGuid;
 use App\Backends\Jellyfin\Action\Export as JellyfinExport;
+use App\Backends\Jellyfin\Action\GetSessions as JellyfinGetSessions;
 use App\Backends\Jellyfin\JellyfinGuid;
+use App\Libs\Container;
 use App\Libs\Entity\StateEntity;
 use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Extends\HttpClient;
@@ -56,11 +60,91 @@ class ExportFlowTest extends MediaBrowserTestCase
             $request = $queue->getQueue()[0];
             $this->assertSame('POST', $request->method->value);
             $this->assertStringContainsString('/Users/user-1/PlayedItems/item-1', (string) $request->url);
+            $this->assertStringContainsString('DatePlayed=', (string) $request->url);
 
             $followUps = ($request->success)(new MockResponse('', ['http_code' => 200]));
             $this->assertCount(1, $followUps);
             $this->assertContainsOnlyInstancesOf(Request::class, $followUps);
-            $this->assertStringContainsString('/Users/user-1/Items/item-1/UserData', (string) $followUps[0]->url);
+            $this->assertProgressResetRequest($clientName, $followUps[0]);
+        }
+    }
+
+    public function test_export_played_resets_progress(): void
+    {
+        foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass]) {
+            $context = $this->makeContext($clientName, [Options::IGNORE_DATE => true]);
+            $queue = new QueueRequests();
+
+            $localEntity = $this->makeLocalEntity($context, watched: 1, updated: 2000);
+            $mapper = $this->buildMapper($context, $localEntity);
+
+            $item = $this->fixture('metadata');
+            $item['UserData']['Played'] = true;
+            $item['UserData']['PlaybackPositionTicks'] = 900000000;
+            $item['UserData']['LastPlayedDate'] = '2024-01-02T00:00:00Z';
+
+            $action = new $actionClass($this->makeQueueHttp(), $this->logger);
+            $guid = new $guidClass($this->logger)->withContext($context);
+
+            $this->invokeProcess(
+                $action,
+                $context,
+                $guid,
+                $mapper,
+                $item,
+                ['library' => ['id' => 'lib-1']],
+                ['queue' => $queue],
+            );
+
+            $this->assertSame(1, $queue->count());
+            $this->assertContainsOnlyInstancesOf(Request::class, $queue->getQueue());
+            $this->assertProgressResetRequest($clientName, $queue->getQueue()[0]);
+        }
+    }
+
+    public function test_export_played_skips_active(): void
+    {
+        foreach ($this->provideBackends() as [$clientName, $actionClass, $guidClass, $sessionsClass]) {
+            Container::add($sessionsClass, fn() => new class() {
+                public function __invoke(): Response
+                {
+                    return new Response(status: true, response: [
+                        'sessions' => [
+                            [
+                                'item_id' => 'item-1',
+                                'item_offset_at' => 1000,
+                                'user_id' => 'user-1',
+                            ],
+                        ],
+                    ]);
+                }
+            });
+
+            $context = $this->makeContext($clientName, [Options::IGNORE_DATE => true]);
+            $queue = new QueueRequests();
+
+            $localEntity = $this->makeLocalEntity($context, watched: 1, updated: 2000);
+            $mapper = $this->buildMapper($context, $localEntity);
+
+            $item = $this->fixture('metadata');
+            $item['UserData']['Played'] = true;
+            $item['UserData']['PlaybackPositionTicks'] = 900000000;
+            $item['UserData']['LastPlayedDate'] = '2024-01-02T00:00:00Z';
+
+            $action = new $actionClass($this->makeQueueHttp(), $this->logger);
+            $guid = new $guidClass($this->logger)->withContext($context);
+
+            $this->invokeProcess(
+                $action,
+                $context,
+                $guid,
+                $mapper,
+                $item,
+                ['library' => ['id' => 'lib-1']],
+                ['queue' => $queue],
+            );
+
+            $this->assertSame(0, $queue->count());
         }
     }
 
@@ -75,6 +159,7 @@ class ExportFlowTest extends MediaBrowserTestCase
 
             $item = $this->fixture('metadata');
             $item['UserData']['Played'] = true;
+            $item['UserData']['PlaybackPositionTicks'] = 0;
             $item['UserData']['LastPlayedDate'] = '2024-01-02T00:00:00Z';
 
             $http = $this->makeQueueHttp();
@@ -107,6 +192,7 @@ class ExportFlowTest extends MediaBrowserTestCase
 
             $item = $this->fixture('metadata');
             $item['UserData']['Played'] = true;
+            $item['UserData']['PlaybackPositionTicks'] = 0;
             $item['UserData']['LastPlayedDate'] = '2024-01-02T00:00:00Z';
 
             $action = new $actionClass($this->makeQueueHttp(), $this->logger);
@@ -267,6 +353,20 @@ class ExportFlowTest extends MediaBrowserTestCase
         ));
     }
 
+    private function assertProgressResetRequest(string $clientName, Request $request): void
+    {
+        $this->assertSame('POST', $request->method->value);
+
+        if ('Emby' === $clientName) {
+            $this->assertStringContainsString('/Users/user-1/PlayingItems/item-1/Progress', (string) $request->url);
+            $this->assertStringContainsString('PositionTicks=0', (string) $request->url);
+            return;
+        }
+
+        $this->assertStringContainsString('/Users/user-1/Items/item-1/UserData', (string) $request->url);
+        $this->assertSame(0, $request->options['json']['PlaybackPositionTicks']);
+    }
+
     private function makeLocalEntity(\App\Backends\Common\Context $context, int $watched, int $updated): iState
     {
         return StateEntity::fromArray([
@@ -310,8 +410,8 @@ class ExportFlowTest extends MediaBrowserTestCase
     private function provideBackends(): array
     {
         return [
-            ['Jellyfin', JellyfinExport::class, JellyfinGuid::class],
-            ['Emby',     EmbyExport::class,     EmbyGuid::class],
+            ['Jellyfin', JellyfinExport::class, JellyfinGuid::class, JellyfinGetSessions::class],
+            ['Emby',     EmbyExport::class,     EmbyGuid::class,     EmbyGetSessions::class],
         ];
     }
 }

--- a/tests/Backends/MediaBrowser/ProgressQueueTest.php
+++ b/tests/Backends/MediaBrowser/ProgressQueueTest.php
@@ -92,6 +92,7 @@ class ProgressQueueTest extends MediaBrowserTestCase
             $this->assertTrue($result->isSuccessful());
             $this->assertSame(1, $queue->count());
             $this->assertContainsOnlyInstancesOf(Request::class, $queue->getQueue());
+            $this->assertProgressRequest($clientName, $queue->getQueue()[0], '700000000');
         }
     }
 
@@ -171,9 +172,24 @@ class ProgressQueueTest extends MediaBrowserTestCase
             $this->assertCount(1, $followUps);
             $this->assertContainsOnlyInstancesOf(Request::class, $followUps);
             $this->assertSame('POST', $followUps[0]->method->value);
-            $this->assertStringContainsString('/Users/user-1/Items/item-1/UserData', (string) $followUps[0]->url);
-            $this->assertFalse($followUps[0]->options['json']['Played']);
-            $this->assertSame('700000000', $followUps[0]->options['json']['PlaybackPositionTicks']);
+            $this->assertProgressRequest($clientName, $followUps[0], '700000000');
+        }
+    }
+
+    private function assertProgressRequest(string $clientName, Request $request, string $positionTicks): void
+    {
+        if ('Emby' === $clientName) {
+            $this->assertStringContainsString('/Users/user-1/PlayingItems/item-1/Progress', (string) $request->url);
+            $this->assertStringContainsString('PositionTicks=' . $positionTicks, (string) $request->url);
+            $this->assertStringContainsString('MediaSourceId=item-1', (string) $request->url);
+            return;
+        }
+
+        $this->assertStringContainsString('/Users/user-1/Items/item-1/UserData', (string) $request->url);
+        $this->assertSame($positionTicks, $request->options['json']['PlaybackPositionTicks']);
+
+        if (array_key_exists('Played', $request->options['json'])) {
+            $this->assertFalse($request->options['json']['Played']);
         }
     }
 

--- a/tests/Backends/MediaBrowser/ProgressQueueTest.php
+++ b/tests/Backends/MediaBrowser/ProgressQueueTest.php
@@ -178,13 +178,6 @@ class ProgressQueueTest extends MediaBrowserTestCase
 
     private function assertProgressRequest(string $clientName, Request $request, string $positionTicks): void
     {
-        if ('Emby' === $clientName) {
-            $this->assertStringContainsString('/Users/user-1/PlayingItems/item-1/Progress', (string) $request->url);
-            $this->assertStringContainsString('PositionTicks=' . $positionTicks, (string) $request->url);
-            $this->assertStringContainsString('MediaSourceId=item-1', (string) $request->url);
-            return;
-        }
-
         $this->assertStringContainsString('/Users/user-1/Items/item-1/UserData', (string) $request->url);
         $this->assertSame($positionTicks, $request->options['json']['PlaybackPositionTicks']);
 

--- a/tests/Backends/MediaBrowser/PushEdgeCasesTest.php
+++ b/tests/Backends/MediaBrowser/PushEdgeCasesTest.php
@@ -48,6 +48,7 @@ class PushEdgeCasesTest extends MediaBrowserTestCase
             $entity = $this->makeEntity($context, watched: 1);
             $payload = $this->fixture('metadata');
             $payload['UserData']['Played'] = true;
+            $payload['UserData']['PlaybackPositionTicks'] = 0;
 
             $action = new $actionClass($this->makeHttpWithPayload($payload), $this->logger);
             $result = $action($context, [$entity], $queue);

--- a/tests/Backends/MediaBrowser/PushQueueTest.php
+++ b/tests/Backends/MediaBrowser/PushQueueTest.php
@@ -5,8 +5,12 @@ declare(strict_types=1);
 namespace Tests\Backends\MediaBrowser;
 
 use App\Backends\Common\Request;
+use App\Backends\Common\Response;
+use App\Backends\Emby\Action\GetSessions as EmbyGetSessions;
 use App\Backends\Emby\Action\Push as EmbyPush;
+use App\Backends\Jellyfin\Action\GetSessions as JellyfinGetSessions;
 use App\Backends\Jellyfin\Action\Push as JellyfinPush;
+use App\Libs\Container;
 use App\Libs\Entity\StateEntity;
 use App\Libs\Entity\StateInterface as iState;
 use App\Libs\Extends\HttpClient;
@@ -63,19 +67,149 @@ class PushQueueTest extends MediaBrowserTestCase
             $request = $queue->getQueue()[0];
             $this->assertSame('POST', $request->method->value);
             $this->assertStringContainsString('/Users/user-1/PlayedItems/item-1', (string) $request->url);
+            $this->assertStringContainsString('DatePlayed=', (string) $request->url);
 
             $followUps = ($request->success)(new MockResponse('', ['http_code' => 200]));
             $this->assertCount(1, $followUps);
             $this->assertContainsOnlyInstancesOf(Request::class, $followUps);
-            $this->assertStringContainsString('/Users/user-1/Items/item-1/UserData', (string) $followUps[0]->url);
+            $this->assertProgressResetRequest($clientName, $followUps[0]);
         }
+    }
+
+    public function test_push_played_resets_progress(): void
+    {
+        $payload = [
+            'Id' => 'item-1',
+            'UserData' => [
+                'Played' => true,
+                'PlaybackPositionTicks' => 900000000,
+                'LastPlayedDate' => '1970-01-01T00:00:01Z',
+            ],
+            'DateCreated' => '1970-01-01T00:00:01Z',
+        ];
+
+        foreach ($this->provideBackends() as [$clientName, $actionClass]) {
+            $http = new HttpClient(new MockHttpClient(
+                fn(string $method, string $url, array $options) => new MockResponse(
+                    json_encode($payload),
+                    [
+                        'http_code' => 200,
+                        'user_data' => $options['user_data'] ?? null,
+                    ],
+                ),
+            ));
+            $context = $this->makeContext($clientName);
+            $queue = new QueueRequests();
+
+            $entity = StateEntity::fromArray([
+                iState::COLUMN_TYPE => iState::TYPE_MOVIE,
+                iState::COLUMN_UPDATED => 2000,
+                iState::COLUMN_WATCHED => 1,
+                iState::COLUMN_VIA => $context->backendName,
+                iState::COLUMN_TITLE => 'Test Movie',
+                iState::COLUMN_META_DATA => [
+                    $context->backendName => [
+                        iState::COLUMN_ID => 'item-1',
+                        iState::COLUMN_TYPE => iState::TYPE_MOVIE,
+                        iState::COLUMN_WATCHED => '1',
+                        iState::COLUMN_TITLE => 'Test Movie',
+                    ],
+                ],
+            ]);
+
+            $action = new $actionClass($http, $this->logger);
+            $result = $action($context, [$entity], $queue);
+
+            $this->assertTrue($result->isSuccessful());
+            $this->assertSame(1, $queue->count());
+            $this->assertContainsOnlyInstancesOf(Request::class, $queue->getQueue());
+            $this->assertProgressResetRequest($clientName, $queue->getQueue()[0]);
+        }
+    }
+
+    public function test_push_played_skips_active(): void
+    {
+        $payload = [
+            'Id' => 'item-1',
+            'UserData' => [
+                'Played' => true,
+                'PlaybackPositionTicks' => 900000000,
+                'LastPlayedDate' => '1970-01-01T00:00:01Z',
+            ],
+            'DateCreated' => '1970-01-01T00:00:01Z',
+        ];
+
+        foreach ($this->provideBackends() as [$clientName, $actionClass, $sessionsClass]) {
+            Container::add($sessionsClass, fn() => new class() {
+                public function __invoke(): Response
+                {
+                    return new Response(status: true, response: [
+                        'sessions' => [
+                            [
+                                'item_id' => 'item-1',
+                                'item_offset_at' => 1000,
+                                'user_id' => 'user-1',
+                            ],
+                        ],
+                    ]);
+                }
+            });
+
+            $http = new HttpClient(new MockHttpClient(
+                fn(string $method, string $url, array $options) => new MockResponse(
+                    json_encode($payload),
+                    [
+                        'http_code' => 200,
+                        'user_data' => $options['user_data'] ?? null,
+                    ],
+                ),
+            ));
+            $context = $this->makeContext($clientName);
+            $queue = new QueueRequests();
+
+            $entity = StateEntity::fromArray([
+                iState::COLUMN_TYPE => iState::TYPE_MOVIE,
+                iState::COLUMN_UPDATED => 2000,
+                iState::COLUMN_WATCHED => 1,
+                iState::COLUMN_VIA => $context->backendName,
+                iState::COLUMN_TITLE => 'Test Movie',
+                iState::COLUMN_META_DATA => [
+                    $context->backendName => [
+                        iState::COLUMN_ID => 'item-1',
+                        iState::COLUMN_TYPE => iState::TYPE_MOVIE,
+                        iState::COLUMN_WATCHED => '1',
+                        iState::COLUMN_TITLE => 'Test Movie',
+                    ],
+                ],
+            ]);
+
+            $action = new $actionClass($http, $this->logger);
+            $result = $action($context, [$entity], $queue);
+
+            $this->assertTrue($result->isSuccessful());
+            $this->assertSame(0, $queue->count());
+        }
+    }
+
+    private function assertProgressResetRequest(string $clientName, Request $request): void
+    {
+        $this->assertSame('POST', $request->method->value);
+
+        if ('Emby' === $clientName) {
+            $this->assertStringContainsString('/Users/user-1/PlayingItems/item-1/Progress', (string) $request->url);
+            $this->assertStringContainsString('PositionTicks=0', (string) $request->url);
+            return;
+        }
+
+        $this->assertStringContainsString('/Users/user-1/Items/item-1/UserData', (string) $request->url);
+        $this->assertSame(0, $request->options['json']['PlaybackPositionTicks']);
     }
 
     private function provideBackends(): array
     {
         return [
-            ['Jellyfin', JellyfinPush::class],
-            ['Emby',     EmbyPush::class],
+            ['Jellyfin', JellyfinPush::class, JellyfinGetSessions::class],
+            ['Emby',     EmbyPush::class,     EmbyGetSessions::class],
         ];
     }
 }


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the backend integrations for Emby and Jellyfin, focusing on safer handling of watched item progress, especially when content is actively being played. The main themes are preventing accidental progress resets for currently playing items, standardizing progress reset requests, and improving request logging and error handling.

**Prevention of Progress Reset for Actively Playing Items:**

* Added logic in both Jellyfin and Emby export and push actions to check if an item is currently being played by the user before attempting to reset its watched progress. If the item is playing, the reset is skipped and a notice is logged. This prevents data loss and ensures user experience is not disrupted. [[1]](diffhunk://#diff-e66e8b83a6ba4907561827ffd01da203894c7f9fec9c0769a74a5d94c1d6ff43R191-R225) [[2]](diffhunk://#diff-464916a14b47b711960530cf7e74b61cf89079c27570ebab43c5cf9d9fa374aeR227-R259)

**Standardization and Refactoring of Progress Reset Requests:**

* Refactored the creation of progress reset requests into a dedicated method (`createProgressResetRequest`) for both backends, ensuring consistent behavior and reducing code duplication. This method handles the different API requirements for Emby and Jellyfin. [[1]](diffhunk://#diff-e66e8b83a6ba4907561827ffd01da203894c7f9fec9c0769a74a5d94c1d6ff43R360-R430) [[2]](diffhunk://#diff-464916a14b47b711960530cf7e74b61cf89079c27570ebab43c5cf9d9fa374aeR351-R356)
* Query parameters for marking items as watched now use the correct date format for each backend (Emby uses `YmdHis`, Jellyfin uses `ATOM`). [[1]](diffhunk://#diff-e66e8b83a6ba4907561827ffd01da203894c7f9fec9c0769a74a5d94c1d6ff43R269-R273) [[2]](diffhunk://#diff-464916a14b47b711960530cf7e74b61cf89079c27570ebab43c5cf9d9fa374aeR321-R325)

**Session Awareness Improvements:**

* Introduced a helper method (`getActiveSessions`) that checks for active playback sessions, allowing the application to avoid conflicting operations on items currently being watched. [[1]](diffhunk://#diff-e66e8b83a6ba4907561827ffd01da203894c7f9fec9c0769a74a5d94c1d6ff43R360-R430) [[2]](diffhunk://#diff-464916a14b47b711960530cf7e74b61cf89079c27570ebab43c5cf9d9fa374aeR89)

**Bug Fixes and Error Handling:**

* Changed error logging to warnings when non-OK HTTP responses are received during progress update requests, reflecting that these are less critical and may be recoverable. [[1]](diffhunk://#diff-e66e8b83a6ba4907561827ffd01da203894c7f9fec9c0769a74a5d94c1d6ff43L252-R299) [[2]](diffhunk://#diff-54f4fad2b3793014495cbf5c7be86ef9ae2d23be6b64410ed8e83ebaa5ccc2d6L285-R300)
* Fixed a bug in the frontend form validation to ensure `options` is always an object and not an array, improving robustness.

**Emby Progress Update API Changes:**

* Updated the Emby progress update endpoint and payload to use the correct path and query parameters, matching Emby's API expectations. This includes sending progress as ticks and using the `/PlayingItems/{id}/Progress` endpoint. [[1]](diffhunk://#diff-54f4fad2b3793014495cbf5c7be86ef9ae2d23be6b64410ed8e83ebaa5ccc2d6L260-R272) [[2]](diffhunk://#diff-54f4fad2b3793014495cbf5c7be86ef9ae2d23be6b64410ed8e83ebaa5ccc2d6L274-R282)

These changes make the backend integrations more robust, prevent accidental data loss, and improve maintainability and clarity of the codebase.