### PR TITLE
fix: flat_array() TypeError when flattening a JSON list

### DIFF
--- a/src/Libs/Utils.php
+++ b/src/Libs/Utils.php
@@ -1890,7 +1890,7 @@ if (!function_exists('flat_array')) {
         $out = [];
 
         foreach ($obj as $key => $val) {
-            $path = $prefix ? "{$prefix}{$separator}{$key}" : $key;
+            $path = $prefix ? "{$prefix}{$separator}{$key}" : (string) $key;
 
             if ((is_array($val) || is_object($val)) && count((array) $val) > 0) {
                 $out = array_merge($out, flat_array((array) $val, $path, $separator));


### PR DESCRIPTION
Retargeted against `dev` per request on #870 (closed, was against `master`).

## What this fixes

`flat_array()` throws a TypeError whenever it recurses into a JSON array (list), because the int key from `foreach` gets passed straight into the next call's `string $prefix` parameter.

Repro: any request body containing a JSON array hits this — e.g. `PUT /v1/api/identities/{id}` with a `backends` array crashes with a 503 and this in the logs:

```
flat_array(): Argument #2 ($prefix) must be of type string, int given, called in /opt/app/src/Libs/Utils.php on line 1896
```

Full writeup with repro steps in #869.

## The fix

One-line cast of `$key` to string when it's used as the next `$prefix`:

```diff
-            $path = $prefix ? "{$prefix}{$separator}{$key}" : $key;
+            $path = $prefix ? "{$prefix}{$separator}{$key}" : (string) $key;
```

Same behavior for string keys, no functional change there — just stops ints from leaking into a string-typed parameter.

Fixes #869