### PR TITLE
Refactor: expose the transport queue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,8 +78,15 @@ jobs:
       matrix:
         php: [8.5]
     steps:
-      - name: Checkout
+      - name: Checkout (GitHub)
+        if: env.REGISTRY == ''
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Checkout (Gitea)
+        if: env.REGISTRY != ''
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -199,8 +206,15 @@ jobs:
     env:
       ARCH: amd64
     steps:
-      - name: Checkout
+      - name: Checkout (GitHub)
+        if: env.REGISTRY == ''
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Checkout (Gitea)
+        if: env.REGISTRY != ''
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -297,8 +311,15 @@ jobs:
     env:
       ARCH: arm64
     steps:
-      - name: Checkout
+      - name: Checkout (GitHub)
+        if: env.REGISTRY == ''
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Checkout (Gitea)
+        if: env.REGISTRY != ''
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
         php: [8.5]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -104,7 +104,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Restore cached dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ steps.composer-cache.outputs.COMPOSER_CACHE_DIR }}
           key: "${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}"
@@ -122,7 +122,7 @@ jobs:
       - name: Run PHP tests
         run: composer run test
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
@@ -130,7 +130,7 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -167,7 +167,7 @@ jobs:
 
       - name: Set up Python
         if: env.REGISTRY == '' && github.event_name != 'pull_request'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
 
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upload frontend build
         if: env.REGISTRY == '' && github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: frontend-build
           path: frontend/exported/
@@ -200,19 +200,19 @@ jobs:
       ARCH: amd64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Download frontend build
         if: env.REGISTRY == ''
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: frontend-build
           path: frontend/exported/
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Update config/config.php
         run: |
@@ -237,7 +237,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             name=${{ env.DOCKERHUB_SLUG }},enable=${{ env.REGISTRY == '' }}
@@ -252,7 +252,7 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Login to Private Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         if: env.REGISTRY != ''
         with:
           registry: ${{ env.REGISTRY }}
@@ -260,7 +260,7 @@ jobs:
           password: ${{ secrets.GIT_TOKEN && secrets.GIT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         if: env.REGISTRY == ''
         with:
           registry: ghcr.io
@@ -268,14 +268,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         if: env.REGISTRY == ''
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/${{ env.ARCH }}
@@ -298,19 +298,19 @@ jobs:
       ARCH: arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Download frontend build
         if: env.REGISTRY == ''
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: frontend-build
           path: frontend/exported/
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Update config/config.php
         run: |
@@ -335,7 +335,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             name=${{ env.DOCKERHUB_SLUG }},enable=${{ env.REGISTRY == '' }}
@@ -350,7 +350,7 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Login to Private Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         if: env.REGISTRY != ''
         with:
           registry: ${{ env.REGISTRY }}
@@ -358,7 +358,7 @@ jobs:
           password: ${{ secrets.GIT_TOKEN && secrets.GIT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         if: env.REGISTRY == ''
         with:
           registry: ghcr.io
@@ -366,14 +366,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         if: env.REGISTRY == ''
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/${{ env.ARCH }}
@@ -400,7 +400,7 @@ jobs:
     steps:
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             name=${{ env.DOCKERHUB_SLUG }},enable=${{ env.REGISTRY == '' }}
@@ -414,7 +414,7 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Login to Private Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         if: env.REGISTRY != ''
         with:
           registry: ${{ env.REGISTRY }}
@@ -422,7 +422,7 @@ jobs:
           password: ${{ secrets.GIT_TOKEN && secrets.GIT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         if: env.REGISTRY == ''
         with:
           registry: ghcr.io
@@ -430,7 +430,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         if: env.REGISTRY == ''
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -466,7 +466,7 @@ jobs:
 
       - name: Overwrite GitHub release notes
         if: startsWith(github.ref, 'refs/tags/v') && env.REGISTRY == ''
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/API.md
+++ b/API.md
@@ -96,7 +96,10 @@ WatchState HTTP API reference. Examples use the default `/v1/api` prefix.
       - [DELETE /v1/api/system/guids/custom/{client}/{id}](#delete-v1apisystemguidscustomclientid)
       - [GET /v1/api/system/guids/custom/{client}/{index}](#get-v1apisystemguidscustomclientindex)
       - [GET /v1/api/system/events](#get-v1apisystemevents)
-      - [GET /v1/api/system/events/stats](#get-v1apisystemeventsstats)
+       - [GET /v1/api/system/events/stats](#get-v1apisystemeventsstats)
+       - [GET /v1/api/system/stats](#get-v1apisystemstats)
+       - [GET /v1/api/system/transport/queue](#get-v1apisystemtransportqueue)
+       - [GET /v1/api/system/transport/queue/{id}](#get-v1apisystemtransportqueueid)
       - [POST /v1/api/system/events](#post-v1apisystemevents)
       - [GET /v1/api/system/events/{id}](#get-v1apisystemeventsid)
       - [PATCH /v1/api/system/events/{id}](#patch-v1apisystemeventsid)
@@ -2581,6 +2584,85 @@ Returns event counts grouped by status.
 
 **Errors**:
 - `400 Bad Request` if any status name is invalid.
+
+---
+
+#### GET /v1/api/system/stats
+Returns the pending counts displayed in the global header.
+
+**Response**:
+```json
+{
+  "events": {
+    "pending": 3
+  },
+  "transport": {
+    "pending": 2
+  }
+}
+```
+
+---
+
+#### GET /v1/api/system/transport/queue
+Lists items currently held by the transport queue.
+
+**Query**:
+- `page` (optional) - Page number. Defaults to 1.
+- `perpage` (optional) - Items per page. Defaults to 25 and is limited to 100.
+- `state` (optional) - `pending`, `processing`, or `failed`.
+- `filter` (optional) - Match an envelope ID or event name.
+
+**Response**:
+```json
+{
+  "items": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "event": "on_webhook",
+      "state": "pending",
+      "created_at": "2026-03-28T12:00:00+00:00"
+    }
+  ],
+  "paging": {
+    "page": 1,
+    "total": 1,
+    "perpage": 25,
+    "next": null,
+    "previous": null
+  },
+  "filter": {
+    "state": "",
+    "filter": ""
+  },
+  "states": ["pending", "processing", "failed"]
+}
+```
+
+Queue item states are `pending`, `processing`, or `failed` when supported by the configured transport.
+
+**Errors**:
+- `400 Bad Request` if `state` is invalid.
+
+---
+
+#### GET /v1/api/system/transport/queue/{id}
+Returns one transport envelope by its exact identifier without claiming it.
+
+**Response**:
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "event": "on_webhook",
+  "state": "pending",
+  "created_at": "2026-03-28T12:00:00+00:00",
+  "data": {},
+  "options": {}
+}
+```
+
+**Errors**:
+- `404 Not Found` if the envelope is not currently visible in the transport.
 
 ---
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -11,7 +11,7 @@ For each backend:
 * **Import** allows WatchState to read data from that backend.
 * **Export** allows WatchState to write data to that backend.
 
-Put simply, **Import** controls what WatchState can use as a source, while **Export** controls what WatchState can update as a target.
+**Import** controls what WatchState can use as a source. **Export** controls what WatchState can update as a target.
 
 For example, if Plex should provide the data and Jellyfin should be updated to match it, enable:
 
@@ -113,7 +113,7 @@ Due to limitations on the Jellyfin/Emby side, our implementation requires you to
 `username:password` format. This is necessary because their API does not allow us to determine the currently
 authenticated user directly.
 
-When prompted for the API key, simply enter your credentials like this:
+When prompted for the API key, enter your credentials in this format:
 
 ```
 username:password
@@ -458,22 +458,22 @@ Click **<!--i:i-lucide-save--> Save Settings**.
 
 ## I Keep receiving 'jellyfin' item 'id: name' is marked as 'played' vs local state 'unplayed'
 
-Sadly, this is due to bug in jellyfin, where it marks the item as played without updating the LastPlayedDate, and as
-such, watchstate doesn't really know the item has changed since last sync. Unfortunately, there is no way to fix this
-issue from our side for the `state:import` task as it working as intended.
+Jellyfin can mark an item as played without updating `LastPlayedDate`. WatchState uses that date to detect changes, so
+the `state:import` task cannot detect this change from the backend response.
 
-### Workarounds.
+### Workarounds
 
-There are two possible workarounds:
+There are two workarounds:
 
 ### (1) Webhooks (Recommended)
 
-However, we managed implemented a workaround for this issue using the webhooks as workaround, until jellyfin devs fixes
-the issue. Please enable webhooks for your jellyfin backend to avoid this issue.
+Enable webhooks for the Jellyfin backend. Webhook events include the state change even when `LastPlayedDate` is not
+updated.
 
-### (1) by special handling
+### (2) Special handling
 
-We have added an experimental workaround for this issue in the `state:import` command. To enable it, add the env `WS_CLIENTS_JELLYFIN_FIX_PLAYED` via the `Configuration > Environment` page. It's turned off by default as it may cause some issues as it's untested in production, so please use it with caution and report any issues you find.
+The `state:import` command has an experimental workaround. Enable it by adding `WS_CLIENTS_JELLYFIN_FIX_PLAYED` on the
+`Configuration > Environment` page. It is disabled by default because it has not been tested in production.
 
 ## DM001 (`error: dm001_stale_date`) - Item queued for re-processing.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,8 +11,8 @@ During that upgrade, the old database files are kept as `.migrated` safety copie
 Cross-backend sync for playlists is now available as a **beta** feature. This is still early work, so expect some rough edges, 
 backend-specific issues, and possible breaking changes as it matures. 
 
-Because playlist behavior differs across backends, the feature may change over time, and if it proves too unreliable to support consistently, 
-it may be reworked or removed. To enable it, simply go to Tasks and enable the `Playlist` task.
+Playlist behavior differs across backends, so this feature may change or be removed if consistent support is not
+possible. To enable it, go to Tasks and enable the `Playlist` task.
 
 ### 2026-04-23
 
@@ -31,27 +31,24 @@ support from WatchState. This change only effects external users, home/managed u
 
 ### 2025-10-29
 
-After more than **3.5 years**, **2.2k+ commits**, **900+ stars**, and **1 million+ downloads**, we’re happy to announce
-the first stable release of **WatchState v1.0.0**.
+After more than **3.5 years**, **2.2k+ commits**, **900+ stars**, and **1 million+ downloads**, **WatchState v1.0.0**
+is now available as the first stable release.
 
-This milestone marks the project’s maturity and reliability for production use. We extend our thanks to everyone who
-provided feedback, reported bugs, and helped refine the tool your input has been invaluable.
+This release closes the initial v1.0.0 feature set. Thanks to everyone who provided feedback and reported bugs.
 
-The current feature set and stability meet our goals, so future work will focus on **maintenance and bug fixes**.
-Feedback and suggestions remain welcome, but **major new features** may be limited as we prioritize **stability and
-long-term reliability**.
+Future work will focus on **maintenance and bug fixes**. Feedback and suggestions remain welcome, but **major new
+features** may be limited.
 
 ### 2025-08-18
 
-We have added the final feature before tagging `v1.0.0`, The new feature is a tool by which you can search your database
-for duplicate file references, this is useful if you have multiple backends that reference the same file, they are
-reporting different metadata for same file.
+We have added the final feature planned before tagging `v1.0.0`: a tool for finding duplicate file references in the
+database. It is useful when multiple backends reference the same file but report different metadata.
 
 To make it skip multi-episode items, go to backends page, and from quick operation list, select
 `Force metadata import from this backend.` this will recreate the metadata which we have included flag to mark
 multi-episode items.
 
-Subsequent updates will mostly focus on bug fixes and performance improvements, as well as documentation updates.
+Future updates will focus on bug fixes, performance improvements, and documentation updates.
 
 ### 2025-08-14
 
@@ -64,24 +61,21 @@ Please refer to [NEWS](/NEWS.md) for the latest updates and changes.
 
 ### 2025-05-30
 
-The new [webhooks](/guides/webhooks.md) system is now available, please start migrating your systems to use it as, we
-have deprecated the old webhook system, and it will be removed in the next release. The new system is more robust and
-user-friendly compared to the old one.
+The new [webhooks](/guides/webhooks.md) system is now available. The old webhook system is deprecated and will be
+removed in the next release. Migrate existing integrations to the new endpoint.
 
 ### 2025-05-23
 
-We have recently added new and improved webhook endpoint that can be used as generic endpoint for all users and
-backends, please head to [webhook-v2 guide](guides/webhooks-v2.md) for more information. Please note that the new
-webhook endpoint still in beta, and things might change/break in the future.
+The new webhook endpoint supports all users and backends. See the [webhook-v2 guide](guides/webhooks-v2.md) for setup
+instructions. The endpoint is still in beta and may change.
 
 ### 2025-05-14
 
-**Breaking change**, we have switched to using user/password form of authentication instead of API key for the WebUI,
-this will lead to better security and easier to use. The API key is still available for the API, but not for the WebUI.
+**Breaking change:** WebUI authentication now uses a username and password instead of an API key. API keys remain
+available for the API, but not for the WebUI.
 
-The first time you access the WebUI after the update, you will be asked to create a new system user/password. This is a
-one time operation. Sorry about that. if you somehow lost your password, you can reset it by running the following
-command from the host machine.
+The first time you access the WebUI after the update, you will be asked to create a system username and password. If you
+lose the password, reset it by running the following command from the host machine.
 
 ```bash
 # change docker to podman if you are using podman
@@ -90,10 +84,8 @@ $ docker exec watchstate console system:resetpassword
 
 ### 2025-05-05
 
-We’ve added a new feature that lets you send requests **sequentially** to the backends instead of using the default
-**parallel** mode. This can be especially helpful if you have very large libraries, slow disks, or simply want to avoid
-overloading the backends with too many concurrent requests. You can enable by enabling `WS_HTTP_SYNC_REQUESTS`
-environment variable. This mode only applies to `import`, `export`, and `backup` tasks at the moment.
+Requests can now be sent **sequentially** instead of using the default **parallel** mode. Set
+`WS_HTTP_SYNC_REQUESTS` to enable sequential requests. This applies to `import`, `export`, and `backup` tasks.
 
 Additionally, two command-line flags let you override the mode on the fly `--sync-requests` and `--async-requests`.
 
@@ -146,14 +138,12 @@ this is still in early stages, and might not work as expected. report any issues
 
 We have added initial support to browse the WebUI as sub user, it's still in early stages, only few Endpoints support
 it.
-We have also added support to webhooks to allow sub users, you simply have to add new hooks using `user@backend`. Please
-take look at [this FAQ](FAQ.md#how-to-add-webhooks) to learn how to use it for sub users.
+Webhooks now support sub-users. Add a hook using `user@backend`; see the [FAQ](FAQ.md#how-to-add-webhooks) for details.
 
 ### 2025-02-02
 
-We are happy to announce that we have merged in direct support for multi-user in `state:import` and `state:export`
-commands and tasks. Therefore, `state:sync` command has been removed. Once you generate the sub users configs. it will
-start working alongside the main user.
+`state:import` and `state:export` now support multiple users directly. The `state:sync` command has been removed. After
+generating the sub-user configuration, those commands run alongside the main user.
 
 ### 2025-02-01
 
@@ -268,9 +258,8 @@ without leaving the WebUI.
 
 ### 2024-08-01
 
-We recently enabled listening on tls connections via `8443` which can be controlled by `HTTPS_PORT` environment
-variable.
-Before today, we simply only exposed the port via the `Dockerfile`, but we weren't listening for connections on it.
+TLS connections are now available on port `8443`, controlled by the `HTTPS_PORT` environment variable.
+Previously, the `Dockerfile` exposed the port without listening for connections on it.
 
 However, please keep in mind that the certificate is self-signed, and you might get a warning from your browser. You can
 either accept the warning or add the certificate to your trusted certificates. We strongly recommend using a reverse
@@ -298,28 +287,20 @@ the [FAQ](FAQ.md#How-does-the-file-integrity-feature-works).
 
 ### 2024-07-06
 
-Recently we have introduced a new feature that allows you to use Jellyfin and Emby OAuth access tokens for syncing
-your play state. This is especially handy if you're not the server owner and can't create API keys. Please note, this
-feature is in its experimental phase, so you might encounter some issues as we yet to explorer the full depth of the
-implementation. We're actively working on making it better, If you have any feedback or suggestions, please let us know.
+Jellyfin and Emby OAuth access tokens can now be used to sync play state. This is useful when you cannot create API keys.
+The feature is experimental. Report any problems or feedback.
 
-Getting your OAuth token is easy. When prompted, simply enter your `username:password` in place of the API key through
-the `WebUI` or the `config:add/manage` command. `WatchState` will automatically contact the backend and generate the
-token for you, as this step is required to get more information like your `User ID` which is sadly inaccessible without
-us generating the token. Both Emby & Jellyfin doesn't provide an API endpoint to inquiry about the current user.
+When prompted, enter `username:password` instead of an API key in the `WebUI` or the `config:add/manage` command.
+WatchState contacts the backend and generates the token to obtain the `User ID`. Neither Emby nor Jellyfin provides an
+API endpoint for querying the current user.
 
-We have also added new `config:test` command to run functional tests on your backends, this will not alter your state,
-And it's quite useful to know if the tool is able to communicate with your backends. without problems, It will report
-the following, `OK` which mean the indicated test has passed, `FA` which mean the indicated test has failed. And `SK`
-which mean the indicated test has been skipped or not yet implemented.
+The new `config:test` command runs functional tests against your backends without changing their state. It reports
+`OK` for a passed test, `FA` for a failed test, and `SK` for a skipped or unimplemented test.
 
 ### 2024-06-23
 
-WE are happy to announce that the `WebUI` is ready for wider usage and we are planning to release it in the next few
-months.
-We are actively working on it to improve it. If you have any feedback or suggestions, please let us know. We feel it's
-almost future complete
-for the things that we want.
+The `WebUI` is ready for wider use. We planned a public release for the following months and continued testing it with
+user feedback.
 
 On another related news, we have added new environment variable `WS_API_AUTO` "disabled by default" which can be used
 to automatically expose your **API KEY/TOKEN**. This is useful for users who are using the `WebUI` from many different
@@ -336,19 +317,14 @@ can be used. This environment variable can be enabled by setting `WS_API_AUTO=tr
 
 ### 2024-05-14
 
-We are happy to announce the beta testing of the `WebUI`. To get started on using it you just need to visit the url
-`http://localhost:8080` We are supposed to
-enabled it by default tomorrow, but we decided to give you a head start. We are looking forward to your feedback. If you
-don't use the `WebUI` then you need to
-add the environment variable `WEBUI_ENABLED=0` in your `compose.yaml` file. and restart the container.
+The `WebUI` is now available for beta testing at `http://localhost:8080`. To disable it, set `WEBUI_ENABLED=0` in
+`compose.yaml` and restart the container.
 
 ### 2024-05-13
 
-In preparation for the beta testing of `WebUI` in two days, we have made little breaking change, we have changed the
-environment variable `WS_WEBUI_ENABLED` to just `WEBUI_ENABLED`, We made this change to make sure people don't disable
-the `WebUI`by mistake via the environment page in the `WebUI`. The `WebUI` will be enabled by default, in two days from
-now, to disable it from now add `WEBUI_ENABLED=false` to your `compose.yaml` file. As this environment variable is
-system level, it cannot be set via `.env` file.
+Before the `WebUI` beta, the environment variable changed from `WS_WEBUI_ENABLED` to `WEBUI_ENABLED`. The WebUI will be
+enabled by default. To disable it, set `WEBUI_ENABLED=false` in `compose.yaml`; this system-level variable cannot be set
+through `.env`.
 
 Note: `WS_WEBUI_ENABLED` will be gone in few weeks, However it will still work for now, if `WEBUI_ENABLED` is not set.
 
@@ -356,10 +332,8 @@ Note: `WS_WEBUI_ENABLED` will be gone in few weeks, However it will still work f
 
 **Edit** - We received requests that people are exposing watchstate externally, and there was concern that having open
 webhook endpoints might lead to abuse. As such, we have added a new environment variable `WS_SECURE_API_ENDPOINTS`.
-Simply set
-the environment variable to `1` to secure the webhook endpoint. This means you have to add `?apikey=yourapikey` to the
-end
-of the webhook endpoint.
+Set the environment variable to `1` to secure the webhook endpoint. Requests must then include
+`?apikey=yourapikey`.
 
 ----- 
 
@@ -372,8 +346,7 @@ set from the `compose.yaml` file itself.
 
 ### 2024-05-04
 
-The new webhook endpoint no longer requires a key, and it's now open to public you just need to specify the backend
-name.
+The new webhook endpoint does not require a key. Specify the backend name in the request.
 
 ### 2024-04-30 - [BREAKING CHANGE]
 
@@ -386,22 +359,16 @@ to.
 
 ### 2024-03-08
 
-This update include breaking changes to how we process commands, we have streamlined the command interface to accept
-some consistent flags and options. Notably, we have added `-s, --select-backend` flag to all commands that accept it.
-commands that were accepting comma separated list of backends now needs to be separate option call for example
+This update changes how commands accept flags and options. The `-s, --select-backend` flag is now available on every
+command that supports backend selection.
+Commands that accepted a comma-separated backend list now require one option per backend. For example, use
 `--select-backend home_plex --select-backend home_jellyfin` instead of `--select-backend home_plex,home_jellyfin`.
 
-All commands that was accepting backend name as argument now accepts `-s, --select-backend` flag. This change is to make
-the command interface more consistent and easier to use.
+Commands that accepted a backend name as an argument now accept the `-s, --select-backend` flag.
 
-Another breaking change is the removal of the `-c, --config` flag from all commands that was accepting it. This flag was
-used to override the default `servers.yaml` file. This was not working as expected as there are more than just the
-`servers.yaml`
-to consider like, the state of cache, and the state of the database. As such, we have removed this flag. However, we
-have
-added a new environment variable called `WS_BACKENDS_FILE` which can be used to override the default `servers.yaml`
-file.
-We strongly recommend not to use it as it might lead to unexpected behavior.
+The `-c, --config` flag has been removed. It only changed the `servers.yaml` path and did not change other state paths,
+such as the cache and database. Use `WS_BACKENDS_FILE` to override the default `servers.yaml` path. This setting can
+leave other state files in a different location, so use it only when those paths are configured separately.
 
 We started working on a `Web API` which hopefully will lead to a `web frontend` to manage the tool. This is a long
 term goal, and it's not expected to be ready soon. However, the `Web API` is expected within 3rd quarter of 2024.
@@ -428,8 +395,7 @@ called`WS_CRON_PROGRESS=1`.
 We push progress update every `45 minutes`, to change it like other features add `WS_CRON_PROGRESS_AT="*/45 * * * *"`
 This is the default timer.
 
-On another point, we have decided to enable backup by default. To disable it simply add new environment
-variable `WS_CRON_BACKUP=0`.
+Backups are now enabled by default. To disable them, set `WS_CRON_BACKUP=0`.
 
 ### 2023-10-31
 

--- a/README.md
+++ b/README.md
@@ -86,38 +86,36 @@ mkdir -p ./data && docker run -itd --name watchstate \
 ```
 
 > [!IMPORTANT]
-> It's really important to match the `user:`, `--user` to the owner of the `data` directory, the container is rootless,
-> as such it will crash if it's unable to write to the data directory.
+> Match `user:` and `--user` to the owner of the `data` directory. The container runs rootless and exits if it cannot
+> write to that directory.
 >
-> It's really not recommended to run containers as root, but if you fail to run the container you can try setting the
-`user: "0:0"` or `--user '0:0'` if that works it means you have permissions issues. refer to [FAQ](FAQ.md) to
-> troubleshoot the problem.
+> Running the container as root is not recommended. If the container fails to start, try `user: "0:0"` or
+> `--user '0:0'`. If that works, the problem is a permissions issue. See the [FAQ](FAQ.md) for troubleshooting steps.
 
 ### Unraid users
 
-For `Unraid` users You can install the `Community Applications` plugin, and search for  **watchstate** it comes
-preconfigured. Otherwise, to manually install it, you need to add value to the `Extra Parameters` section in advanced
-tab/view. add the following value `--user 99:100`.
+For `Unraid` users, install the `Community Applications` plugin and search for **watchstate**. It is preconfigured.
+To install it manually, add `--user 99:100` to the `Extra Parameters` section in the advanced tab.
 
-This has to happen before you start the container, otherwise it will have the old user id, and
-you then have to run the following command from terminal `chown -R 99:100 /mnt/user/appdata/watchstate`.
+Set this before starting the container. If the container already created files with another user ID, run
+`chown -R 99:100 /mnt/user/appdata/watchstate` from a terminal.
 
 ### Podman instead of docker
 
-To use this container with `podman` set `compose.yaml` `user` to `0:0`. it will appear to be working as root inside the
-container, but it will be mapped to the user in which the command was run under.
+To use this container with `podman`, set `user` to `0:0` in `compose.yaml`. The container appears to run as root, but
+Podman maps it to the user who ran the command.
 
 # Management
 
 After starting the container, you can access the WebUI by visiting `http://localhost:8080` in your browser.
 
 > [!NOTE]
-> Note, For the first time, you will be prompted to create a new system user, this is a one time operation.
+> On first access, you will be prompted to create a system user. This is a one-time operation.
 
 If you want WatchState to match items using local media paths, see the [path matching guide](guides/path-match.md).
 
-To add your backends, please click on the help button in the top right corner, and choose which method you
-want [one-way](guides/one-way-sync.md) or [two-way](guides/two-way-sync.md) sync. and follow the instructions.
+To add your backends, click the help button in the top-right corner and choose [one-way](guides/one-way-sync.md) or
+[two-way](guides/two-way-sync.md) sync. Follow the instructions in the selected guide.
 
 Once you have added your backends and imported your data you should see something like
 
@@ -128,16 +126,15 @@ Once you have added your backends and imported your data you should see somethin
 Currently, the tool supports three methods to import data from backends.
 
 - **Scheduled Tasks**.
-    - `A scheduled job that pull data from backends on a schedule.`
+    - `A scheduled job that pulls data from backends.`
 - **On demand**.
     - `Pull data from backends on demand. By running the import task manually.`
 - **Webhooks**.
     - `Receive events from backends and update the database accordingly.`
 
 > [!NOTE]
-> Even if all your backends support webhooks, you should keep import task enabled. This help keep healthy relationship
-> and pick up any missed events. For more information please check the [webhook guide](/guides/webhooks.md) to
-> understand webhooks limitations.
+> Keep the import task enabled even when all your backends support webhooks. It can pick up missed events. See the
+> [webhook guide](/guides/webhooks.md) for backend limitations.
 
 # FAQ
 
@@ -146,15 +143,13 @@ to configure things.
 
 # Social channels
 
-If you have quick questions or would like to chat with other users, you can join
-the [Discord server](https://discord.gg/haUXHJyj6Y). Please note that this is a solo project, so replies may take some
-time. I’m based in the `UTC+3` timezone.
+If you have questions or want to chat with other users, join the [Discord server](https://discord.gg/haUXHJyj6Y).
+This is a solo project, so replies may take some time. I’m based in the `UTC+3` timezone.
 
 # Donate
 
-If you’d like to show appreciation for my work, please note that I don’t accept donations. Instead, I encourage you to
-donate to a children’s charity of your choice. For
-example, [The International Make-A-Wish foundation](https://worldwish.org).
+I don’t accept donations. If you want to support the project, consider donating to a children’s charity such as
+[Make-A-Wish](https://worldwish.org).
 
 # Disclaimer
 

--- a/composer.lock
+++ b/composer.lock
@@ -259,16 +259,16 @@
     },
     {
       "name": "laravel/serializable-closure",
-      "version": "v2.0.13",
+      "version": "v2.0.15",
       "source": {
         "type": "git",
         "url": "https://github.com/laravel/serializable-closure.git",
-        "reference": "b566ee0dd251f3c4078bed003a7ce015f5ea6dce"
+        "reference": "dccd8bcb851bb03fcc005df650b708b57cc52661"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/b566ee0dd251f3c4078bed003a7ce015f5ea6dce",
-        "reference": "b566ee0dd251f3c4078bed003a7ce015f5ea6dce",
+        "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/dccd8bcb851bb03fcc005df650b708b57cc52661",
+        "reference": "dccd8bcb851bb03fcc005df650b708b57cc52661",
         "shasum": ""
       },
       "require": {
@@ -316,7 +316,7 @@
         "issues": "https://github.com/laravel/serializable-closure/issues",
         "source": "https://github.com/laravel/serializable-closure"
       },
-      "time": "2026-04-16T14:03:50+00:00"
+      "time": "2026-07-21T16:49:22+00:00"
     },
     {
       "name": "league/container",
@@ -2807,16 +2807,16 @@
   "packages-dev": [
     {
       "name": "carthage-software/mago",
-      "version": "1.44.0",
+      "version": "1.45.0",
       "source": {
         "type": "git",
         "url": "https://github.com/carthage-software/mago.git",
-        "reference": "f303d492ebf79bd691009cc5dd0c6907a5ae3bc3"
+        "reference": "8771af7d3cdac8d2934e8fd187563d3c0464ac9a"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/carthage-software/mago/zipball/f303d492ebf79bd691009cc5dd0c6907a5ae3bc3",
-        "reference": "f303d492ebf79bd691009cc5dd0c6907a5ae3bc3",
+        "url": "https://api.github.com/repos/carthage-software/mago/zipball/8771af7d3cdac8d2934e8fd187563d3c0464ac9a",
+        "reference": "8771af7d3cdac8d2934e8fd187563d3c0464ac9a",
         "shasum": ""
       },
       "require": {
@@ -2854,7 +2854,7 @@
       ],
       "support": {
         "issues": "https://github.com/carthage-software/mago/issues",
-        "source": "https://github.com/carthage-software/mago/tree/1.44.0"
+        "source": "https://github.com/carthage-software/mago/tree/1.45.0"
       },
       "funding": [
         {
@@ -2862,7 +2862,7 @@
           "type": "github"
         }
       ],
-      "time": "2026-07-18T22:50:18+00:00"
+      "time": "2026-07-24T04:43:42+00:00"
     },
     {
       "name": "myclabs/deep-copy",
@@ -3101,11 +3101,11 @@
     },
     {
       "name": "phpstan/phpstan",
-      "version": "2.2.5",
+      "version": "2.2.6",
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/phpstan/phpstan/zipball/909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
-        "reference": "909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
+        "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a6e9b5a9420f6109c091e87d82683bd1a80b87ed",
+        "reference": "a6e9b5a9420f6109c091e87d82683bd1a80b87ed",
         "shasum": ""
       },
       "require": {
@@ -3161,7 +3161,7 @@
           "type": "github"
         }
       ],
-      "time": "2026-07-05T06:31:06+00:00"
+      "time": "2026-07-26T21:22:49+00:00"
     },
     {
       "name": "phpunit/php-code-coverage",
@@ -3548,16 +3548,16 @@
     },
     {
       "name": "phpunit/phpunit",
-      "version": "13.2.4",
+      "version": "13.2.5",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/phpunit.git",
-        "reference": "8f5180f4627fc1978be2f61d8d9979dbe37e0c10"
+        "reference": "2beef9f448c9e04914a273c89ff6d039f8b97bc8"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/8f5180f4627fc1978be2f61d8d9979dbe37e0c10",
-        "reference": "8f5180f4627fc1978be2f61d8d9979dbe37e0c10",
+        "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2beef9f448c9e04914a273c89ff6d039f8b97bc8",
+        "reference": "2beef9f448c9e04914a273c89ff6d039f8b97bc8",
         "shasum": ""
       },
       "require": {
@@ -3580,7 +3580,7 @@
         "sebastian/comparator": "^8.3.0",
         "sebastian/diff": "^9.0",
         "sebastian/environment": "^9.3.2",
-        "sebastian/exporter": "^8.1.0",
+        "sebastian/exporter": "^8.1.1",
         "sebastian/file-filter": "^1.0",
         "sebastian/git-state": "^1.0",
         "sebastian/global-state": "^9.0.1",
@@ -3628,7 +3628,7 @@
       "support": {
         "issues": "https://github.com/sebastianbergmann/phpunit/issues",
         "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-        "source": "https://github.com/sebastianbergmann/phpunit/tree/13.2.4"
+        "source": "https://github.com/sebastianbergmann/phpunit/tree/13.2.5"
       },
       "funding": [
         {
@@ -3636,7 +3636,7 @@
           "type": "other"
         }
       ],
-      "time": "2026-07-08T08:36:51+00:00"
+      "time": "2026-07-25T06:59:14+00:00"
     },
     {
       "name": "rector/rector",
@@ -3704,12 +3704,12 @@
       "source": {
         "type": "git",
         "url": "https://github.com/Roave/SecurityAdvisories.git",
-        "reference": "4fac0729c45b6dba8d6171a94eccb1d5d9514bf9"
+        "reference": "e7d396822cefa7207fd352f61f68660811e108a4"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/4fac0729c45b6dba8d6171a94eccb1d5d9514bf9",
-        "reference": "4fac0729c45b6dba8d6171a94eccb1d5d9514bf9",
+        "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/e7d396822cefa7207fd352f61f68660811e108a4",
+        "reference": "e7d396822cefa7207fd352f61f68660811e108a4",
         "shasum": ""
       },
       "conflict": {
@@ -3846,7 +3846,7 @@
         "codingms/modules": "<4.3.11|>=5,<5.7.4|>=6,<6.4.2|>=7,<7.5.5",
         "commerceteam/commerce": ">=0.9.6,<0.9.9",
         "components/jquery": ">=1.0.3,<3.5",
-        "composer/composer": "<2.2.28|>=2.3,<2.9.8",
+        "composer/composer": "<2.2.29|>=2.3,<2.10.2",
         "concrete5/concrete5": "<9.5.2",
         "concrete5/core": "<8.5.8|>=9,<9.1",
         "contao-components/mediaelement": ">=2.14.2,<2.21.1",
@@ -3906,7 +3906,7 @@
         "doctrine/mongodb-odm-bundle": "<3.0.1",
         "doctrine/orm": ">=1,<1.2.4|>=2,<2.4.8|>=2.5,<2.5.1|>=2.8.3,<2.8.4",
         "dolibarr/dolibarr": "<=23.0.2",
-        "dompdf/dompdf": "<2.0.4",
+        "dompdf/dompdf": "<3.1.6",
         "doublethreedigital/guest-entries": "<3.1.2",
         "dreamfactory/df-core": "<1.0.4",
         "drupal-pattern-lab/unified-twig-extensions": "<=0.1",
@@ -4061,10 +4061,10 @@
         "gregwar/rst": "<1.0.3",
         "grumpydictator/firefly-iii": "<=6.6.2",
         "gugoan/economizzer": "<=0.9.0.0-beta1",
-        "guzzlehttp/guzzle": "<7.12.1",
+        "guzzlehttp/guzzle": "<7.15.1",
         "guzzlehttp/guzzle-services": "<1.5.4",
         "guzzlehttp/oauth-subscriber": "<0.8.1",
-        "guzzlehttp/psr7": "<2.12.1",
+        "guzzlehttp/psr7": "<2.12.3",
         "haffner/jh_captcha": "<=2.1.3|>=3,<=3.0.2",
         "handcraftedinthealps/goodby-csv": "<1.4.3",
         "harvesthq/chosen": "<1.8.7",
@@ -4339,7 +4339,7 @@
         "personnummer/personnummer": "<3.0.2",
         "ph7software/ph7builder": "<=17.9.1",
         "phanan/koel": "<=9.7",
-        "pheditor/pheditor": "<2.0.6",
+        "pheditor/pheditor": "<2.0.8",
         "phenx/php-svg-lib": "<0.5.2",
         "php-censor/php-censor": "<2.0.13|>=2.1,<2.1.5",
         "php-mod/curl": "<2.3.2",
@@ -4355,7 +4355,7 @@
         "phpoffice/common": "<0.2.9",
         "phpoffice/math": "<=0.2",
         "phpoffice/phpexcel": "<=1.8.2",
-        "phpoffice/phpspreadsheet": "<=1.30.4|>=2,<=2.1.15|>=2.2,<=2.4.4|>=3,<=3.10.4|>=4,<=5.6",
+        "phpoffice/phpspreadsheet": "<=1.30.5|>=2,<=2.1.17|>=2.2,<=2.4.6|>=3,<=3.10.6|>=4,<=5.8",
         "phppgadmin/phppgadmin": "<=7.13",
         "phpseclib/phpseclib": "<=2.0.54|>=3,<=3.0.53",
         "phpservermon/phpservermon": "<3.6",
@@ -4382,7 +4382,7 @@
         "pocketmine/pocketmine-mp": "<5.42.1",
         "pocketmine/raklib": ">=0.14,<0.14.6|>=0.15,<0.15.1",
         "pontedilana/php-weasyprint": "<=2.5.1",
-        "poweradmin/poweradmin": "<4.2.4|>=4.3,<4.3.3",
+        "poweradmin/poweradmin": "<4.2.5|>=4.3,<4.3.4",
         "pressbooks/pressbooks": "<5.18",
         "prestashop/autoupgrade": ">=4,<4.10.1",
         "prestashop/blockreassurance": "<=5.1.3",
@@ -4818,7 +4818,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2026-07-17T19:07:03+00:00"
+      "time": "2026-07-24T23:00:42+00:00"
     },
     {
       "name": "sebastian/cli-parser",

--- a/frontend/app/components/HeaderStatus.vue
+++ b/frontend/app/components/HeaderStatus.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="flex shrink-0 items-center gap-0.5 sm:gap-2">
+    <UButton
+      to="/events"
+      color="neutral"
+      variant="ghost"
+      size="sm"
+      icon="i-lucide-calendar-days"
+      aria-label="Events"
+    >
+      <span class="hidden xl:inline">Events</span>
+      <StatusDots v-if="!loading" :stats="stats.events" />
+      <UIcon v-else name="i-lucide-loader-circle" class="size-4 animate-spin" />
+    </UButton>
+
+    <UButton
+      to="/transport/queue"
+      color="neutral"
+      variant="ghost"
+      size="sm"
+      icon="i-lucide-inbox"
+      aria-label="Transport Queue"
+    >
+      <span class="hidden xl:inline">Transport</span>
+      <StatusDots v-if="!loading" :stats="stats.transport" />
+      <UIcon v-else name="i-lucide-loader-circle" class="size-4 animate-spin" />
+    </UButton>
+  </div>
+</template>
+
+<script setup lang="ts">
+import StatusDots from '~/components/StatusDots.vue';
+import type { SystemStats } from '~/types';
+
+defineProps<{ stats: SystemStats; loading: boolean }>();
+</script>

--- a/frontend/app/components/StatusDots.vue
+++ b/frontend/app/components/StatusDots.vue
@@ -11,9 +11,9 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
-import type { EventsStats } from '~/types';
+import type { PendingStats } from '~/types';
 
-const props = withDefaults(defineProps<{ stats: EventsStats; hideZero?: boolean }>(), {
+const props = withDefaults(defineProps<{ stats: PendingStats; hideZero?: boolean }>(), {
   hideZero: false,
 });
 

--- a/frontend/app/components/StructuredLogLine.vue
+++ b/frontend/app/components/StructuredLogLine.vue
@@ -34,19 +34,14 @@
     </UDropdownMenu>
 
     <span
-      :class="[logLevelBadgeClass(getLogLevel(log.level)), compact ? 'w-16! text-[9px]' : '']"
+      :class="[
+        logLevelBadgeClass(getLogLevel(log.level)),
+        compact ? 'w-20! text-[10px]' : 'text-[11px]',
+      ]"
       @click="showDetails ? $emit('details', log) : undefined"
     >
-      <UIcon :name="LOG_LEVEL_ICON[getLogLevel(log.level)]" class="size-3" />
+      <UIcon :name="LOG_LEVEL_ICON[getLogLevel(log.level)]" class="size-3.5 shrink-0" />
       {{ getLogLevel(log.level) }}
-    </span>
-
-    <span
-      v-if="log.logger"
-      :title="log.logger"
-      class="inline-block max-w-[46vw] truncate align-middle text-[11px] font-semibold text-toned sm:max-w-104"
-    >
-      [{{ log.logger }}]
     </span>
   </span>
 

--- a/frontend/app/components/StructuredLogLine.vue
+++ b/frontend/app/components/StructuredLogLine.vue
@@ -53,7 +53,7 @@
   <button
     v-if="toggleable"
     type="button"
-    class="block min-w-0 flex-1 cursor-pointer text-left"
+    class="block min-w-0 flex-1 cursor-pointer select-text text-left"
     :aria-expanded="expanded || wrapped"
     @click="emit('toggleExpand')"
   >
@@ -71,7 +71,7 @@ import { useStorage } from '@vueuse/core';
 import { computed } from 'vue';
 import { useDialog } from '~/composables/useDialog';
 import type { ServerJsonLogEntry } from '~/types';
-import { goto_history_item, makeEventName } from '~/utils';
+import { copyText, goto_history_item, makeEventName } from '~/utils';
 import {
   getLogLevel,
   LOG_LEVEL_ICON,
@@ -185,6 +185,22 @@ const menuItems = computed<Array<Array<MenuItem>>>(() => {
       label: 'Log details',
       icon: 'i-lucide-panel-right-open',
       onSelect: () => emit('details', props.log),
+    },
+    {
+      label: 'Copy text',
+      icon: 'i-lucide-message-square-text',
+      onSelect: () => {
+        copyText(
+          `[${props.log.datetime}] ${props.log.level.toUpperCase()} [${props.log.logger}] ${props.log.message}`,
+        );
+      },
+    },
+    {
+      label: 'Copy raw',
+      icon: 'i-lucide-braces',
+      onSelect: () => {
+        copyText(JSON.stringify(props.log));
+      },
     },
   ];
 

--- a/frontend/app/components/TransportQueueView.vue
+++ b/frontend/app/components/TransportQueueView.vue
@@ -1,0 +1,275 @@
+<template>
+  <div class="space-y-4">
+    <div class="flex flex-wrap items-start justify-between gap-3">
+      <p class="min-w-0 flex-1 text-sm text-toned"></p>
+
+      <Popover placement="bottom-end" trigger="click" :z-index="13000">
+        <template #trigger>
+          <UButton
+            color="neutral"
+            variant="outline"
+            size="sm"
+            icon="i-lucide-copy"
+            trailing-icon="i-lucide-chevron-down"
+          >
+            <span class="hidden sm:inline">Copy</span>
+          </UButton>
+        </template>
+
+        <template #content="{ hide }">
+          <div class="w-52 space-y-1 p-1">
+            <button
+              type="button"
+              class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm text-default hover:bg-elevated hover:text-highlighted"
+              @click="
+                copyText(props.item.id);
+                hide();
+              "
+            >
+              <UIcon name="i-lucide-hash" class="size-4 text-toned" />
+              <span>Copy ID</span>
+            </button>
+            <button
+              type="button"
+              class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm text-default hover:bg-elevated hover:text-highlighted"
+              @click="
+                copyText(fullJson);
+                hide();
+              "
+            >
+              <UIcon name="i-lucide-copy" class="size-4 text-toned" />
+              <span>Copy item</span>
+            </button>
+            <button
+              type="button"
+              class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm text-default hover:bg-elevated hover:text-highlighted"
+              @click="
+                copyText(displayedData);
+                hide();
+              "
+            >
+              <UIcon name="i-lucide-database" class="size-4 text-toned" />
+              <span>Copy data</span>
+            </button>
+            <button
+              type="button"
+              class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm text-default hover:bg-elevated hover:text-highlighted"
+              @click="
+                copyText(displayedOptions);
+                hide();
+              "
+            >
+              <UIcon name="i-lucide-settings-2" class="size-4 text-toned" />
+              <span>Copy options</span>
+            </button>
+          </div>
+        </template>
+      </Popover>
+    </div>
+
+    <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <StatCard label="Event" :value="item.event" icon="i-lucide-tag" value-wrap />
+      <StatCard label="State" :value="item.state" :icon="stateIcon" :color="stateColor" />
+      <StatCard
+        label="Created"
+        :value="moment(item.created_at).fromNow()"
+        icon="i-lucide-clock"
+        :tooltip="moment(item.created_at).format(TOOLTIP_DATE_FORMAT)"
+      />
+      <StatCard
+        label="Envelope ID"
+        :value="shortId(item.id)"
+        icon="i-lucide-fingerprint"
+        :tooltip="item.id"
+      />
+    </div>
+
+    <section v-if="Object.keys(item.data).length > 0" class="space-y-3">
+      <button
+        type="button"
+        class="flex w-full flex-wrap items-center justify-between gap-3 text-left"
+        @click="showData = !showData"
+      >
+        <div class="flex items-center gap-3">
+          <span
+            class="inline-flex size-9 shrink-0 items-center justify-center rounded-md border border-default bg-elevated/70 text-primary"
+          >
+            <UIcon name="i-lucide-database" class="size-4" />
+          </span>
+          <p class="text-base font-semibold text-highlighted">Attached Data</p>
+        </div>
+        <div class="flex items-center gap-2" @click.stop>
+          <UButton
+            color="neutral"
+            :variant="wrapData ? 'soft' : 'outline'"
+            size="sm"
+            icon="i-lucide-wrap-text"
+            @click="wrapData = !wrapData"
+          >
+            <span class="hidden sm:inline">Wrap</span>
+          </UButton>
+          <UButton
+            color="neutral"
+            variant="outline"
+            size="sm"
+            icon="i-lucide-copy"
+            @click="copyText(displayedData)"
+          >
+            Copy
+          </UButton>
+          <UIcon
+            name="i-lucide-chevron-right"
+            :class="['size-4 text-toned transition-transform', showData ? 'rotate-90' : '']"
+          />
+        </div>
+      </button>
+
+      <template v-if="showData">
+        <UInput
+          v-model="dataQuery"
+          type="search"
+          icon="i-lucide-filter"
+          size="sm"
+          placeholder="Filter attached data"
+          class="w-full"
+        />
+        <UAlert
+          v-if="dataQuery && filteredDataLines.length < 1"
+          color="warning"
+          variant="soft"
+          icon="i-lucide-filter"
+          title="No matching lines"
+        />
+        <code
+          v-if="!dataQuery || filteredDataLines.length > 0"
+          class="ws-terminal ws-terminal-panel ws-terminal-panel-lg max-h-[35vh] overflow-auto wrap-break-word"
+          :class="wrapData ? 'whitespace-pre-wrap' : 'whitespace-pre'"
+          >{{ displayedData }}</code
+        >
+      </template>
+    </section>
+
+    <section v-if="Object.keys(item.options).length > 0" class="space-y-3">
+      <button
+        type="button"
+        class="flex w-full flex-wrap items-center justify-between gap-3 text-left"
+        @click="showOptions = !showOptions"
+      >
+        <div class="flex items-center gap-3">
+          <span
+            class="inline-flex size-9 shrink-0 items-center justify-center rounded-md border border-default bg-elevated/70 text-primary"
+          >
+            <UIcon name="i-lucide-settings-2" class="size-4" />
+          </span>
+          <p class="text-base font-semibold text-highlighted">Attached Options</p>
+        </div>
+        <div class="flex items-center gap-2" @click.stop>
+          <UButton
+            color="neutral"
+            :variant="wrapOptions ? 'soft' : 'outline'"
+            size="sm"
+            icon="i-lucide-wrap-text"
+            @click="wrapOptions = !wrapOptions"
+          >
+            <span class="hidden sm:inline">Wrap</span>
+          </UButton>
+          <UButton
+            color="neutral"
+            variant="outline"
+            size="sm"
+            icon="i-lucide-copy"
+            @click="copyText(displayedOptions)"
+          >
+            Copy
+          </UButton>
+          <UIcon
+            name="i-lucide-chevron-right"
+            :class="['size-4 text-toned transition-transform', showOptions ? 'rotate-90' : '']"
+          />
+        </div>
+      </button>
+
+      <template v-if="showOptions">
+        <UInput
+          v-model="optionsQuery"
+          type="search"
+          icon="i-lucide-filter"
+          size="sm"
+          placeholder="Filter attached options"
+          class="w-full"
+        />
+        <UAlert
+          v-if="optionsQuery && filteredOptionsLines.length < 1"
+          color="warning"
+          variant="soft"
+          icon="i-lucide-filter"
+          title="No matching lines"
+        />
+        <code
+          v-if="!optionsQuery || filteredOptionsLines.length > 0"
+          class="ws-terminal ws-terminal-panel ws-terminal-panel-lg max-h-[35vh] overflow-auto wrap-break-word"
+          :class="wrapOptions ? 'whitespace-pre-wrap' : 'whitespace-pre'"
+          >{{ displayedOptions }}</code
+        >
+      </template>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useStorage } from '@vueuse/core';
+import moment from 'moment';
+import Popover from '~/components/Popover.vue';
+import StatCard from '~/components/StatCard.vue';
+import type { TransportQueueDetail } from '~/types';
+import { copyText, TOOLTIP_DATE_FORMAT } from '~/utils';
+import { filterLogTextLines } from '~/utils/logs';
+
+const props = defineProps<{ item: TransportQueueDetail }>();
+
+const showData = useStorage<boolean>('transport_queue_show_data', true);
+const showOptions = useStorage<boolean>('transport_queue_show_options', true);
+const wrapData = useStorage<boolean>('transport_queue_wrap_data', false);
+const wrapOptions = useStorage<boolean>('transport_queue_wrap_options', false);
+const dataQuery = ref<string>('');
+const optionsQuery = ref<string>('');
+
+const fullJson = computed<string>(() => JSON.stringify(props.item, null, 2));
+const dataJson = computed<string>(() => JSON.stringify(props.item.data, null, 2));
+const optionsJson = computed<string>(() => JSON.stringify(props.item.options, null, 2));
+const filteredDataLines = computed<Array<string>>(() =>
+  filterLogTextLines(dataJson.value, dataQuery.value),
+);
+const filteredOptionsLines = computed<Array<string>>(() =>
+  filterLogTextLines(optionsJson.value, optionsQuery.value),
+);
+const displayedData = computed<string>(() =>
+  dataQuery.value ? filteredDataLines.value.join('\n') : dataJson.value,
+);
+const displayedOptions = computed<string>(() =>
+  optionsQuery.value ? filteredOptionsLines.value.join('\n') : optionsJson.value,
+);
+
+const stateIcon = computed<string>(() => {
+  if ('processing' === props.item.state) {
+    return 'i-lucide-loader-circle';
+  }
+  if ('failed' === props.item.state) {
+    return 'i-lucide-circle-x';
+  }
+  return 'i-lucide-clock-3';
+});
+
+const stateColor = computed<'neutral' | 'warning' | 'error'>(() => {
+  if ('processing' === props.item.state) {
+    return 'warning';
+  }
+  if ('failed' === props.item.state) {
+    return 'error';
+  }
+  return 'neutral';
+});
+
+const shortId = (id: string): string => `${id.slice(0, 8)}...${id.slice(-4)}`;
+</script>

--- a/frontend/app/composables/useSystemStats.ts
+++ b/frontend/app/composables/useSystemStats.ts
@@ -1,30 +1,31 @@
-import { ref, onBeforeUnmount } from 'vue';
-import { request, parse_api_response } from '~/utils';
-import type { EventsStats } from '~/types';
+import { onBeforeUnmount, ref } from 'vue';
+import { parse_api_response, request } from '~/utils';
+import type { SystemStats } from '~/types';
 
-/**
- * Reusable composable to fetch and auto-reload event statistics.
- */
-export default function useEventsStats(only: Array<keyof EventsStats> = []) {
-  const onlyParam = only.length > 0 ? `?only=${only.join(',')}` : '';
-  const stats = ref<EventsStats>({ pending: 0, running: 0, completed: 0, failed: 0, cancelled: 0 });
+export default function useSystemStats() {
+  const stats = ref<SystemStats>({
+    events: { pending: 0 },
+    transport: { pending: 0 },
+  });
   const loading = ref<boolean>(true);
   const intervalRef = ref<ReturnType<typeof setInterval> | null>(null);
   const frequency = 60000;
 
   const load = async (): Promise<void> => {
     try {
-      const response = await request(`/system/events/stats${onlyParam}`);
+      const response = await request('/system/stats');
       if (!response.ok) {
         return;
       }
-      const json = await parse_api_response<EventsStats>(response);
+
+      const json = await parse_api_response<SystemStats>(response);
       if ('error' in json) {
         return;
       }
+
       stats.value = json;
     } catch {
-      // ignore
+      // Ignore background polling failures.
     } finally {
       loading.value = false;
     }
@@ -34,7 +35,7 @@ export default function useEventsStats(only: Array<keyof EventsStats> = []) {
     if (intervalRef.value !== null) {
       return;
     }
-    // initial load
+
     void load();
     intervalRef.value = setInterval(() => void load(), frequency);
   };
@@ -43,17 +44,12 @@ export default function useEventsStats(only: Array<keyof EventsStats> = []) {
     if (intervalRef.value === null) {
       return;
     }
+
     clearInterval(intervalRef.value);
     intervalRef.value = null;
   };
 
   onBeforeUnmount(() => stop());
 
-  return {
-    stats,
-    loading,
-    load,
-    start,
-    stop,
-  };
+  return { stats, loading, load, start, stop };
 }

--- a/frontend/app/layouts/default.vue
+++ b/frontend/app/layouts/default.vue
@@ -75,7 +75,7 @@
           <template #header>
             <UDashboardNavbar :toggle="false" :title="pageTitle" :ui="dashboardNavbarUi">
               <template #left>
-                <div class="flex min-w-0 items-center gap-2">
+                <div class="flex min-w-0 shrink-0 items-center gap-2">
                   <UDashboardSidebarToggle class="lg:hidden" />
                   <UButton
                     to="/"
@@ -92,7 +92,7 @@
               </template>
 
               <template #right>
-                <div class="flex items-center gap-1.5 sm:gap-2">
+                <div class="flex min-w-0 shrink items-center gap-0.5 sm:gap-2">
                   <UTooltip v-if="inContainer" text="Task Scheduler Status">
                     <UButton
                       color="neutral"
@@ -117,20 +117,10 @@
                     </UButton>
                   </UTooltip>
 
-                  <UButton
-                    to="/events"
-                    color="neutral"
-                    variant="ghost"
-                    size="sm"
-                    icon="i-lucide-calendar-days"
-                  >
-                    <span class="hidden xl:inline">Events</span>
-                    <StatusDots
-                      :stats="eventsStats.stats.value"
-                      v-if="!eventsStats.loading.value"
-                    />
-                    <UIcon v-else name="i-lucide-loader-circle" class="size-4 animate-spin" />
-                  </UButton>
+                  <HeaderStatus
+                    :stats="systemStats.stats.value"
+                    :loading="systemStats.loading.value"
+                  />
 
                   <UTooltip text="Change Identity" placement="bottom">
                     <UButton
@@ -263,9 +253,9 @@ import TaskScheduler from '~/components/TaskScheduler.vue';
 import NewVersion from '~/components/NewVersion.vue';
 import Dialog from '~/components/Dialog.vue';
 import SettingsPanel from '~/components/SettingsPanel.vue';
-import StatusDots from '~/components/StatusDots.vue';
+import HeaderStatus from '~/components/HeaderStatus.vue';
 import IdentitySelection from '~/components/IdentitySelection.vue';
-import useEventsStats from '~/composables/useEventsStats';
+import useSystemStats from '~/composables/useSystemStats';
 
 type NavEntry = {
   id: string;
@@ -329,7 +319,7 @@ registerToastController(useToast());
 const { newVersionIsAvailable } = useVersionUpdate();
 const auth = useAuthStore();
 const breakpoints = useBreakpoints({ mobile: 0, desktop: 640 });
-const eventsStats = useEventsStats(['pending']);
+const systemStats = useSystemStats();
 const { pageBackgroundOverride, requestPageBackgroundReload } = usePageBackground();
 
 const bgEnable = useStorage<boolean>('bg_enable', true);
@@ -760,7 +750,7 @@ const dashboardSidebarUi = {
 const dashboardNavbarUi = {
   root: 'border-b border-default bg-transparent px-4 py-3 sm:px-5 lg:px-6',
   title: 'text-sm font-semibold text-highlighted',
-  right: 'flex items-center shrink-0 gap-1.5',
+  right: 'flex min-w-0 shrink items-center gap-0.5 sm:gap-1.5',
 };
 
 const dashboardPanelUi = {
@@ -956,7 +946,7 @@ onMounted(async () => {
   });
   await getVersion();
   await loadImage();
-  eventsStats.start();
+  systemStats.start();
 });
 
 onBeforeUnmount(() => {

--- a/frontend/app/pages/transport/queue.vue
+++ b/frontend/app/pages/transport/queue.vue
@@ -1,0 +1,446 @@
+<template>
+  <main class="w-full min-w-0 max-w-full space-y-6">
+    <PageHeader v-bind="pageShell">
+      <template #actions>
+        <UInput
+          v-if="showFilter"
+          id="transport-filter"
+          v-model.lazy="filter"
+          type="search"
+          placeholder="Filter displayed results"
+          icon="i-lucide-filter"
+          size="sm"
+          class="w-full sm:w-72"
+        />
+
+        <USelect
+          v-model="stateFilter"
+          :items="stateItems"
+          value-key="value"
+          label-key="label"
+          color="neutral"
+          variant="outline"
+          size="sm"
+          class="w-full sm:w-40"
+          :disabled="isLoading"
+          @update:model-value="() => void loadContent(1, false)"
+        />
+
+        <USelect
+          v-model="perpage"
+          :items="perPageItems"
+          value-key="value"
+          label-key="label"
+          color="neutral"
+          variant="outline"
+          size="sm"
+          class="w-40"
+          :disabled="isLoading"
+          @update:model-value="() => void loadContent(1, false)"
+        />
+
+        <UButton
+          color="neutral"
+          :variant="showFilter ? 'soft' : 'outline'"
+          size="sm"
+          icon="i-lucide-filter"
+          @click="toggleFilter"
+        >
+          <span class="hidden sm:inline">Filter</span>
+        </UButton>
+
+        <UButton
+          color="neutral"
+          variant="outline"
+          size="sm"
+          icon="i-lucide-refresh-cw"
+          :loading="isLoading"
+          :disabled="isLoading"
+          @click="() => void loadContent(page, true)"
+        >
+          <span class="hidden sm:inline">Reload</span>
+        </UButton>
+      </template>
+    </PageHeader>
+
+    <div v-if="total && last_page > 1" class="flex flex-wrap items-center justify-between gap-3">
+      <Pager :page="page" :last_page="last_page" :is-loading="isLoading" @navigate="navigatePage" />
+    </div>
+
+    <UAlert
+      v-if="isLoading"
+      color="info"
+      variant="soft"
+      icon="i-lucide-loader-circle"
+      title="Loading"
+      description="Loading transport items."
+      :ui="{ icon: 'animate-spin' }"
+    />
+
+    <UAlert
+      v-else-if="filteredItems.length < 1"
+      color="warning"
+      variant="soft"
+      icon="i-lucide-triangle-alert"
+      title="No items found"
+    >
+      <template #description>
+        <div class="space-y-2 text-sm text-default">
+          <p>No items found.</p>
+          <p v-if="'__all__' !== stateFilter">
+            State: <code>{{ stateFilter }}</code>
+          </p>
+          <p v-if="filter">
+            Displayed-results filter: <code>{{ filter }}</code>
+          </p>
+          <code
+            v-if="error"
+            class="block rounded-md border border-default bg-elevated/60 p-3 text-xs"
+          >
+            {{ error }}
+          </code>
+        </div>
+      </template>
+    </UAlert>
+
+    <div v-else class="grid gap-4 xl:grid-cols-2">
+      <UCard v-for="item in filteredItems" :key="item.id" class="h-full shadow-sm">
+        <template #header>
+          <div class="flex items-start justify-between gap-3">
+            <div class="min-w-0 flex-1">
+              <UTooltip :text="item.event">
+                <button
+                  type="button"
+                  class="block max-w-full truncate text-left text-base font-semibold text-highlighted hover:text-primary"
+                  @click="() => void openItem(item)"
+                >
+                  {{ item.event }}
+                </button>
+              </UTooltip>
+            </div>
+            <UBadge :color="stateColor(item.state)" variant="soft">
+              <span class="inline-flex items-center gap-1">
+                <UIcon :name="stateIcon(item.state)" class="size-3.5" />
+                <span class="capitalize">{{ item.state }}</span>
+              </span>
+            </UBadge>
+          </div>
+        </template>
+
+        <div class="grid gap-2.5 sm:grid-cols-2">
+          <div class="rounded-md border border-default bg-elevated/20 px-3 py-3">
+            <div class="flex items-center gap-2 text-xs font-medium text-toned">
+              <UIcon name="i-lucide-fingerprint" class="size-4" />
+              <span>Envelope ID</span>
+            </div>
+            <UTooltip :text="item.id">
+              <p class="mt-2 truncate font-mono text-xs text-default">{{ shortId(item.id) }}</p>
+            </UTooltip>
+          </div>
+          <div class="rounded-md border border-default bg-elevated/20 px-3 py-3">
+            <div class="flex items-center gap-2 text-xs font-medium text-toned">
+              <UIcon name="i-lucide-calendar" class="size-4" />
+              <span>Created</span>
+            </div>
+            <UTooltip :text="formatDate(item.created_at)">
+              <p class="mt-2 text-sm text-default">{{ fromNow(item.created_at) }}</p>
+            </UTooltip>
+          </div>
+        </div>
+      </UCard>
+    </div>
+
+    <div v-if="total && last_page > 1" class="flex flex-wrap items-center justify-between gap-3">
+      <Pager :page="page" :last_page="last_page" :is-loading="isLoading" @navigate="navigatePage" />
+      <div class="text-xs text-toned">Page {{ page }} of {{ last_page }}</div>
+    </div>
+
+    <UModal
+      v-model:open="detailOpen"
+      :title="selectedSummary ? `Transport item #${shortId(selectedSummary.id)}` : 'Transport item'"
+      :ui="{ content: 'max-w-4xl', body: 'p-4 sm:p-5' }"
+    >
+      <template #body>
+        <UAlert
+          v-if="detailLoading"
+          color="info"
+          variant="soft"
+          icon="i-lucide-loader-circle"
+          title="Loading envelope"
+          description="Loading transport data and options."
+          :ui="{ icon: 'animate-spin' }"
+        />
+        <UAlert
+          v-else-if="detailError"
+          color="error"
+          variant="soft"
+          icon="i-lucide-triangle-alert"
+          title="Unable to load envelope"
+        >
+          {{ detailError }}
+        </UAlert>
+        <TransportQueueView v-else-if="selectedItem" :item="selectedItem" />
+      </template>
+    </UModal>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue';
+import { useHead, useRoute, useRouter } from '#app';
+import moment from 'moment';
+import PageHeader from '~/components/PageHeader.vue';
+import Pager from '~/components/Pager.vue';
+import TransportQueueView from '~/components/TransportQueueView.vue';
+import type { TransportQueueDetail, TransportQueueItem } from '~/types';
+import {
+  awaitElement,
+  notification,
+  parse_api_response,
+  request,
+  TOOLTIP_DATE_FORMAT,
+} from '~/utils';
+import { requireTopLevelPageShell } from '~/utils/topLevelNavigation';
+
+type StateFilter = '__all__' | 'pending' | 'processing' | 'failed';
+
+const pageShell = requireTopLevelPageShell('transport-queue');
+const route = useRoute();
+const router = useRouter();
+const routeState = String(route.query.state ?? '__all__');
+const routePage = Number(route.query.page ?? 1);
+const routePerpage = Number(route.query.perpage ?? 25);
+const items = ref<Array<TransportQueueItem>>([]);
+const isLoading = ref<boolean>(false);
+const error = ref<string>('');
+const filter = ref<string>(String(route.query.filter ?? ''));
+const showFilter = ref<boolean>('' !== filter.value);
+const stateFilter = ref<StateFilter>(
+  ['pending', 'processing', 'failed'].includes(routeState)
+    ? (routeState as StateFilter)
+    : '__all__',
+);
+const availableStates = ref<Array<TransportQueueItem['state']>>([]);
+const selectedSummary = ref<TransportQueueItem | null>(null);
+const selectedItem = ref<TransportQueueDetail | null>(null);
+const detailLoading = ref<boolean>(false);
+const detailError = ref<string>('');
+let detailRequest = 0;
+const detailOpen = ref<boolean>(false);
+const page = ref<number>(Number.isInteger(routePage) && routePage > 0 ? routePage : 1);
+const perpage = ref<number>(Number.isInteger(routePerpage) && routePerpage > 0 ? routePerpage : 25);
+const total = ref<number>(0);
+
+const stateItems = computed<Array<{ label: string; value: StateFilter }>>(() => [
+  { label: 'All states', value: '__all__' },
+  ...availableStates.value.map((state) => ({
+    label: state.charAt(0).toUpperCase() + state.slice(1),
+    value: state,
+  })),
+]);
+
+const perPageItems = [25, 50, 100].map((value) => ({
+  label: `${value} per page`,
+  value,
+}));
+const last_page = computed<number>(() => Math.ceil(total.value / perpage.value));
+const filteredItems = computed<Array<TransportQueueItem>>(() => {
+  if (!filter.value) {
+    return items.value;
+  }
+
+  const query = filter.value.toLowerCase();
+  return items.value.filter((item) => JSON.stringify(item).toLowerCase().includes(query));
+});
+
+useHead({ title: 'Transport Queue' });
+
+const stateColor = (state: TransportQueueItem['state']): 'neutral' | 'warning' | 'error' => {
+  switch (state) {
+    case 'processing':
+      return 'warning';
+    case 'failed':
+      return 'error';
+    default:
+      return 'neutral';
+  }
+};
+
+const stateIcon = (state: TransportQueueItem['state']): string => {
+  switch (state) {
+    case 'processing':
+      return 'i-lucide-loader-circle';
+    case 'failed':
+      return 'i-lucide-circle-x';
+    default:
+      return 'i-lucide-clock-3';
+  }
+};
+
+const shortId = (id: string): string => `${id.slice(0, 8)}...${id.slice(-4)}`;
+const formatDate = (value: string): string => moment(value).format(TOOLTIP_DATE_FORMAT.value);
+const fromNow = (value: string): string => moment(value).fromNow();
+
+const toggleFilter = (): void => {
+  showFilter.value = !showFilter.value;
+  if (!showFilter.value) {
+    filter.value = '';
+    return;
+  }
+
+  awaitElement('#transport-filter', (_, element) => (element as HTMLInputElement).focus());
+};
+
+const openItem = async (item: TransportQueueItem): Promise<void> => {
+  const requestId = ++detailRequest;
+  selectedSummary.value = item;
+  selectedItem.value = null;
+  detailError.value = '';
+  detailLoading.value = true;
+  detailOpen.value = true;
+
+  try {
+    const response = await request(`/system/transport/queue/${encodeURIComponent(item.id)}`);
+    const json = await parse_api_response<TransportQueueDetail>(response);
+
+    if (requestId !== detailRequest) {
+      return;
+    }
+
+    if ('error' in json) {
+      detailError.value = `${json.error.code}: ${json.error.message}`;
+      return;
+    }
+
+    selectedItem.value = json;
+  } catch (caughtError: unknown) {
+    if (requestId === detailRequest) {
+      detailError.value = caughtError instanceof Error ? caughtError.message : String(caughtError);
+    }
+  } finally {
+    if (requestId === detailRequest) {
+      detailLoading.value = false;
+    }
+  }
+};
+
+const navigatePage = (pageNumber: number): void => {
+  void loadContent(pageNumber);
+};
+
+const loadContent = async (pageNumber: number, fromPopState: boolean = false): Promise<void> => {
+  pageNumber = parseInt(pageNumber.toString());
+  if (Number.isNaN(pageNumber) || pageNumber < 1) {
+    pageNumber = 1;
+  }
+
+  error.value = '';
+  isLoading.value = true;
+  items.value = [];
+  try {
+    const query = new URLSearchParams({
+      page: String(pageNumber),
+      perpage: String(perpage.value),
+    });
+    if ('__all__' !== stateFilter.value) {
+      query.set('state', stateFilter.value);
+    }
+
+    const response = await request(`/system/transport/queue?${query.toString()}`);
+    const json = await parse_api_response<{
+      items: Array<TransportQueueItem>;
+      paging: {
+        page: number;
+        total: number;
+        perpage: number;
+        next: number | null;
+        previous: number | null;
+      };
+      states: Array<TransportQueueItem['state']>;
+    }>(response);
+
+    if ('error' in json) {
+      error.value = json.error.message;
+      notification('error', 'Error', `${json.error.code}: ${json.error.message}`);
+      return;
+    }
+
+    if ('transport-queue' !== route.name) {
+      return;
+    }
+
+    items.value = json.items ?? [];
+    page.value = json.paging.page;
+    total.value = json.paging.total;
+    perpage.value = json.paging.perpage;
+    availableStates.value = json.states ?? [];
+    if (!fromPopState) {
+      await router.push({
+        path: '/transport/queue',
+        query: {
+          page: page.value,
+          perpage: perpage.value,
+          state: '__all__' === stateFilter.value ? undefined : stateFilter.value,
+          filter: '' === filter.value ? undefined : filter.value,
+        },
+      });
+    }
+  } catch (caughtError: unknown) {
+    const message = caughtError instanceof Error ? caughtError.message : String(caughtError);
+    error.value = message;
+    notification('error', 'Error', message);
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+watch(filter, (value: string) => {
+  const nextFilter = value.trim();
+  const currentFilter = String(route.query.filter ?? '');
+
+  if (currentFilter === nextFilter) {
+    return;
+  }
+
+  void router.push({
+    path: '/transport/queue',
+    query: {
+      ...route.query,
+      filter: nextFilter || undefined,
+    },
+  });
+});
+
+watch(
+  () => route.fullPath,
+  async () => {
+    if ('transport-queue' !== route.name) {
+      return;
+    }
+
+    const nextPage = parseInt(route.query.page as string) || 1;
+    const nextPerPage = parseInt(route.query.perpage as string) || 25;
+    const rawState = String(route.query.state ?? '__all__');
+    const nextState: StateFilter = ['pending', 'processing', 'failed'].includes(rawState)
+      ? (rawState as StateFilter)
+      : '__all__';
+    const nextFilter = String(route.query.filter ?? '');
+    const shouldReload =
+      nextPage !== page.value || nextPerPage !== perpage.value || nextState !== stateFilter.value;
+
+    page.value = nextPage;
+    perpage.value = nextPerPage;
+    stateFilter.value = nextState;
+    filter.value = nextFilter;
+    showFilter.value = Boolean(nextFilter);
+
+    if (!shouldReload) {
+      return;
+    }
+
+    await loadContent(nextPage, true);
+  },
+);
+
+onMounted(() => void loadContent(page.value));
+</script>

--- a/frontend/app/types/index.d.ts
+++ b/frontend/app/types/index.d.ts
@@ -494,6 +494,21 @@ export interface EventsItem {
 }
 
 /**
+ * Represents an item currently held by the transport queue.
+ */
+export interface TransportQueueItem {
+  id: string;
+  event: string;
+  state: 'pending' | 'processing' | 'failed';
+  created_at: string;
+}
+
+export interface TransportQueueDetail extends TransportQueueItem {
+  data: JsonObject;
+  options: JsonObject;
+}
+
+/**
  * Event statistics from /api/system/events/stats endpoint.
  */
 export interface EventsStats {
@@ -507,6 +522,15 @@ export interface EventsStats {
   failed: number;
   /** Number of cancelled events */
   cancelled: number;
+}
+
+export interface SystemStats {
+  events: PendingStats;
+  transport: PendingStats;
+}
+
+export interface PendingStats {
+  pending: number;
 }
 
 /**

--- a/frontend/app/utils/topLevelNavigation.ts
+++ b/frontend/app/utils/topLevelNavigation.ts
@@ -12,6 +12,7 @@ type TopLevelEntryId =
   | 'backends'
   | 'history'
   | 'events'
+  | 'transport-queue'
   | 'tasks'
   | 'logs'
   | 'console'
@@ -112,6 +113,17 @@ const TOP_LEVEL_NAVIGATION: Array<TopLevelNavigationDefinition> = [
     icon: 'i-lucide-calendar-days',
     to: '/events',
     matchPath: '/events',
+  },
+  {
+    id: 'transport-queue',
+    section: 'activity',
+    label: 'Transport',
+    pageLabel: 'Transport Queue',
+    breadcrumbSectionLabel: 'Activity',
+    description: 'Items in the transport queue.',
+    icon: 'i-lucide-inbox',
+    to: '/transport/queue',
+    matchPath: '/transport/queue',
   },
   {
     id: 'backends',

--- a/guides/one-way-sync.md
+++ b/guides/one-way-sync.md
@@ -71,9 +71,8 @@ Do exactly as you did for the main backend, but make the following changes:
     - If you have multiple backends, keep this option disabled and proceed to Step 2.
 
 > [!IMPORTANT]  
-> Selecting the correct options is crucial to avoid altering the data in the main backend. When
-> *`Enable Import`* is disabled, WatchState automatically keeps metadata refresh
-> enabled for that backend.
+> These settings prevent this backend from importing data and changing the main backend. When *`Enable Import`* is
+> disabled, WatchState keeps metadata refresh enabled for that backend.
 
 ### Step 2
 
@@ -84,7 +83,7 @@ You have two options:
 Go to the <!--i:i-lucide-server--> **Backends** page, and under the backend, there is a `Quick operations` list. Select
 *`2. Force export local play state to this backend.`* Once selected, you'll be redirected to
 the **Operations** > <!--i:i-lucide-terminal--> **Console** page, where the command will be pre-filled
-for you. Just hit *Enter* or click the <!--i:i-lucide-terminal--> **Execute** button.
+for you. Press *Enter* or click the <!--i:i-lucide-terminal--> **Execute** button.
 
 ##### Option 2 (Multiple Backends)
 

--- a/guides/two-way-sync.md
+++ b/guides/two-way-sync.md
@@ -1,26 +1,22 @@
 # Two-Way Sync
 
-Two-way sync in WatchState helps keep your `play progress` and `watch state` synchronized across multiple backends. It’s
-called "many-to-many" sync, meaning you can sync data between several backends, and they all stay up to date with each
-other. This sync is powered by WatchState's `import` and `export` features.
+Two-way sync lets WatchState exchange `play progress` and `watch state` between multiple backends. It uses the `import`
+and `export` features, so each backend can provide data and receive updates.
 
 # Use Cases
 
-- If you watch a show on Plex and want to continue it on Jellyfin or Emby, two-way sync ensures your progress is saved.
-- Keep your media backends synced so you always know where you left off.
+- If you watch a show on Plex and continue it on Jellyfin or Emby, two-way sync sends the progress between those
+  backends.
+- The configured backends exchange play state through the local WatchState database.
 
 # How Sync Works
 
-WatchState first pulls the latest play and progress information from your backends, then stores it locally this is the
-`import` process. The system checks to ensure the data is up-to-date, and older data is saved as metadata without
-overriding the most current watch state.
+WatchState first pulls play and progress information from the backends and stores it locally. This is the `import`
+process. Older data is retained as metadata and does not replace the latest local watch state.
 
-On the export side, we compare the backend's last sync date with any local changes. From there, we create a list of
-items that need updating for each backend. If there are only a few changes, we trigger a quick sync operation
-`push mode`. If the changes are more extensive, we perform a full export, which compares all remote data with the local
-data. This full export only happens when there are many changes and/or metadata is missing from the backend, which is
-why it's crucial to keep the `Enable Import` option enabled, or disable it only when you want that
-backend to stay in metadata-only mode.
+During export, WatchState compares the backend's last sync date with local changes and builds a list of updates for each
+backend. A small change uses `push mode`. Larger changes use a full export, which compares remote and local data. Keep
+`Enable Import` enabled unless the backend should remain in metadata-only mode.
 
 # Setting Up Two-Way Sync
 

--- a/guides/using-ws-as-backup-solution.md
+++ b/guides/using-ws-as-backup-solution.md
@@ -53,8 +53,8 @@ After your backend is configured:
 
 ### Step 3: Run the initial import
 
-Now that you have added the all users, simply go to the <!--i:i-lucide-list-checks--> **Tasks** page and queue the `Import` task to
-start importing playstate. To bring all existing playstate into WatchState.
+After adding the users, go to the <!--i:i-lucide-list-checks--> **Tasks** page and queue the `Import` task. This imports
+the existing play state into WatchState.
 
 The task will take some time depending on your library size. Monitor progress at the <!--i:i-lucide-globe--> **Logs** page by
 checking the `task.YYYYMMDD.log` file. Once the task completed you should see something like

--- a/guides/webhooks.md
+++ b/guides/webhooks.md
@@ -237,13 +237,12 @@ Click *Save*.
 
 # Media Backends Webhook Limitations
 
-See the [backend limitations](/guides/backend-limitations.md) for a comprehensive list of per-backend requirements 
-and limitations, including webhook-specific event behaviour.
+See the [backend limitations](/guides/backend-limitations.md) for per-backend requirements and limitations, including
+webhook-specific event behavior.
 
 # Sometimes Newly Added Content Does Not Show Up
 
-As previously mentioned, webhooks aren't 100% reliable, thus it's recommended to enable **import/export tasks** to
-complement webhook functionality.
+Webhooks can miss events. Enable the **Import** and **Export** tasks as a second path for synchronizing changes.
 
-Simply go to the *Tasks* page and enable the *Import* and *Export* tasks. and set the schedule to `every 12 hours` or
-`every 24 hours` depending on your needs.
+Go to the *Tasks* page, enable the *Import* and *Export* tasks, and set the schedule to `every 12 hours` or
+`every 24 hours`.

--- a/src/API/System/Stats.php
+++ b/src/API/System/Stats.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\API\System;
+
+use App\Libs\Attributes\Route\Get;
+use App\Libs\Enums\Http\Status;
+use App\Libs\Events\Queue\EventEnvelopeState;
+use App\Libs\Events\Queue\EventTransportInterface;
+use App\Model\Events\EventsRepository;
+use App\Model\Events\EventStatus;
+use Psr\Http\Message\ResponseInterface as iResponse;
+
+final readonly class Stats
+{
+    public const string URL = '%{api.prefix}/system/stats';
+
+    public function __construct(
+        private EventsRepository $events,
+        private EventTransportInterface $transport,
+    ) {}
+
+    #[Get(pattern: self::URL . '[/]', name: 'system.stats')]
+    public function get(): iResponse
+    {
+        return api_response(
+            Status::OK,
+            [
+                'events' => [
+                    'pending' => $this->events->countByStatus(EventStatus::PENDING),
+                ],
+                'transport' => [
+                    'pending' => $this->transport->inspectCount(EventEnvelopeState::PENDING),
+                ],
+            ],
+            headers: ['X-No-AccessLog' => '1'],
+        );
+    }
+}

--- a/src/API/System/TransportQueue.php
+++ b/src/API/System/TransportQueue.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\API\System;
+
+use App\Libs\Attributes\Route\Get;
+use App\Libs\DataUtil;
+use App\Libs\Enums\Http\Status;
+use App\Libs\Events\Queue\EventEnvelope;
+use App\Libs\Events\Queue\EventEnvelopeState;
+use App\Libs\Events\Queue\EventTransportInterface;
+use Psr\Http\Message\ResponseInterface as iResponse;
+use Psr\Http\Message\ServerRequestInterface as iRequest;
+
+final readonly class TransportQueue
+{
+    public const string URL = '%{api.prefix}/system/transport/queue';
+    public const int PERPAGE = 25;
+
+    public function __construct(
+        private EventTransportInterface $transport,
+    ) {}
+
+    #[Get(pattern: self::URL . '[/]', name: 'system.transport.queue.list')]
+    public function list(iRequest $request): iResponse
+    {
+        $params = DataUtil::fromRequest($request, true);
+        [$page, $perpage] = get_pagination($request, 1, self::PERPAGE);
+        $page = max(1, $page);
+        $perpage = max(1, min(100, $perpage));
+        $state = strtolower(trim((string) $params->get('state', '')));
+        $filter = trim((string) $params->get('filter', ''));
+        $states = $this->transport->inspectStates();
+        $stateEnum = '' === $state ? null : EventEnvelopeState::tryFrom($state);
+
+        if ('' !== $state && (null === $stateEnum || false === in_array($stateEnum, $states, true))) {
+            return api_error("Invalid transport state '{$state}'.", Status::BAD_REQUEST);
+        }
+
+        $total = $this->transport->inspectCount($stateEnum, $filter);
+        $page = min($page, max(1, (int) ceil($total / $perpage)));
+        $start = $perpage * ($page - 1);
+
+        return api_response(
+            Status::OK,
+            [
+                'items' => array_map(
+                    fn(EventEnvelope $envelope): array => $this->formatEnvelope($envelope, false),
+                    $this->transport->inspect($perpage, $start, $stateEnum, $filter),
+                ),
+                'paging' => [
+                    'page' => $page,
+                    'total' => $total,
+                    'perpage' => $perpage,
+                    'next' => $page < (int) ceil($total / $perpage) ? $page + 1 : null,
+                    'previous' => $page > 1 ? $page - 1 : null,
+                ],
+                'filter' => [
+                    'state' => null !== $stateEnum ? $stateEnum->value : '',
+                    'filter' => $filter,
+                ],
+                'states' => array_map(static fn(EventEnvelopeState $item): string => $item->value, $states),
+            ],
+            headers: ['X-No-AccessLog' => '1'],
+        );
+    }
+
+    #[Get(pattern: self::URL . '/{id}[/]', name: 'system.transport.queue.view')]
+    public function view(string $id): iResponse
+    {
+        $id = trim($id);
+        if ('' === $id) {
+            return api_error('Invalid transport envelope id.', Status::BAD_REQUEST);
+        }
+
+        $envelope = $this->transport->inspectOne($id);
+        if (null === $envelope) {
+            return api_error('Transport envelope not found.', Status::NOT_FOUND);
+        }
+
+        return api_response(Status::OK, $this->formatEnvelope($envelope, true), headers: ['X-No-AccessLog' => '1']);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function formatEnvelope(EventEnvelope $envelope, bool $includePayload): array
+    {
+        $formatted = [
+            'id' => $envelope->id,
+            'event' => $envelope->event,
+            'state' => $envelope->state,
+            'created_at' => $envelope->createdAt,
+        ];
+
+        if ($includePayload) {
+            $formatted['data'] = $envelope->data;
+            $formatted['options'] = $envelope->opts;
+        }
+
+        return $formatted;
+    }
+}

--- a/src/Commands/Transport/AbstractTransportCommand.php
+++ b/src/Commands/Transport/AbstractTransportCommand.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands\Transport;
+
+use App\Command;
+use InvalidArgumentException;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class AbstractTransportCommand extends Command
+{
+    protected const array STATES = ['pending', 'processing', 'failed'];
+
+    protected function outputMode(InputInterface $input): string
+    {
+        $mode = strtolower((string) $input->getOption('output'));
+
+        return in_array($mode, self::DISPLAY_OUTPUT, true) ? $mode : 'table';
+    }
+
+    protected function apiError(OutputInterface $output, mixed $response): int
+    {
+        $output->writeln(r('<error>API error. {status}: {message}</error>', [
+            'status' => $response->status->value,
+            'message' => OutputFormatter::escape((string) ag($response->body, 'error.message', 'Unknown error.')),
+        ]));
+
+        return self::FAILURE;
+    }
+
+    protected function parseSections(string $value): array
+    {
+        $sections = array_values(array_filter(array_map(
+            static fn(string $section): string => strtolower(trim($section)),
+            explode(',', $value),
+        )));
+
+        if ([] === $sections) {
+            $sections = ['summary', 'data', 'options'];
+        }
+
+        foreach ($sections as $section) {
+            if (!in_array($section, ['summary', 'data', 'options', 'entry', 'all'], true)) {
+                throw new InvalidArgumentException(r('Unknown section [{section}].', ['section' => $section]));
+            }
+        }
+
+        return $sections;
+    }
+
+    /**
+     * @param array<string,mixed> $item
+     * @param array<string> $sections
+     */
+    protected function renderView(array $item, array $sections, OutputInterface $output): void
+    {
+        $showAll = in_array('all', $sections, true);
+
+        if ($showAll || in_array('summary', $sections, true)) {
+            $output->writeln('<info>Summary</info>');
+            $output->writeln($this->escape(implode(' | ', array_filter(
+                [
+                    '#' . (string) ag($item, 'id', ''),
+                    strtoupper((string) ag($item, 'state', 'unknown')),
+                    (string) ag($item, 'event', ''),
+                    (string) ag($item, 'created_at', ''),
+                ],
+                static fn(string $part): bool => '' !== trim($part),
+            ))));
+            $output->writeln('');
+        }
+
+        if ($showAll || in_array('data', $sections, true)) {
+            $this->renderJsonSection('Data', (array) ag($item, 'data', []), $output);
+        }
+
+        if ($showAll || in_array('options', $sections, true)) {
+            $this->renderJsonSection('Options', (array) ag($item, 'options', []), $output);
+        }
+
+        if ($showAll || in_array('entry', $sections, true)) {
+            $output->writeln('<info>Entry</info>');
+            $output->writeln($this->escape($this->encodeJson($item)));
+        }
+    }
+
+    /**
+     * @param array<string,mixed> $value
+     */
+    private function renderJsonSection(string $title, array $value, OutputInterface $output): void
+    {
+        if ([] === $value) {
+            return;
+        }
+
+        $output->writeln('<info>' . $title . '</info>');
+        $output->writeln($this->escape($this->encodeJson($value)));
+        $output->writeln('');
+    }
+
+    /**
+     * @param array<string,mixed> $value
+     */
+    private function encodeJson(array $value): string
+    {
+        return (string) json_encode(
+            $value,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_IGNORE,
+        );
+    }
+
+    protected function escape(string $value): string
+    {
+        return OutputFormatter::escape($value);
+    }
+}

--- a/src/Commands/Transport/QueueCommand.php
+++ b/src/Commands/Transport/QueueCommand.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands\Transport;
+
+use App\Libs\Attributes\Route\Cli;
+use App\Libs\Enums\Http\Method;
+use App\Libs\Enums\Http\Status;
+use InvalidArgumentException;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[Cli(command: self::ROUTE)]
+final class QueueCommand extends AbstractTransportCommand
+{
+    public const string ROUTE = 'transport:queue';
+
+    protected function configure(): void
+    {
+        $this
+            ->setName(self::ROUTE)
+            ->setDescription('List items held by the transport queue.')
+            ->addOption('page', 'p', InputOption::VALUE_REQUIRED, 'Page number.', '1')
+            ->addOption('perpage', null, InputOption::VALUE_REQUIRED, 'Items per page.', '25')
+            ->addOption('state', 's', InputOption::VALUE_REQUIRED, 'Filter by state [pending|processing|failed].')
+            ->addOption('filter', 'f', InputOption::VALUE_REQUIRED, 'Filter by envelope ID or event name.');
+    }
+
+    protected function runCommand(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            $query = $this->buildQuery($input);
+        } catch (InvalidArgumentException $e) {
+            $output->writeln('<error>' . OutputFormatter::escape($e->getMessage()) . '</error>');
+            return self::FAILURE;
+        }
+
+        $response = api_request(Method::GET, '/system/transport/queue', opts: ['query' => $query]);
+        if (Status::OK !== $response->status) {
+            $output->writeln(r('<error>API error. {status}: {message}</error>', [
+                'status' => $response->status->value,
+                'message' => OutputFormatter::escape((string) ag($response->body, 'error.message', 'Unknown error.')),
+            ]));
+            return self::FAILURE;
+        }
+
+        $mode = strtolower((string) $input->getOption('output'));
+        $mode = in_array($mode, self::DISPLAY_OUTPUT, true) ? $mode : 'table';
+        if ('table' !== $mode) {
+            $this->displayContent($response->body, $output, $mode);
+            return self::SUCCESS;
+        }
+
+        $paging = (array) ag($response->body, 'paging', []);
+        $filter = (array) ag($response->body, 'filter', []);
+        $output->writeln('<info>Transport Queue</info>');
+        $output->writeln(OutputFormatter::escape(r(
+            'page {page} | per-page {perpage} | total {total} | next {next} | prev {previous}',
+            [
+                'page' => ag($paging, 'page', 1),
+                'perpage' => ag($paging, 'perpage', 0),
+                'total' => ag($paging, 'total', 0),
+                'next' => null === ag($paging, 'next') ? '-' : (string) ag($paging, 'next'),
+                'previous' => null === ag($paging, 'previous') ? '-' : (string) ag($paging, 'previous'),
+            ],
+        )));
+
+        $parts = array_values(array_filter([
+            '' !== (string) ag($filter, 'state', '') ? 'state=' . ag($filter, 'state') : null,
+            '' !== (string) ag($filter, 'filter', '') ? 'filter="' . ag($filter, 'filter') . '"' : null,
+        ]));
+        if ([] !== $parts) {
+            $output->writeln(OutputFormatter::escape('filters: ' . implode(', ', $parts)));
+        }
+
+        $items = (array) ag($response->body, 'items', []);
+        if ([] === $items) {
+            $output->writeln('No transport items matched the current filters.');
+            return self::SUCCESS;
+        }
+
+        foreach ($items as $item) {
+            $output->writeln(OutputFormatter::escape(r(
+                '{id} | {state} | {event} | {created_at}',
+                [
+                    'id' => ag($item, 'id', ''),
+                    'state' => ag($item, 'state', ''),
+                    'event' => ag($item, 'event', ''),
+                    'created_at' => ag($item, 'created_at', ''),
+                ],
+            )));
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildQuery(InputInterface $input): array
+    {
+        $state = strtolower(trim((string) $input->getOption('state')));
+        if ('' !== $state && false === in_array($state, self::STATES, true)) {
+            throw new InvalidArgumentException("Unknown transport state [{$state}].");
+        }
+
+        $query = [
+            'page' => $this->positiveInteger((string) $input->getOption('page'), 'Page'),
+            'perpage' => $this->positiveInteger((string) $input->getOption('perpage'), 'Per-page'),
+        ];
+
+        if ('' !== $state) {
+            $query['state'] = $state;
+        }
+
+        if ('' !== ($filter = trim((string) $input->getOption('filter')))) {
+            $query['filter'] = $filter;
+        }
+
+        return $query;
+    }
+
+    private function positiveInteger(string $value, string $label): int
+    {
+        $value = trim($value);
+        if (1 !== preg_match('/^\d+$/', $value) || (int) $value < 1) {
+            throw new InvalidArgumentException(r('{label} must be a positive integer.', ['label' => $label]));
+        }
+
+        return (int) $value;
+    }
+}

--- a/src/Commands/Transport/ViewCommand.php
+++ b/src/Commands/Transport/ViewCommand.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands\Transport;
+
+use App\Libs\Attributes\Route\Cli;
+use App\Libs\Enums\Http\Method;
+use App\Libs\Enums\Http\Status;
+use InvalidArgumentException;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[Cli(command: self::ROUTE)]
+final class ViewCommand extends AbstractTransportCommand
+{
+    public const string ROUTE = 'transport:queue:view';
+
+    protected function configure(): void
+    {
+        $this
+            ->setName(self::ROUTE)
+            ->setDescription('Show a detailed transport queue envelope.')
+            ->addArgument('id', InputArgument::REQUIRED, 'Envelope UUID or latest.')
+            ->addOption(
+                'section',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Section to render: summary, data, options, entry, all.',
+                'summary,data,options',
+            );
+    }
+
+    protected function runCommand(InputInterface $input, OutputInterface $output): int
+    {
+        $id = $this->resolveId(trim((string) $input->getArgument('id')), $output);
+        if (null === $id) {
+            return self::FAILURE;
+        }
+
+        try {
+            $sections = $this->parseSections((string) $input->getOption('section'));
+        } catch (InvalidArgumentException $e) {
+            $output->writeln('<error>' . $this->escape($e->getMessage()) . '</error>');
+            return self::FAILURE;
+        }
+
+        $response = api_request(Method::GET, r('/system/transport/queue/{id}', ['id' => $id]));
+        if (Status::OK !== $response->status) {
+            return $this->apiError($output, $response);
+        }
+
+        $mode = $this->outputMode($input);
+        if ('table' !== $mode) {
+            $this->displayContent((array) $response->body, $output, $mode);
+            return self::SUCCESS;
+        }
+
+        $this->renderView((array) $response->body, $sections, $output);
+
+        return self::SUCCESS;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        parent::complete($input, $suggestions);
+
+        if ($input->mustSuggestArgumentValuesFor('id')) {
+            $suggestions->suggestValues(['latest']);
+        }
+    }
+
+    private function resolveId(string $value, OutputInterface $output): ?string
+    {
+        if ('' === $value) {
+            $output->writeln('<error>Transport envelope id is required.</error>');
+            return null;
+        }
+
+        if ('latest' === strtolower($value)) {
+            $response = api_request(Method::GET, '/system/transport/queue', opts: [
+                'query' => ['page' => 1, 'perpage' => 1],
+            ]);
+
+            if (Status::OK !== $response->status) {
+                $this->apiError($output, $response);
+                return null;
+            }
+
+            $id = trim((string) ag($response->body, 'items.0.id', ''));
+            if ('' === $id) {
+                $output->writeln('<error>No transport envelopes are available.</error>');
+                return null;
+            }
+
+            return $id;
+        }
+
+        if (1 === preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i', $value)) {
+            return $value;
+        }
+
+        $matches = [];
+        $page = 1;
+        do {
+            $response = api_request(Method::GET, '/system/transport/queue', opts: [
+                'query' => ['page' => $page, 'perpage' => 100],
+            ]);
+
+            if (Status::OK !== $response->status) {
+                $this->apiError($output, $response);
+                return null;
+            }
+
+            foreach ((array) ag($response->body, 'items', []) as $item) {
+                $itemId = (string) ag($item, 'id', '');
+                if (str_starts_with($itemId, $value)) {
+                    $matches[$itemId] = true;
+                }
+            }
+
+            $page = (int) ag($response->body, 'paging.next', 0);
+        } while ($page > 0);
+
+        if (0 === count($matches)) {
+            $output->writeln(r('<error>No transport envelope matched id [{id}].</error>', ['id' => $value]));
+            return null;
+        }
+
+        if (1 !== count($matches)) {
+            $output->writeln(r('<error>Short transport id [{id}] is ambiguous.</error>', ['id' => $value]));
+            return null;
+        }
+
+        return (string) array_key_first($matches);
+    }
+}

--- a/src/Libs/Events/Queue/ArrayEventTransport.php
+++ b/src/Libs/Events/Queue/ArrayEventTransport.php
@@ -9,6 +9,9 @@ final class ArrayEventTransport implements EventTransportInterface
     /** @var array<EventEnvelope> */
     private array $items = [];
 
+    /** @var array<EventEnvelope> */
+    private array $processing = [];
+
     /**
      * @inheritdoc
      */
@@ -33,6 +36,7 @@ final class ArrayEventTransport implements EventTransportInterface
             }
 
             unset($this->items[$i]);
+            $this->processing[$envelope->id] = $envelope;
             $claimed[] = $envelope;
         }
 
@@ -44,20 +48,27 @@ final class ArrayEventTransport implements EventTransportInterface
     /**
      * @inheritdoc
      */
-    public function ack(EventEnvelope $envelope): void {}
+    public function ack(EventEnvelope $envelope): void
+    {
+        unset($this->processing[$envelope->id]);
+    }
 
     /**
      * @inheritdoc
      */
     public function release(EventEnvelope $envelope): void
     {
+        unset($this->processing[$envelope->id]);
         $this->items[] = $envelope;
     }
 
     /**
      * @inheritdoc
      */
-    public function fail(EventEnvelope $envelope): void {}
+    public function fail(EventEnvelope $envelope): void
+    {
+        unset($this->processing[$envelope->id]);
+    }
 
     /**
      * @inheritdoc
@@ -65,5 +76,74 @@ final class ArrayEventTransport implements EventTransportInterface
     public function count(): int
     {
         return count($this->items);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function inspect(
+        int $limit = 100,
+        int $offset = 0,
+        ?EventEnvelopeState $state = null,
+        ?string $filter = null,
+    ): array {
+        return array_slice($this->inspectable($state, $filter), max(0, $offset), max(1, $limit));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function inspectCount(?EventEnvelopeState $state = null, ?string $filter = null): int
+    {
+        return count($this->inspectable($state, $filter));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function inspectOne(string $id): ?EventEnvelope
+    {
+        foreach ($this->inspectable(null, null) as $envelope) {
+            if ($envelope->id === $id) {
+                return $envelope;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function inspectStates(): array
+    {
+        return [EventEnvelopeState::PENDING, EventEnvelopeState::PROCESSING];
+    }
+
+    /**
+     * @return array<EventEnvelope>
+     */
+    private function inspectable(?EventEnvelopeState $state, ?string $filter): array
+    {
+        $items = array_values(array_merge(
+            array_map(
+                static fn(EventEnvelope $envelope): EventEnvelope => $envelope->withState(EventEnvelopeState::PENDING),
+                $this->items,
+            ),
+            array_map(
+                static fn(EventEnvelope $envelope): EventEnvelope => $envelope->withState(EventEnvelopeState::PROCESSING),
+                $this->processing,
+            ),
+        ));
+
+        $filter = strtolower(trim((string) $filter));
+
+        return array_values(array_filter($items, static function (EventEnvelope $envelope) use ($state, $filter): bool {
+            if (null !== $state && $envelope->state !== $state) {
+                return false;
+            }
+
+            return '' === $filter || str_contains(strtolower($envelope->id . ' ' . $envelope->event), $filter);
+        }));
     }
 }

--- a/src/Libs/Events/Queue/EventEnvelope.php
+++ b/src/Libs/Events/Queue/EventEnvelope.php
@@ -20,6 +20,7 @@ final class EventEnvelope
         public readonly array $opts,
         public readonly string $createdAt,
         public readonly mixed $ack = null,
+        public readonly EventEnvelopeState $state = EventEnvelopeState::PENDING,
     ) {}
 
     /**
@@ -82,6 +83,23 @@ final class EventEnvelope
             opts: $this->opts,
             createdAt: $this->createdAt,
             ack: $ack,
+            state: $this->state,
+        );
+    }
+
+    /**
+     * Return this envelope with its current transport state.
+     */
+    public function withState(EventEnvelopeState $state): self
+    {
+        return new self(
+            id: $this->id,
+            event: $this->event,
+            data: $this->data,
+            opts: $this->opts,
+            createdAt: $this->createdAt,
+            ack: $this->ack,
+            state: $state,
         );
     }
 

--- a/src/Libs/Events/Queue/EventEnvelopeState.php
+++ b/src/Libs/Events/Queue/EventEnvelopeState.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Libs\Events\Queue;
+
+enum EventEnvelopeState: string
+{
+    case PENDING = 'pending';
+    case PROCESSING = 'processing';
+    case FAILED = 'failed';
+}

--- a/src/Libs/Events/Queue/EventTransportInterface.php
+++ b/src/Libs/Events/Queue/EventTransportInterface.php
@@ -37,4 +37,33 @@ interface EventTransportInterface
      * Count currently queued envelopes when supported by the transport.
      */
     public function count(): int;
+
+    /**
+     * Inspect envelopes currently held by the transport without claiming them.
+     *
+     * @return array<EventEnvelope>
+     */
+    public function inspect(
+        int $limit = 100,
+        int $offset = 0,
+        ?EventEnvelopeState $state = null,
+        ?string $filter = null,
+    ): array;
+
+    /**
+     * Count envelopes visible through transport inspection.
+     */
+    public function inspectCount(?EventEnvelopeState $state = null, ?string $filter = null): int;
+
+    /**
+     * Find one envelope by its exact identifier without claiming it.
+     */
+    public function inspectOne(string $id): ?EventEnvelope;
+
+    /**
+     * Return the states exposed by this transport.
+     *
+     * @return array<EventEnvelopeState>
+     */
+    public function inspectStates(): array;
 }

--- a/src/Libs/Events/Queue/FilesystemEventTransport.php
+++ b/src/Libs/Events/Queue/FilesystemEventTransport.php
@@ -128,6 +128,121 @@ final class FilesystemEventTransport implements EventTransportInterface
         return count($this->pendingFiles());
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function inspect(
+        int $limit = 100,
+        int $offset = 0,
+        ?EventEnvelopeState $state = null,
+        ?string $filter = null,
+    ): array {
+        $this->reclaimStale();
+
+        if ('' === trim((string) $filter)) {
+            return $this->readInspectable(array_slice(
+                $this->inspectableFiles($state),
+                max(0, $offset),
+                max(1, $limit),
+            ));
+        }
+
+        return array_slice($this->inspectable($state, $filter), max(0, $offset), max(1, $limit));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function inspectCount(?EventEnvelopeState $state = null, ?string $filter = null): int
+    {
+        $this->reclaimStale();
+
+        if ('' === trim((string) $filter)) {
+            return count($this->inspectableFiles($state));
+        }
+
+        return count($this->inspectable($state, $filter));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function inspectOne(string $id): ?EventEnvelope
+    {
+        foreach ($this->inspectable(null, null) as $envelope) {
+            if ($envelope->id === $id) {
+                return $envelope;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function inspectStates(): array
+    {
+        return EventEnvelopeState::cases();
+    }
+
+    /**
+     * @return array<EventEnvelope>
+     */
+    private function inspectable(?EventEnvelopeState $requestedState, ?string $filter): array
+    {
+        $filter = strtolower(trim((string) $filter));
+        $items = $this->readInspectable($this->inspectableFiles($requestedState));
+
+        return array_values(array_filter(
+            $items,
+            static fn(EventEnvelope $envelope): bool => str_contains(
+                strtolower($envelope->id . ' ' . $envelope->event),
+                $filter,
+            ),
+        ));
+    }
+
+    /**
+     * @return array<array{state:string,path:string}>
+     */
+    private function inspectableFiles(?EventEnvelopeState $requestedState): array
+    {
+        $files = [];
+
+        foreach (EventEnvelopeState::cases() as $state) {
+            if (null !== $requestedState && $state !== $requestedState) {
+                continue;
+            }
+
+            foreach ($this->files($state->value) as $file) {
+                $files[] = ['state' => $state->value, 'path' => $this->dir($state->value) . '/' . $file];
+            }
+        }
+
+        return $files;
+    }
+
+    /**
+     * @param array<array{state:string,path:string}> $files
+     * @return array<EventEnvelope>
+     */
+    private function readInspectable(array $files): array
+    {
+        $items = [];
+
+        foreach ($files as $file) {
+            try {
+                $items[] = EventEnvelope::fromArray($this->readPayload($file['path']), $file['path'])
+                    ->withState(EventEnvelopeState::from($file['state']));
+            } catch (Throwable) {
+                continue;
+            }
+        }
+
+        return $items;
+    }
+
     private function ensureDirectories(): void
     {
         foreach (['pending', 'processing', 'failed', 'tmp'] as $dir) {
@@ -162,15 +277,23 @@ final class FilesystemEventTransport implements EventTransportInterface
      */
     private function pendingFiles(): array
     {
+        return $this->files('pending', self::EXTENSION);
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function files(string $directory, ?string $suffix = null): array
+    {
         $files = [];
 
-        foreach (new DirectoryIterator($this->dir('pending')) as $file) {
+        foreach (new DirectoryIterator($this->dir($directory)) as $file) {
             if ($file->isDot() || false === $file->isFile()) {
                 continue;
             }
 
             $name = $file->getFilename();
-            if (false === str_ends_with($name, self::EXTENSION)) {
+            if (null !== $suffix && false === str_ends_with($name, $suffix)) {
                 continue;
             }
 

--- a/src/Libs/Events/Queue/NullEventTransport.php
+++ b/src/Libs/Events/Queue/NullEventTransport.php
@@ -44,4 +44,40 @@ final class NullEventTransport implements EventTransportInterface
     {
         return 0;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function inspect(
+        int $limit = 100,
+        int $offset = 0,
+        ?EventEnvelopeState $state = null,
+        ?string $filter = null,
+    ): array {
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function inspectCount(?EventEnvelopeState $state = null, ?string $filter = null): int
+    {
+        return 0;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function inspectOne(string $id): ?EventEnvelope
+    {
+        return null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function inspectStates(): array
+    {
+        return [];
+    }
 }

--- a/src/Libs/Events/Queue/RedisStreamEventTransport.php
+++ b/src/Libs/Events/Queue/RedisStreamEventTransport.php
@@ -99,6 +99,139 @@ final class RedisStreamEventTransport implements EventTransportInterface
         return is_int($count) ? $count : 0;
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function inspect(
+        int $limit = 100,
+        int $offset = 0,
+        ?EventEnvelopeState $state = null,
+        ?string $filter = null,
+    ): array {
+        if (null === $state && '' === trim((string) $filter)) {
+            $records = $this->readInspectable(max(1, $offset + $limit));
+            if ([] === $records) {
+                return [];
+            }
+
+            $ids = array_keys($records);
+            $items = $this->parseStreamEntries(
+                $records,
+                false,
+                $this->processingIds((string) reset($ids), (string) end($ids)),
+            );
+
+            return array_slice($items, max(0, $offset), max(1, $limit));
+        }
+
+        return array_slice($this->inspectable($state, $filter), max(0, $offset), max(1, $limit));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function inspectCount(?EventEnvelopeState $state = null, ?string $filter = null): int
+    {
+        if (null === $state && '' === trim((string) $filter)) {
+            return $this->count();
+        }
+
+        return count($this->inspectable($state, $filter));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function inspectOne(string $id): ?EventEnvelope
+    {
+        foreach ($this->inspectable(null, null) as $envelope) {
+            if ($envelope->id === $id) {
+                return $envelope;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function inspectStates(): array
+    {
+        return [EventEnvelopeState::PENDING, EventEnvelopeState::PROCESSING];
+    }
+
+    /**
+     * @return array<EventEnvelope>
+     */
+    private function inspectable(?EventEnvelopeState $state, ?string $filter): array
+    {
+        $records = $this->readInspectable();
+        $items = $this->parseStreamEntries($records, false, $this->processingIds());
+        $filter = strtolower(trim((string) $filter));
+
+        return array_values(array_filter($items, static function (EventEnvelope $envelope) use ($state, $filter): bool {
+            if (null !== $state && $envelope->state !== $state) {
+                return false;
+            }
+
+            return '' === $filter || str_contains(strtolower($envelope->id . ' ' . $envelope->event), $filter);
+        }));
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private function processingIds(string $start = '-', string $end = '+'): array
+    {
+        try {
+            $summary = $this->redis->rawCommand('XPENDING', $this->stream, $this->group);
+            $count = is_array($summary) && is_numeric($summary[0] ?? null) ? (int) $summary[0] : 0;
+            if ($count < 1) {
+                return [];
+            }
+
+            $records = $this->redis->rawCommand('XPENDING', $this->stream, $this->group, $start, $end, (string) $count);
+        } catch (Throwable $e) {
+            if (true === str_contains($e->getMessage(), 'NOGROUP')) {
+                return [];
+            }
+
+            throw $e;
+        }
+
+        if (false === is_array($records)) {
+            return [];
+        }
+
+        $ids = [];
+        foreach ($records as $record) {
+            if (false === is_array($record) || false === is_string($record[0] ?? null)) {
+                continue;
+            }
+
+            $ids[$record[0]] = true;
+        }
+
+        return $ids;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function readInspectable(?int $count = null): array
+    {
+        $records = null === $count
+            ? $this->redis->xRange($this->stream, '-', '+')
+            : $this->redis->xRange($this->stream, '-', '+', $count);
+
+        if (false === is_array($records)) {
+            throw new RuntimeException(r("Unable to inspect Redis stream '{stream}'.", ['stream' => $this->stream]));
+        }
+
+        return $records;
+    }
+
     private function createGroup(): void
     {
         if (true === $this->groupReady) {
@@ -173,9 +306,10 @@ final class RedisStreamEventTransport implements EventTransportInterface
 
     /**
      * @param array<mixed> $entries
+     * @param array<string, true> $processingIds
      * @return array<EventEnvelope>
      */
-    private function parseStreamEntries(array $entries): array
+    private function parseStreamEntries(array $entries, bool $cleanup = true, array $processingIds = []): array
     {
         $items = [];
 
@@ -196,16 +330,23 @@ final class RedisStreamEventTransport implements EventTransportInterface
 
             $data = json_decode($payload, true);
             if (false === is_array($data)) {
-                $this->redis->xAck($this->stream, $this->group, [$id]);
-                $this->redis->xDel($this->stream, [$id]);
+                if (true === $cleanup) {
+                    $this->redis->xAck($this->stream, $this->group, [$id]);
+                    $this->redis->xDel($this->stream, [$id]);
+                }
                 continue;
             }
 
             try {
-                $items[] = EventEnvelope::fromArray($data, $id);
+                $state = true === ($processingIds[$id] ?? false)
+                    ? EventEnvelopeState::PROCESSING
+                    : EventEnvelopeState::PENDING;
+                $items[] = EventEnvelope::fromArray($data, $id)->withState($state);
             } catch (Throwable) {
-                $this->redis->xAck($this->stream, $this->group, [$id]);
-                $this->redis->xDel($this->stream, [$id]);
+                if (true === $cleanup) {
+                    $this->redis->xAck($this->stream, $this->group, [$id]);
+                    $this->redis->xDel($this->stream, [$id]);
+                }
             }
         }
 

--- a/src/Libs/Initializer.php
+++ b/src/Libs/Initializer.php
@@ -474,14 +474,16 @@ final class Initializer
                 ->pushHandler($wrap->withHandler($accessHandler));
 
             assert($this->accessLog instanceof Logger, 'Expected logger instance for access log.');
-            $this->accessLog->pushHandler($wrap->withHandler(
-                $this->createStreamHandler(
-                    'php://stderr',
-                    ag($accessContext, 'level', Level::Info),
-                    true,
-                    ag($accessContext, 'format', 'text'),
-                ),
-            ));
+            if (true === $inContainer) {
+                $this->accessLog->pushHandler($wrap->withHandler(
+                    $this->createStreamHandler(
+                        'php://stderr',
+                        ag($accessContext, 'level', Level::Info),
+                        true,
+                        ag($accessContext, 'format', 'text'),
+                    ),
+                ));
+            }
         }
 
         foreach ($loggers as $name => $context) {

--- a/src/Libs/Utils.php
+++ b/src/Libs/Utils.php
@@ -1890,7 +1890,7 @@ if (!function_exists('flat_array')) {
         $out = [];
 
         foreach ($obj as $key => $val) {
-            $path = $prefix ? "{$prefix}{$separator}{$key}" : $key;
+            $path = $prefix ? "{$prefix}{$separator}{$key}" : (string) $key;
 
             if ((is_array($val) || is_object($val)) && count((array) $val) > 0) {
                 $out = array_merge($out, flat_array((array) $val, $path, $separator));

--- a/tests/API/System/StatsTest.php
+++ b/tests/API/System/StatsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\API\System;
+
+use App\API\System\Stats;
+use App\Libs\Events\Queue\ArrayEventTransport;
+use App\Libs\Events\Queue\EventEnvelope;
+use App\Libs\TestCase;
+use App\Model\Events\EventsRepository;
+use App\Model\Events\EventStatus;
+
+final class StatsTest extends TestCase
+{
+    public function test_get(): void
+    {
+        $events = $this->createMock(EventsRepository::class);
+        $events
+            ->expects(self::once())
+            ->method('countByStatus')
+            ->with(EventStatus::PENDING)
+            ->willReturn(4);
+
+        $transport = new ArrayEventTransport();
+        $transport->enqueue(EventEnvelope::create('on_push'));
+        $transport->enqueue(EventEnvelope::create('on_webhook'));
+
+        $response = new Stats($events, $transport)->get();
+        $payload = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(4, ag($payload, 'events.pending'));
+        self::assertSame(2, ag($payload, 'transport.pending'));
+    }
+}

--- a/tests/API/System/TransportQueueTest.php
+++ b/tests/API/System/TransportQueueTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\API\System;
+
+use App\API\System\TransportQueue;
+use App\Libs\Enums\Http\Status;
+use App\Libs\Events\Queue\ArrayEventTransport;
+use App\Libs\Events\Queue\EventEnvelope;
+use App\Libs\TestCase;
+use Tests\Support\RequestResponseTrait;
+
+final class TransportQueueTest extends TestCase
+{
+    use RequestResponseTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->initTempApp();
+    }
+
+    public function test_list(): void
+    {
+        $transport = new ArrayEventTransport();
+        $first = EventEnvelope::create('on_webhook', ['payload' => 'first']);
+        $second = EventEnvelope::create('on_push', ['payload' => 'second']);
+        $transport->enqueue($first);
+        $transport->enqueue($second);
+
+        $handler = new TransportQueue($transport);
+        $queueResponse = $handler->list($this->getRequest(query: ['page' => 2, 'perpage' => 1]));
+        self::assertSame(Status::OK->value, $queueResponse->getStatusCode());
+        $queuePayload = json_decode((string) $queueResponse->getBody(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertSame($second->id, ag($queuePayload, 'items.0.id'));
+        self::assertArrayNotHasKey('data', $queuePayload['items'][0]);
+        self::assertArrayNotHasKey('options', $queuePayload['items'][0]);
+        self::assertSame(2, ag($queuePayload, 'paging.page'));
+        self::assertSame(2, ag($queuePayload, 'paging.total'));
+        self::assertSame(1, ag($queuePayload, 'paging.perpage'));
+        self::assertSame(1, ag($queuePayload, 'paging.previous'));
+        self::assertNull(ag($queuePayload, 'paging.next'));
+        self::assertSame(['pending', 'processing'], ag($queuePayload, 'states'));
+    }
+
+    public function test_filter(): void
+    {
+        $transport = new ArrayEventTransport();
+        $webhook = EventEnvelope::create('on_webhook');
+        $transport->enqueue($webhook);
+        $transport->enqueue(EventEnvelope::create('on_push'));
+        $transport->dequeue(1);
+
+        $response = new TransportQueue($transport)->list($this->getRequest(query: [
+            'state' => 'processing',
+            'filter' => 'webhook',
+        ]));
+        $payload = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+
+        self::assertSame($webhook->id, ag($payload, 'items.0.id'));
+        self::assertSame('processing', ag($payload, 'items.0.state'));
+        self::assertSame(1, ag($payload, 'paging.total'));
+    }
+
+    public function test_view(): void
+    {
+        $transport = new ArrayEventTransport();
+        $envelope = EventEnvelope::create('on_webhook', ['payload' => 'view'], ['delay' => 5]);
+        $transport->enqueue($envelope);
+
+        $response = new TransportQueue($transport)->view($envelope->id);
+        $payload = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+
+        self::assertSame(Status::OK->value, $response->getStatusCode());
+        self::assertSame($envelope->id, ag($payload, 'id'));
+        self::assertSame('view', ag($payload, 'data.payload'));
+        self::assertSame(5, ag($payload, 'options.delay'));
+    }
+
+    public function test_view_missing(): void
+    {
+        $response = new TransportQueue(new ArrayEventTransport())->view(generate_uuid());
+
+        self::assertSame(Status::NOT_FOUND->value, $response->getStatusCode());
+    }
+
+    public function test_invalid_state(): void
+    {
+        $response = new TransportQueue(new ArrayEventTransport())->list($this->getRequest(query: [
+            'state' => 'unknown',
+        ]));
+
+        self::assertSame(Status::BAD_REQUEST->value, $response->getStatusCode());
+    }
+}

--- a/tests/Commands/Transport/QueueCommandTest.php
+++ b/tests/Commands/Transport/QueueCommandTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands\Transport;
+
+use App\API\System\TransportQueue;
+use App\Commands\Transport\QueueCommand;
+use App\Commands\Transport\ViewCommand;
+use App\Libs\Container;
+use App\Libs\Events\Queue\ArrayEventTransport;
+use App\Libs\Events\Queue\EventEnvelope;
+use App\Libs\Initializer;
+use App\Libs\TestCase;
+use Psr\Http\Message\ResponseInterface as iResponse;
+use Psr\Http\Message\ServerRequestInterface as iRequest;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class QueueCommandTest extends TestCase
+{
+    private ArrayEventTransport $transport;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->initTempApp();
+        $this->transport = new ArrayEventTransport();
+        $this->registerInitializer();
+    }
+
+    public function test_list_table(): void
+    {
+        $this->transport->enqueue(EventEnvelope::create('on_webhook'));
+
+        $tester = $this->makeTester();
+        $status = $tester->execute([]);
+
+        self::assertSame(QueueCommand::SUCCESS, $status);
+        self::assertStringContainsString('Transport Queue', $tester->getDisplay());
+        self::assertStringContainsString('on_webhook', $tester->getDisplay());
+        self::assertStringContainsString('page 1 | per-page 25 | total 1', $tester->getDisplay());
+    }
+
+    public function test_list_json(): void
+    {
+        $this->transport->enqueue(EventEnvelope::create('on_push', ['ok' => true]));
+
+        $tester = $this->makeTester();
+        $status = $tester->execute(['--output' => 'json']);
+        $payload = json_decode($tester->getDisplay(), true, flags: JSON_THROW_ON_ERROR);
+
+        self::assertSame(QueueCommand::SUCCESS, $status);
+        self::assertSame('on_push', ag($payload, 'items.0.event'));
+        self::assertArrayNotHasKey('data', $payload['items'][0]);
+        self::assertArrayNotHasKey('options', $payload['items'][0]);
+        self::assertSame(1, ag($payload, 'paging.total'));
+    }
+
+    public function test_list_filter(): void
+    {
+        $this->transport->enqueue(EventEnvelope::create('on_webhook'));
+        $this->transport->enqueue(EventEnvelope::create('on_push'));
+
+        $tester = $this->makeTester();
+        $status = $tester->execute(['--filter' => 'webhook']);
+
+        self::assertSame(QueueCommand::SUCCESS, $status);
+        self::assertStringContainsString('on_webhook', $tester->getDisplay());
+        self::assertStringNotContainsString('on_push', $tester->getDisplay());
+    }
+
+    public function test_view(): void
+    {
+        $envelope = EventEnvelope::create('on_webhook', ['ok' => true], ['delay' => 5]);
+        $this->transport->enqueue($envelope);
+
+        $application = new Application();
+        $application->getDefinition()->addOption(new InputOption('output', 'o', InputOption::VALUE_REQUIRED, '', 'table'));
+        $application->addCommand(new ViewCommand());
+        $tester = new CommandTester($application->find(ViewCommand::ROUTE));
+
+        $status = $tester->execute(['id' => $envelope->id]);
+
+        self::assertSame(ViewCommand::SUCCESS, $status);
+        self::assertStringContainsString('Summary', $tester->getDisplay());
+        self::assertStringContainsString('on_webhook', $tester->getDisplay());
+        self::assertStringContainsString('"delay": 5', $tester->getDisplay());
+    }
+
+    public function test_invalid_page(): void
+    {
+        $tester = $this->makeTester();
+        $status = $tester->execute(['--page' => 'nope']);
+
+        self::assertSame(QueueCommand::FAILURE, $status);
+        self::assertStringContainsString('Page must be a positive integer.', $tester->getDisplay());
+    }
+
+    public function test_invalid_state(): void
+    {
+        $tester = $this->makeTester();
+        $status = $tester->execute(['--state' => 'unknown']);
+
+        self::assertSame(QueueCommand::FAILURE, $status);
+        self::assertStringContainsString('Unknown transport state', $tester->getDisplay());
+    }
+
+    private function makeTester(): CommandTester
+    {
+        $application = new Application();
+        $application->getDefinition()->addOption(new InputOption('output', 'o', InputOption::VALUE_REQUIRED, '', 'table'));
+        $application->addCommand(new QueueCommand());
+        $application->addCommand(new ViewCommand());
+
+        return new CommandTester($application->find(QueueCommand::ROUTE));
+    }
+
+    private function registerInitializer(): void
+    {
+        Container::add(Initializer::class, [
+            'shared' => true,
+            'class' => function () {
+                return new class($this->transport) {
+                    public function __construct(
+                        private readonly ArrayEventTransport $transport,
+                    ) {}
+
+                    public function http(iRequest $request): iResponse
+                    {
+                        $path = $request->getUri()->getPath();
+                        if (str_contains($path, '/system/transport/queue/') && !str_ends_with($path, '/queue/')) {
+                            return new TransportQueue($this->transport)->view(basename($path));
+                        }
+
+                        return new TransportQueue($this->transport)->list($request);
+                    }
+                };
+            },
+        ]);
+    }
+}

--- a/tests/Libs/Events/ArrayAndNullEventTransportTest.php
+++ b/tests/Libs/Events/ArrayAndNullEventTransportTest.php
@@ -6,6 +6,7 @@ namespace Tests\Libs\Events;
 
 use App\Libs\Events\Queue\ArrayEventTransport;
 use App\Libs\Events\Queue\EventEnvelope;
+use App\Libs\Events\Queue\EventEnvelopeState;
 use App\Libs\Events\Queue\NullEventTransport;
 use App\Libs\TestCase;
 
@@ -35,6 +36,7 @@ final class ArrayAndNullEventTransportTest extends TestCase
 
         self::assertSame($envelope, $transport->enqueue($envelope));
         self::assertSame(1, $transport->count());
+        self::assertSame($envelope->id, $transport->inspectOne($envelope->id)?->id);
     }
 
     public function test_array_dequeue(): void
@@ -67,5 +69,23 @@ final class ArrayAndNullEventTransportTest extends TestCase
         $reclaimed = $transport->dequeue(10);
         self::assertCount(1, $reclaimed);
         self::assertSame($events[0]->id, $reclaimed[0]->id);
+    }
+
+    public function test_array_inspect(): void
+    {
+        $transport = new ArrayEventTransport();
+        $processing = EventEnvelope::create('on_webhook');
+        $pending = EventEnvelope::create('on_push');
+        $transport->enqueue($processing);
+        $transport->enqueue($pending);
+        $transport->dequeue(1);
+
+        $items = $transport->inspect(state: EventEnvelopeState::PROCESSING, filter: 'webhook');
+
+        self::assertTrue(array_is_list($items));
+        self::assertCount(1, $items);
+        self::assertSame($processing->id, $items[0]->id);
+        self::assertSame(EventEnvelopeState::PROCESSING, $items[0]->state);
+        self::assertSame(1, $transport->inspectCount(EventEnvelopeState::PROCESSING, 'webhook'));
     }
 }

--- a/tests/Libs/Events/FilesystemEventTransportTest.php
+++ b/tests/Libs/Events/FilesystemEventTransportTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Libs\Events;
 
 use App\Libs\Events\Queue\EventEnvelope;
+use App\Libs\Events\Queue\EventEnvelopeState;
 use App\Libs\Events\Queue\FilesystemEventTransport;
 use App\Libs\TestCase;
 
@@ -43,6 +44,44 @@ final class FilesystemEventTransportTest extends TestCase
         self::assertSame($events[0]->id, $reclaimed[0]->id);
         self::assertSame($events[0]->event, $reclaimed[0]->event);
         self::assertSame($events[0]->data, $reclaimed[0]->data);
+    }
+
+    public function test_inspect(): void
+    {
+        $transport = $this->transport();
+        $envelope = EventEnvelope::create('on_webhook', ['ok' => true]);
+        $transport->enqueue($envelope);
+
+        $items = $transport->inspect();
+
+        self::assertCount(1, $items);
+        self::assertSame($envelope->id, $items[0]->id);
+        self::assertSame(EventEnvelopeState::PENDING, $items[0]->state);
+        self::assertSame(['ok' => true], $items[0]->data);
+        self::assertSame($envelope->id, $transport->inspectOne($envelope->id)?->id);
+    }
+
+    public function test_inspect_pages_states(): void
+    {
+        $transport = $this->transport();
+        $first = EventEnvelope::create('on_webhook');
+        $second = EventEnvelope::create('on_push');
+        $third = EventEnvelope::create('on_progress');
+        $transport->enqueue($first);
+        $transport->enqueue($second);
+        $transport->enqueue($third);
+
+        $processing = $transport->dequeue(2);
+        $transport->fail($processing[1]);
+
+        $items = $transport->inspect(2, 1);
+
+        self::assertCount(2, $items);
+        self::assertSame($processing[0]->id, $items[0]->id);
+        self::assertSame(EventEnvelopeState::PROCESSING, $items[0]->state);
+        self::assertSame($processing[1]->id, $items[1]->id);
+        self::assertSame(EventEnvelopeState::FAILED, $items[1]->state);
+        self::assertSame(1, $transport->inspectCount(EventEnvelopeState::PENDING, 'progress'));
     }
 
     private function transport(int $claimAfterSeconds = 300): FilesystemEventTransport

--- a/tests/Libs/Events/RedisStreamEventTransportTest.php
+++ b/tests/Libs/Events/RedisStreamEventTransportTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Libs\Events;
+
+use App\Libs\Events\Queue\EventEnvelope;
+use App\Libs\Events\Queue\EventEnvelopeState;
+use App\Libs\Events\Queue\RedisStreamEventTransport;
+use App\Libs\TestCase;
+use Redis;
+use RuntimeException;
+
+final class RedisStreamEventTransportTest extends TestCase
+{
+    public function test_inspect(): void
+    {
+        $redis = $this->createMock(Redis::class);
+        $pending = EventEnvelope::create('on_webhook');
+        $processing = EventEnvelope::create('on_push');
+        $redis
+            ->expects($this->once())
+            ->method('xRange')
+            ->willReturn([
+                '1-0' => ['payload' => json_encode($pending->toArray(), flags: JSON_THROW_ON_ERROR)],
+                '2-0' => ['payload' => json_encode($processing->toArray(), flags: JSON_THROW_ON_ERROR)],
+            ]);
+        $redis
+            ->expects($this->exactly(2))
+            ->method('rawCommand')
+            ->willReturnOnConsecutiveCalls(
+                [1, '2-0', '2-0', [['consumer', 1]]],
+                [['2-0', 'consumer', 1, 1]],
+            );
+        $redis->expects($this->never())->method('xAck');
+        $redis->expects($this->never())->method('xDel');
+
+        $items = $this->transport($redis)->inspect();
+
+        self::assertCount(2, $items);
+        self::assertSame(EventEnvelopeState::PENDING, $items[0]->state);
+        self::assertSame(EventEnvelopeState::PROCESSING, $items[1]->state);
+    }
+
+    public function test_inspect_error(): void
+    {
+        $redis = $this->createStub(Redis::class);
+        $redis->method('xRange')->willThrowException(new RuntimeException('Redis unavailable.'));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Redis unavailable.');
+
+        $this->transport($redis)->inspect();
+    }
+
+    private function transport(Redis $redis): RedisStreamEventTransport
+    {
+        return new RedisStreamEventTransport($redis, 'events', 'watchstate', 'test');
+    }
+}


### PR DESCRIPTION
This pull request updates the documentation and CI workflows to improve clarity, accuracy, and maintainability, and adds new API endpoints. The most significant changes are the addition of new system and transport queue API endpoints, multiple dependency updates in GitHub Actions workflows, and various documentation clarifications.

**API documentation improvements:**

* Added documentation for three new system-level API endpoints: `GET /v1/api/system/stats`, `GET /v1/api/system/transport/queue`, and `GET /v1/api/system/transport/queue/{id}`. These endpoints provide pending event/transport counts and allow inspection of the transport queue and its items.

**CI workflow updates:**

* Updated GitHub Actions versions

**General documentation and clarity:**

* Reworded and clarified explanations in `FAQ.md` regarding import/export semantics, credential format, and Jellyfin played state workarounds. 
* Improved `NEWS.md` entries for clarity, conciseness, and accuracy, especially around playlist sync, the v1.0.0 release, webhooks, and authentication changes. [[1]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaL14-R15) [[2]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaL34-R51) [[3]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaL67-R78)

These changes collectively improve the developer and user experience by keeping documentation accurate and workflows up-to-date.