### PR TITLE
fix: require authorization for backend webhook registration

### DIFF
--- a/src/Libs/Middlewares/AuthorizationMiddleware.php
+++ b/src/Libs/Middlewares/AuthorizationMiddleware.php
@@ -9,6 +9,7 @@ use App\API\Player\Index as PlayerIndex;
 use App\API\System\Auth;
 use App\API\System\HealthCheck;
 use App\API\System\StaticFiles;
+use App\API\WebHook;
 use App\Libs\Config;
 use App\Libs\Enums\Http\Method;
 use App\Libs\Enums\Http\Status;
@@ -24,25 +25,29 @@ final class AuthorizationMiddleware implements MiddlewareInterface
     public const string KEY_NAME = 'apikey';
     public const string TOKEN_NAME = 'ws_token';
 
+    private const string MATCH_EXACT = 'exact';
+    private const string MATCH_PREFIX = 'prefix';
+
     /**
      * Public routes that are accessible without an API key. and must remain open.
      */
     private const array PUBLIC_ROUTES = [
-        PlayerIndex::URL,
-        PlexToken::URL,
-        StaticFiles::URL,
-        HealthCheck::URL,
-        Auth::URL . '/test',
-        Auth::URL . '/has_user',
-        Auth::URL . '/signup',
-        Auth::URL . '/login',
+        PlayerIndex::URL => self::MATCH_PREFIX,
+        StaticFiles::URL => self::MATCH_PREFIX,
+        PlexToken::URL . '/generate' => self::MATCH_EXACT,
+        PlexToken::URL . '/check' => self::MATCH_EXACT,
+        HealthCheck::URL => self::MATCH_EXACT,
+        Auth::URL . '/test' => self::MATCH_EXACT,
+        Auth::URL . '/has_user' => self::MATCH_EXACT,
+        Auth::URL . '/signup' => self::MATCH_EXACT,
+        Auth::URL . '/login' => self::MATCH_EXACT,
     ];
 
     /**
      * Routes that follow the open route policy. However, those routes are subject to user configuration.
      */
     private const array OPEN_ROUTES = [
-        '/webhook',
+        WebHook::URL => self::MATCH_EXACT,
     ];
 
     public function process(iRequest $request, iHandler $handler): iResponse
@@ -59,12 +64,17 @@ final class AuthorizationMiddleware implements MiddlewareInterface
 
         $openRoutes = self::PUBLIC_ROUTES;
         if (false === (bool) Config::get('api.secure', false)) {
-            $openRoutes = array_merge($openRoutes, self::OPEN_ROUTES);
+            $openRoutes += self::OPEN_ROUTES;
         }
 
-        foreach ($openRoutes as $route) {
+        foreach ($openRoutes as $route => $strategy) {
             $route = rtrim(parse_config_value($route), '/');
-            if (true === str_starts_with($requestPath, $route) || true === str_ends_with($requestPath, $route)) {
+            $matched = match ($strategy) {
+                self::MATCH_EXACT => $route === $requestPath,
+                self::MATCH_PREFIX => $route === $requestPath || true === str_starts_with($requestPath, $route . '/'),
+            };
+
+            if (true === $matched) {
                 return $handler->handle($request);
             }
         }

--- a/tests/Libs/Middlewares/AuthorizationMiddlewareTest.php
+++ b/tests/Libs/Middlewares/AuthorizationMiddlewareTest.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Libs\Middlewares;
 
+use App\API\Backends\PlexToken;
+use App\API\Player\Index as PlayerIndex;
 use App\API\System\Auth;
 use App\API\System\HealthCheck;
+use App\API\System\StaticFiles;
+use App\API\WebHook;
 use App\Libs\Config;
 use App\Libs\Enums\Http\Method;
 use App\Libs\Enums\Http\Status;
@@ -51,16 +55,23 @@ class AuthorizationMiddlewareTest extends TestCase
         $routes = [
             HealthCheck::URL,
             Auth::URL . '/test',
+            Auth::URL . '/has_user',
+            Auth::URL . '/signup',
+            Auth::URL . '/login',
+            PlayerIndex::URL . '/stream/token',
+            PlexToken::URL . '/generate',
+            PlexToken::URL . '/check',
+            StaticFiles::URL . '/app.js',
         ];
 
         $routesSemiOpen = [
-            '/webhook',
+            WebHook::URL,
         ];
 
         foreach ($routes as $route) {
             $uri = parse_config_value($route);
             $result = new AuthorizationMiddleware()->process(
-                request: $this->getRequest(uri: $uri),
+                request: $this->getRequest(uri: $uri)->withoutHeader('Authorization'),
                 handler: $this->getHandler(),
             );
             $this->assertSame(Status::OK, Status::from($result->getStatusCode()), "Open route '{$uri}' failed");
@@ -69,7 +80,7 @@ class AuthorizationMiddlewareTest extends TestCase
         foreach ($routesSemiOpen as $route) {
             $uri = parse_config_value($route);
             $result = new AuthorizationMiddleware()->process(
-                request: $this->getRequest(uri: $uri),
+                request: $this->getRequest(uri: $uri)->withoutHeader('Authorization'),
                 handler: $this->getHandler(),
             );
             $this->assertSame(Status::OK, Status::from($result->getStatusCode()), "Open route '{$uri}' failed");
@@ -117,6 +128,65 @@ class AuthorizationMiddlewareTest extends TestCase
                 Status::OK,
                 Status::from($result->getStatusCode()),
                 "Route '{$uri}' should pass with correct API key",
+            );
+        }
+
+        Config::reset();
+    }
+
+    public function test_open_route_trailing_slash(): void
+    {
+        Config::save('api.prefix', '/v1/api');
+
+        $result = new AuthorizationMiddleware()->process(
+            request: $this->getRequest(uri: parse_config_value(Auth::URL . '/test/'))->withoutHeader('Authorization'),
+            handler: $this->getHandler(),
+        );
+
+        $this->assertSame(Status::OK, Status::from($result->getStatusCode()));
+
+        Config::reset();
+    }
+
+    public function test_webhook_suffix_protected(): void
+    {
+        Config::save('api.prefix', '/v1/api');
+        Config::save('api.secure', false);
+
+        $result = new AuthorizationMiddleware()->process(
+            request: $this->getRequest(uri: '/v1/api/backend/plex/webhook')->withoutHeader('Authorization'),
+            handler: $this->getHandler(),
+        );
+
+        $this->assertSame(Status::BAD_REQUEST, Status::from($result->getStatusCode()));
+
+        Config::reset();
+    }
+
+    public function test_open_route_boundaries(): void
+    {
+        Config::save('api.prefix', '/v1/api');
+        Config::save('api.secure', false);
+
+        $routes = [
+            Auth::URL . '/login/admin',
+            PlayerIndex::URL . '-admin',
+            PlexToken::URL . '/generate/admin',
+            StaticFiles::URL . '-private',
+            WebHook::URL . '/admin',
+        ];
+
+        foreach ($routes as $route) {
+            $uri = parse_config_value($route);
+            $result = new AuthorizationMiddleware()->process(
+                request: $this->getRequest(uri: $uri)->withoutHeader('Authorization'),
+                handler: $this->getHandler(),
+            );
+
+            $this->assertSame(
+                Status::BAD_REQUEST,
+                Status::from($result->getStatusCode()),
+                "Route '{$uri}' should require authorization",
             );
         }
 


### PR DESCRIPTION
## Summary

Require authorization for backend webhook registration while preserving the intended public webhook receiver.

## Changes

- Restrict the conditionally public webhook route to the configured receiver path.
- Preserve existing public route behavior.
- Add regression tests for webhook authorization and public routes.

