### PR TITLE
refactor: remove plex library agent gating

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -299,7 +299,9 @@ If there are no errors, the database has been repaired successfully. And you can
 
 ---
 
-# Which Providers id `GUIDs` supported by for PlexClient?
+# Which provider `GUIDs` does Plex support?
+
+WatchState parses the following Plex GUIDs:
 
 * tvdb://(id)
 * imdb://(id)

--- a/src/Backends/Plex/Action/GetLibrariesList.php
+++ b/src/Backends/Plex/Action/GetLibrariesList.php
@@ -121,9 +121,6 @@ final class GetLibrariesList
         foreach ($listDirs as $section) {
             $key = (int) ag($section, 'key');
             $type = ag($section, 'type', 'unknown');
-            $agent = ag($section, 'agent', 'unknown');
-            $supportedType = PlexClient::TYPE_MOVIE === $type || PlexClient::TYPE_SHOW === $type;
-
             $webUrl = $context
                 ->backendUrl
                 ->withPath('/web/index.html')
@@ -145,7 +142,7 @@ final class GetLibrariesList
                 'title' => ag($section, 'title', '???'),
                 'type' => ucfirst($type),
                 'ignored' => true === in_array($key, $ignoreIds ?? [], true),
-                'supported' => $supportedType && true === in_array($agent, PlexClient::SUPPORTED_AGENTS, true),
+                'supported' => true === in_array($type, [PlexClient::TYPE_MOVIE, PlexClient::TYPE_SHOW], true),
                 'agent' => ag($section, 'agent'),
                 'scanner' => ag($section, 'scanner'),
                 'contentType' => $contentType,

--- a/src/Backends/Plex/Action/Import.php
+++ b/src/Backends/Plex/Action/Import.php
@@ -270,17 +270,6 @@ class Import
                 continue;
             }
 
-            if (false === in_array(ag($logContext, 'library.agent'), PlexClient::SUPPORTED_AGENTS, true)) {
-                $this->logger->notice(
-                    message: "Ignoring '{identity.user}@{identity.backend}' - '{library.title}' Unsupported agent type. '{agent}'.",
-                    context: [
-                        ...$logContext,
-                        'agent' => ag($logContext, 'library.agent', '??'),
-                    ],
-                );
-                continue;
-            }
-
             $isMovieLibrary = PlexClient::TYPE_MOVIE === ag($logContext, 'library.type');
 
             $url = $context
@@ -436,10 +425,6 @@ class Import
                 continue;
             }
 
-            if (!in_array(ag($section, 'agent'), PlexClient::SUPPORTED_AGENTS, true)) {
-                continue;
-            }
-
             if ($selectLibraryList && $inverseLibrarySelect === in_array($libraryId, $selectLibraryList, true)) {
                 continue;
             }
@@ -539,10 +524,6 @@ class Import
                     'type' => ag($section, 'type', 'unknown'),
                 ],
             ];
-
-            if (false === in_array(ag($section, 'agent'), PlexClient::SUPPORTED_AGENTS, true)) {
-                continue;
-            }
 
             if (true === in_array($libraryId, $ignoreIds ?? [], true)) {
                 $ignored++;

--- a/src/Backends/Plex/PlexClient.php
+++ b/src/Backends/Plex/PlexClient.php
@@ -92,25 +92,6 @@ class PlexClient implements iClient
     ];
 
     /**
-     * @var array List of supported agents.
-     */
-    public const array SUPPORTED_AGENTS = [
-        'com.plexapp.agents.imdb',
-        'com.plexapp.agents.tmdb',
-        'com.plexapp.agents.themoviedb',
-        'com.plexapp.agents.xbmcnfo',
-        'com.plexapp.agents.xbmcnfotv',
-        'com.plexapp.agents.thetvdb',
-        'com.plexapp.agents.hama',
-        'com.plexapp.agents.ytinforeader',
-        'com.plexapp.agents.cmdb',
-        'tv.plex.agents.movie',
-        'tv.plex.agents.series',
-        'tv.plex.agents.nfo.movie',
-        'tv.plex.agents.nfo.series',
-    ];
-
-    /**
      * @var mixed $context Backend context.
      */
     private Context $context;

--- a/tests/Backends/Plex/GetLibrariesListTest.php
+++ b/tests/Backends/Plex/GetLibrariesListTest.php
@@ -93,7 +93,6 @@ class GetLibrariesListTest extends TestCase
             $key = (int) ag($item, 'key');
             $type = ag($item, 'type', 'unknown');
             $agent = ag($item, 'agent', 'unknown');
-            $supportedType = PlexClient::TYPE_MOVIE === $type || PlexClient::TYPE_SHOW === $type;
             $webUrl = $this->context
                 ->backendUrl
                 ->withPath('/web/index.html')
@@ -109,7 +108,7 @@ class GetLibrariesListTest extends TestCase
                 'title' => ag($item, 'title'),
                 'type' => ucfirst($type),
                 'ignored' => false,
-                'supported' => $supportedType && true === in_array($agent, PlexClient::SUPPORTED_AGENTS),
+                'supported' => true === in_array($type, [PlexClient::TYPE_MOVIE, PlexClient::TYPE_SHOW], true),
                 'agent' => $agent,
                 'scanner' => ag($item, 'scanner'),
                 'contentType' => strtolower($type),
@@ -183,5 +182,26 @@ class GetLibrariesListTest extends TestCase
         $this->assertCount(2, $response->response);
         $this->assertTrue((bool) $response->response[0]['supported']);
         $this->assertTrue((bool) $response->response[1]['supported']);
+    }
+
+    public function test_unknown_agent(): void
+    {
+        $payload = [
+            'MediaContainer' => [
+                'Directory' => [
+                    ['key' => '1', 'title' => 'Movies', 'type' => 'movie', 'agent' => 'unknown.movie'],
+                    ['key' => '2', 'title' => 'Shows', 'type' => 'show', 'agent' => 'unknown.show'],
+                    ['key' => '3', 'title' => 'Music', 'type' => 'artist', 'agent' => 'unknown.artist'],
+                ],
+            ],
+        ];
+
+        $resp = new MockResponse(json_encode($payload), ['http_code' => 200]);
+        $client = new MockHttpClient($resp);
+        $response = (new GetLibrariesList($client, $this->logger))($this->context);
+
+        $this->assertTrue((bool) $response->response[0]['supported']);
+        $this->assertTrue((bool) $response->response[1]['supported']);
+        $this->assertFalse((bool) $response->response[2]['supported']);
     }
 }

--- a/tests/Backends/Plex/ImportTest.php
+++ b/tests/Backends/Plex/ImportTest.php
@@ -137,4 +137,30 @@ class ImportTest extends PlexTestCase
         $logContext = $result->response[0]->extras['logContext'] ?? [];
         $this->assertSame(5, (int) ag($logContext, 'library.id'));
     }
+
+    public function test_unknown_agent(): void
+    {
+        $sections = [
+            'MediaContainer' => [
+                'Directory' => [
+                    ['key' => '6', 'title' => 'Shows', 'type' => 'show', 'agent' => 'unknown.show'],
+                ],
+            ],
+        ];
+        $http = $this->makeHttpClient(
+            $this->makeResponse($sections),
+            new MockResponse('', ['http_code' => 200, 'response_headers' => ['X-Plex-Container-Total-Size' => '1']]),
+            new MockResponse('', ['http_code' => 200, 'response_headers' => ['X-Plex-Container-Total-Size' => '1']]),
+        );
+        $context = $this->makeContext();
+        $action = new Import($http, $this->logger);
+        $result = $action($context, new PlexGuid($this->logger), $context->userContext->mapper);
+
+        $this->assertTrue($result->isSuccessful());
+        $this->assertCount(2, $result->response);
+        foreach ($result->response as $request) {
+            $logContext = $request->extras['logContext'] ?? [];
+            $this->assertSame(6, (int) ag($logContext, 'library.id'));
+        }
+    }
 }


### PR DESCRIPTION
* Removed the `SUPPORTED_AGENTS` constant and all code that checked for supported agents in `PlexClient` and related actions. Now, support is determined by whether the library type is `movie` or `show`.
